### PR TITLE
fix: use wait-for-gh-rate-limit output to get rate limit info

### DIFF
--- a/scripts/github-token.js
+++ b/scripts/github-token.js
@@ -94,17 +94,12 @@ async function recordUsage(baseUrl, secret, tokenId, endpoint, rateLimitInfo) {
   });
 }
 
-async function markRateLimited(baseUrl, secret, tokenId, retryAfter, resetTime) {
+async function markRateLimited(baseUrl, secret, tokenId, resetTime) {
   const rateLimitUrl = `${baseUrl}/api/token/rate-limit`;
 
-  let reset_at = new Date(Date.now() + 10 * 60 * 1000).toISOString(); // Default to 10 minutes from now
-  if (retryAfter) {
-    // retryAfter is in seconds
-    reset_at = new Date(Date.now() + retryAfter * 1000).toISOString();
-  } else if (resetTime) {
-    // resetTime is in YYYY-MM-DD HH:MM:SS +timezone format
-    reset_at = new Date(resetTime).toISOString();
-  }
+  const reset_at = resetTime
+    ? new Date(resetTime).toISOString() // resetTime is in YYYY-MM-DD HH:MM:SS +timezone format
+    : new Date(Date.now() + 10 * 60 * 1000).toISOString(); // Default to 10 minutes from now
 
   const payload = JSON.stringify({
     token_id: tokenId,
@@ -164,8 +159,7 @@ async function main() {
       
     } else if (action === 'mark-rate-limited') {
       const tokenId = process.argv[3];
-      const retryAfter = process.argv[4]; // Optional retry after time (seconds)
-      const resetTime = process.argv[5]; // Optional reset time (e.g. 2025-07-28 04:18:45 +10:00)
+      const resetTime = process.argv[4]; // Optional reset time (e.g. 2025-07-28 04:18:45 +10:00)
 
       if (!tokenId) {
         console.error('❌ Usage: node github-token.js mark-rate-limited <token_id> [reset_time]');
@@ -174,7 +168,7 @@ async function main() {
       
       console.error(`🚫 Marking token ${tokenId} as rate-limited...`);
 
-      const response = await markRateLimited(baseUrl, secret, parseInt(tokenId), parseInt(retryAfter), resetTime);
+      const response = await markRateLimited(baseUrl, secret, parseInt(tokenId), resetTime);
 
       if (response.status !== 200) {
         console.error(`❌ Failed to mark token as rate-limited: ${response.status} ${response.data}`);

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -171,19 +171,18 @@ SUMMARY_EOF
 # Function to mark a token as rate-limited
 mark_token_rate_limited() {
 	local token_id="$1"
-	local retry_after="${2:-}"
-	local reset_time="${3:-}"
+	local reset_time="${2:-}"
 
 	if [ -z "$TOKEN_MANAGER_URL" ] || [ -z "$TOKEN_MANAGER_SECRET" ]; then
 		return
 	fi
 
-	echo "🚫 Marking token $token_id as rate-limited (retry after: $retry_after, reset time: $reset_time)" >&2
+	echo "🚫 Marking token $token_id as rate-limited" >&2
 	increment_stat "total_rate_limits_hit"
 
 	# Mark token as rate-limited asynchronously
 	{
-		node scripts/github-token.js mark-rate-limited "$token_id" "$retry_after" "$reset_time" || true
+		node scripts/github-token.js mark-rate-limited "$token_id" "$reset_time" || true
 	} &
 }
 
@@ -257,39 +256,41 @@ fetch() {
 		increment_stat "total_tools_failed"
 		return 1
 	fi
-	
-	GITHUB_TOKEN="$token" mise x -- wait-for-gh-rate-limit || true
+
+	local rate_limit_info
+	rate_limit_info=$(GITHUB_TOKEN="$token" mise x -- wait-for-gh-rate-limit 2>&1 || echo "")
 	echo "Fetching $1 (using token ID: $token_id)"
-	
+
 	# Create a temporary file to capture stderr and check for rate limiting
 	local stderr_file
 	stderr_file=$(mktemp)
-	
+
 	if ! docker run -e GITHUB_TOKEN="$token" -e MISE_USE_VERSIONS_HOST -e MISE_LIST_ALL_VERSIONS -e MISE_LOG_HTTP -e MISE_EXPERIMENTAL -e MISE_TRUSTED_CONFIG_PATHS=/ \
 		jdxcode/mise -y ls-remote "$1" >"docs/$1" 2>"$stderr_file"; then
 		echo "Failed to fetch versions for $1"
 		increment_stat "total_tools_failed"
-		
+
+		cat "$stderr_file" >&2
+
 		# Check if this was a rate limit issue (403 Forbidden)
 		if grep -q "403 Forbidden" "$stderr_file"; then
 			echo "⚠️ Rate limit hit for token $token_id on $1, marking token as rate-limited" >&2
 
-			# Extract rate limit from warning message
-			local retry_after
-			retry_after=$(grep -oP 'GitHub rate limit exceeded. Retry after \K\d+' "$stderr_file" || echo "")
+			local remaining
 			local reset_time
-			reset_time=$(grep -oPi 'GitHub rate limit exceeded. Resets at \K.*' "$stderr_file" || echo "")
+			remaining=$(echo "$rate_limit_info" | grep -oP 'GitHub rate limit: \K[0-9]+')
+			reset_time=""
+			if [ "$remaining" -eq 0 ]; then
+				reset_time=$(echo "$rate_limit_info" | grep -oP 'resets at \K\S+ \S+')
+			fi
 
 			# Mark this specific token as rate-limited
-			mark_token_rate_limited "$token_id" "$retry_after" "$reset_time"
+			mark_token_rate_limited "$token_id" "$reset_time"
 
 			echo "🔄 Retrying with a different token" >&2
 			fetch "$1"
-		else
-			# Show the actual error for non-rate-limit failures
-			cat "$stderr_file" >&2
 		fi
-		
+
 		rm -f "$stderr_file" "docs/$1"
 		return
 	fi


### PR DESCRIPTION
I checked the workflow [logs](https://github.com/jdx/mise-versions/actions) and noticed that the rate limit headers are not being set as documented.

First, I found that the `retry-after` header is never set.
There are several reports on this, which suggest GitHub is not setting it as documented.
https://github.com/orgs/community/discussions/24760
https://github.com/hub4j/github-api/issues/1805

Additionally, the `x-ratelimit-remaining` header does not seem to be set as expected.
I implemented the rate limit warning message to appear only when `x-ratelimit-remaining` is 0, so the `x-ratelimit-reset` time should not be printed if the remaining count is not 0.
https://github.com/jdx/mise/blob/9ff9b91eba5ad75a213557777545baa243f0f0d7/src/http.rs#L282-L296)

However, the log from `wait-for-gh-rate-limit` immediately before `mise ls-remote` shows different remaining and reset times.
Furthermore, the reset time (`2025-07-29 17:00:43 +00:00` in the log below) is the same for all tokens within a single workflow run.

I suspect GitHub has an additional, possibly IP-based, rate limit that returns `x-ratelimit-remaining=0` with a reset time approximately one hour in the future.
Since the IP address should change between runs, I believe we can ignore this particular rate limit.

To resolve this issue, this PR uses the output from `wait-for-gh-rate-limit`, which directly queries the `https://api.github.com/rate_limit` endpoint.
This would allow us to ignore these weird rate limit headers.

```
📊 Token ID: 8
📊 Installation ID: 8
⏰ Expires at: null
✅ Token obtained from token manager (ID: 8)
GitHub rate limit: 4997/5000 - resets at 2025-07-29 16:41:55 (~36m 10s)
Fetching hugo-extended (using token ID: 8)
Failed to fetch versions for hugo-extended
⚠️ Rate limit hit for token 8 on hugo-extended, marking token as rate-limited
🚫 Marking token 8 as rate-limited (retry after: , reset time: 2025-07-29 17:00:43 +00:00)
```
