### PR TITLE
feat: resume from last update run

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,8 +29,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
+      - name: Cache last processed tool
+        id: cache-last-tool
+        uses: actions/cache@v4
+        with:
+          path: last_processed_tool.txt
+          key: last-processed-tool-${{ github.run_id }}
+          restore-keys: |
+            last-processed-tool-
       - run: ./scripts/update.sh "${{ github.event.schedule }}"
-      - run: git checkout docs && git clean -df
+      - run: git checkout docs && git clean -df docs
       - uses: actions/configure-pages@v5
       - name: Upload static files as artifact
         id: deployment

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -25,6 +25,8 @@ echo "0" > "$STATS_DIR/total_tokens_used"
 echo "0" > "$STATS_DIR/total_rate_limits_hit"
 echo "0" > "$STATS_DIR/total_tools_available"
 echo "" > "$STATS_DIR/updated_tools_list"
+echo "" > "$STATS_DIR/first_processed_tool"
+echo "" > "$STATS_DIR/last_processed_tool"
 echo "false" > "$STATS_DIR/summary_generated"
 START_TIME=$(date +%s)
 echo "$START_TIME" > "$STATS_DIR/start_time"
@@ -129,6 +131,8 @@ generate_summary() {
 - **Tools Failed**: $(get_stat "total_tools_failed")
 - **Tools with No Versions**: $(get_stat "total_tools_no_versions")
 - **Total Duration**: ${duration_minutes}m ${duration_seconds}s
+- **First Tool Processed**: $(get_stat "first_processed_tool")
+- **Last Tool Processed**: $(get_stat "last_processed_tool")
 
 ## 📊 Performance Metrics
 - **Processing Speed**: $([ "$duration" -gt 0 ] && [ "$((duration / 60))" -gt 0 ] && echo "$(( $(get_stat "total_tools_checked") / (duration / 60) ))" || echo "0") tools/minute
@@ -370,63 +374,74 @@ setup_token_management() {
 }
 
 # Setup token management before starting
-if setup_token_management; then
-	CUR_MISE_VERSION=$(docker run jdxcode/mise -v)
-	export CUR_MISE_VERSION
-
-	tools="$(docker run -e MISE_EXPERIMENTAL=1 -e MISE_VERSION="$CUR_MISE_VERSION" jdxcode/mise registry | awk '{print $1}')"
-	set_stat "total_tools_available" "$(echo "$tools" | wc -w)"
-
-	# Check if tokens are available before starting processing
-	echo "🔍 Checking token availability before starting..."
-	if ! get_github_token >/dev/null; then
-		echo "🛑 No tokens available - stopping all processing"
-		generate_summary
-		exit 0
-	fi
-
-	# Enhanced parallel processing with better token distribution
-	echo "🚀 Starting parallel fetch operations..."
-	# Prevent broken pipe error by collecting tools first
-	tools_limited=$(echo "$tools" | shuf -n 100)
-	export -f fetch get_github_token mark_token_rate_limited increment_stat get_stat add_to_list set_stat
-	export STATS_DIR
-	for tool in $tools_limited; do
-		if ! timeout 60s bash -c "fetch $tool"; then
-			echo "❌ Failed to fetch $tool, stopping processing"
-			break
-		fi
-	done
-
-	if [ "${DRY_RUN:-}" == 0 ] && ! git diff-index --cached --quiet HEAD; then
-		git diff --compact-summary --cached
-		
-		# Get the list of updated tools for the commit message
-		updated_tools_list=$(cat "$STATS_DIR/updated_tools_list" 2>/dev/null || echo "")
-		tools_updated_count=$(get_stat "total_tools_updated")
-		
-		if [ -n "$updated_tools_list" ] && [ "$tools_updated_count" -gt 0 ]; then
-			# Create a more descriptive commit message with updated tools
-			if [ "$tools_updated_count" -le 10 ]; then
-				# If 10 or fewer tools, list them all
-				commit_msg="versions: update $tools_updated_count tools ($updated_tools_list)"
-			else
-				# If more than 10 tools, just show the count
-				commit_msg="versions: update $tools_updated_count tools"
-			fi
-		else
-			# Fallback to original message
-			commit_msg="versions"
-		fi
-		
-		git commit -m "$commit_msg"
-		git pull --autostash --rebase origin main
-		git push
-	fi
-else
+if ! setup_token_management; then
 	echo "❌ Token management setup failed"
 	generate_summary
 	exit 0
+fi
+
+CUR_MISE_VERSION=$(docker run jdxcode/mise -v)
+export CUR_MISE_VERSION
+
+tools="$(docker run -e MISE_EXPERIMENTAL=1 -e MISE_VERSION="$CUR_MISE_VERSION" jdxcode/mise registry | awk '{print $1}')"
+set_stat "total_tools_available" "$(echo "$tools" | wc -w)"
+
+# Check if tokens are available before starting processing
+echo "🔍 Checking token availability before starting..."
+if ! get_github_token >/dev/null; then
+	echo "🛑 No tokens available - stopping all processing"
+	generate_summary
+	exit 0
+fi
+
+# Resume from the last processed tool
+last_tool_processed=$(git log -1 --pretty=%B | grep -oP 'end: \K[^\s]+' || echo "")
+tools_limited=$(echo -e "$tools\n$tools" | grep -m 1 -A 100 -F -x "$last_tool_processed" | tail -n +2 || echo "$tools" | head -n 100)
+first_processed_tool=$(echo "$tools_limited" | head -n 1)
+set_stat "first_processed_tool" "$first_processed_tool"
+
+# Enhanced parallel processing with better token distribution
+echo "🚀 Starting parallel fetch operations..."
+export -f fetch get_github_token mark_token_rate_limited increment_stat get_stat add_to_list set_stat
+export STATS_DIR
+last_processed_tool=""
+for tool in $tools_limited; do
+	if ! timeout 60s bash -c "fetch $tool"; then
+		echo "❌ Failed to fetch $tool, stopping processing"
+		break
+	fi
+	last_processed_tool="$tool"
+done
+set_stat "last_processed_tool" "$last_processed_tool"
+
+if [ "${DRY_RUN:-}" == 0 ] && ! git diff-index --cached --quiet HEAD; then
+	git diff --compact-summary --cached
+	
+	# Get the list of updated tools for the commit message
+	updated_tools_list=$(cat "$STATS_DIR/updated_tools_list" 2>/dev/null || echo "")
+	tools_updated_count=$(get_stat "total_tools_updated")
+	
+	commit_subject=""
+	if [ -n "$updated_tools_list" ] && [ "$tools_updated_count" -gt 0 ]; then
+		# Create a more descriptive commit message with updated tools
+		if [ "$tools_updated_count" -le 10 ]; then
+			# If 10 or fewer tools, list them all
+			commit_subject="versions: update $tools_updated_count tools ($updated_tools_list)"
+		else
+			# If more than 10 tools, just show the count
+			commit_subject="versions: update $tools_updated_count tools"
+		fi
+	else
+		# Fallback to original message
+		commit_subject="versions: update"
+	fi
+
+	commit_body="start: $first_processed_tool
+end: $last_processed_tool"
+
+	git commit -m "$commit_subject" -m "$commit_body"
+	git pull --autostash --rebase origin main
+	git push
 fi
 
 # Always generate and display summary


### PR DESCRIPTION
This PR reduces the tool update delay by resuming from where it stopped in the last run.
The first and last tools processed in each run are written to the commit message body.

---


Currently, tools are processed in a random order.
Due to rate limiting, an average of $47.54$ tools is processed per run.

This is a classic coupon collector's problem, so the expected number of runs required to process all tools can be approximated by the formula $E \approx \frac{N}{k} H_N$, where $N$ is the total number of tools, $k$ is the number of tools processed per run, and $H_N$ is the N-th harmonic number.
(This is an approximation. The formula isn't exact because we select $k$ unique tools per run rather than one at a time. However, since $N$ is much larger than $k$, this provides a reasonable estimate.)

Plugging in $N = 920$ ($936$ total − $16$ skipped) and $k = 47.54$, the estimated number of runs to update all tools is $143.2$. [WolframAlpha](https://www.wolframalpha.com/input?i=920+%2F+47.54+*+HarmonicNumber%28920%29)


With sequential updates, we would ideally need only $920 / 47.54 \approx 19.4$ runs to process every tool.


Since we perform $48$ runs per day, this change should reduce the average maximum update delay from **~3 days** to **~10 hours**.