### PR TITLE
fix: respect retry-after response header for rate limit

### DIFF
--- a/scripts/github-token.js
+++ b/scripts/github-token.js
@@ -97,7 +97,7 @@ async function recordUsage(baseUrl, secret, tokenId, endpoint, rateLimitInfo) {
 async function markRateLimited(baseUrl, secret, tokenId, retryAfter, remainingRequests, resetTime) {
   const rateLimitUrl = `${baseUrl}/api/token/rate-limit`;
 
-  let reset_at = new Date(Date.now() + 3600000).toISOString(); // Default to 1 hour from now
+  let reset_at = new Date(Date.now() + 10 * 60 * 1000).toISOString(); // Default to 10 minutes from now
   if (remainingRequests === 0 && resetTime) {
     // resetTime is in epoch seconds
     reset_at = new Date(resetTime * 1000).toISOString();

--- a/scripts/github-token.js
+++ b/scripts/github-token.js
@@ -94,13 +94,21 @@ async function recordUsage(baseUrl, secret, tokenId, endpoint, rateLimitInfo) {
   });
 }
 
-async function markRateLimited(baseUrl, secret, tokenId, resetTime) {
+async function markRateLimited(baseUrl, secret, tokenId, retryAfter, remainingRequests, resetTime) {
   const rateLimitUrl = `${baseUrl}/api/token/rate-limit`;
-  
+
+  let reset_at = new Date(Date.now() + 3600000).toISOString(); // Default to 1 hour from now
+  if (remainingRequests === 0 && resetTime) {
+    // resetTime is in epoch seconds
+    reset_at = new Date(resetTime * 1000).toISOString();
+  } else if (retryAfter) {
+    // retryAfter is in minutes
+    reset_at = new Date(Date.now() + retryAfter * 60 * 1000).toISOString();
+  }
+
   const payload = JSON.stringify({
     token_id: tokenId,
-    remaining_requests: 0,
-    reset_at: resetTime ? new Date(resetTime * 1000).toISOString() : new Date(Date.now() + 3600000).toISOString(), // Default to 1 hour from now
+    reset_at: reset_at,
   });
   
   return makeRequest(rateLimitUrl, {
@@ -156,17 +164,19 @@ async function main() {
       
     } else if (action === 'mark-rate-limited') {
       const tokenId = process.argv[3];
-      const resetTime = process.argv[4]; // Optional reset time (unix timestamp)
-      
+      const retryAfter = process.argv[4]; // Optional retry after time (minutes)
+      const remainingRequests = process.argv[5]; // Optional remaining requests
+      const resetTime = process.argv[6]; // Optional reset time (unix timestamp)
+
       if (!tokenId) {
         console.error('❌ Usage: node github-token.js mark-rate-limited <token_id> [reset_time]');
         process.exit(1);
       }
       
       console.error(`🚫 Marking token ${tokenId} as rate-limited...`);
-      
-      const response = await markRateLimited(baseUrl, secret, parseInt(tokenId), resetTime ? parseInt(resetTime) : undefined);
-      
+
+      const response = await markRateLimited(baseUrl, secret, parseInt(tokenId), parseInt(retryAfter), parseInt(remainingRequests), parseInt(resetTime));
+
       if (response.status !== 200) {
         console.error(`❌ Failed to mark token as rate-limited: ${response.status} ${response.data}`);
         process.exit(1);

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -167,22 +167,20 @@ SUMMARY_EOF
 # Function to mark a token as rate-limited
 mark_token_rate_limited() {
 	local token_id="$1"
-	local reset_time="${2:-}"
-	
+	local retry_after="${2:-}"
+	local remaining_requests="${3:-}"
+	local reset_time="${4:-}"
+
 	if [ -z "$TOKEN_MANAGER_URL" ] || [ -z "$TOKEN_MANAGER_SECRET" ]; then
 		return
 	fi
-	
-	echo "🚫 Marking token $token_id as rate-limited" >&2
+
+	echo "🚫 Marking token $token_id as rate-limited (retry after: $retry_after, remaining: $remaining_requests, reset: $reset_time)" >&2
 	increment_stat "total_rate_limits_hit"
-	
+
 	# Mark token as rate-limited asynchronously
 	{
-		if [ -n "$reset_time" ]; then
-			node scripts/github-token.js mark-rate-limited "$token_id" "$reset_time" || true
-		else
-			node scripts/github-token.js mark-rate-limited "$token_id" || true
-		fi
+		node scripts/github-token.js mark-rate-limited "$token_id" "$retry_after" "$remaining_requests" "$reset_time" || true
 	} &
 }
 
@@ -271,14 +269,18 @@ fetch() {
 		
 		# Check if this was a rate limit issue (403 Forbidden)
 		if grep -q "403 Forbidden" "$stderr_file"; then
-			echo "⚠️  Rate limit hit for token $token_id on $1, marking token as rate-limited" >&2
+			echo "⚠️ Rate limit hit for token $token_id on $1, marking token as rate-limited" >&2
 			
 			# Extract rate limit reset time from response headers if available
+			local retry_after
+			retry_after=$(grep -i "retry-after" "$stderr_file" | cut -d: -f2 | tr -d ' ' || echo "")
+			local remaining_requests
+			remaining_requests=$(grep -i "x-ratelimit-remaining" "$stderr_file" | cut -d: -f2 | tr -d ' ' || echo "")
 			local reset_time
 			reset_time=$(grep -i "x-ratelimit-reset" "$stderr_file" | cut -d: -f2 | tr -d ' ' || echo "")
 			
 			# Mark this specific token as rate-limited
-			mark_token_rate_limited "$token_id" "$reset_time"
+			mark_token_rate_limited "$token_id" "$retry_after" "$remaining_requests" "$reset_time"
 			
 			echo "🔄 Will try with a different token next time" >&2
 		else

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,11 +219,10 @@ export default {
 
         const rateLimitData = await request.json() as {
           token_id: number;
-          remaining_requests?: number;
-          reset_at?: string;
+          reset_at: string;
         };
 
-        // Mark token as rate-limited for 1 hour (or until reset_at)
+        // Mark token as rate-limited until reset_at
         await database.markTokenRateLimited(
           rateLimitData.token_id,
           rateLimitData.reset_at


### PR DESCRIPTION
Follows the GitHub docs to minimise the reset time.

> If the `retry-after` response header is present, you should not retry your request until after that many seconds has elapsed. If the `x-ratelimit-remaining` header is `0`, you should not retry your request until after the time, in UTC epoch seconds, specified by the `x-ratelimit-reset` header. Otherwise, wait for at least one minute before retrying.
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit

Currently, we're only using `x-ratelimit-reset`, but this is set even if the primary rate limit is not hit yet.
I think the secondary rate limit uses `retry-after` as documented instead.

Since they say "at least one minute", I changed the default reset time from an hour to 10 minutes.

However, I couldn't reproduce the rate limit locally, so this might be wrong.
I added the logs to the script so we can see if it works.