### PR TITLE
fix: only push version commits after D1 sync succeeds

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -57,7 +57,8 @@ jobs:
           FULL_SYNC: ${{ inputs.full_sync || 'false' }}
       - name: Push committed versions
         run: |
-          if [ "$(git rev-list --count @{u}..HEAD 2>/dev/null || echo 0)" -gt 0 ]; then
+          git fetch origin main
+          if [ "$(git rev-list --count origin/main..HEAD)" -gt 0 ]; then
             git pull --autostash --rebase origin main
             git push
           else

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -55,6 +55,14 @@ jobs:
           SYNC_API_URL: https://mise-tools.jdx.dev
           API_SECRET: ${{ secrets.TOKEN_MANAGER_SECRET }}
           FULL_SYNC: ${{ inputs.full_sync || 'false' }}
+      - name: Push committed versions
+        run: |
+          if [ "$(git rev-list --count @{u}..HEAD 2>/dev/null || echo 0)" -gt 0 ]; then
+            git pull --autostash --rebase origin main
+            git push
+          else
+            echo "No local commits to push"
+          fi
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Upload static files as artifact
         id: deployment

--- a/scripts/lib/fetch-with-retry.js
+++ b/scripts/lib/fetch-with-retry.js
@@ -1,0 +1,39 @@
+// Retry wrapper for sync API calls.
+// Retries on network errors, 5xx, and 404 (worker cold-start / deploy races
+// against mise-tools.jdx.dev have been observed returning 404 intermittently).
+// Other 4xx responses are treated as fatal since retrying won't help.
+export async function fetchWithRetry(
+  url,
+  init,
+  { attempts = 4, baseDelayMs = 2000 } = {},
+) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, init);
+      if (res.ok) return res;
+
+      const body = await res.text().catch(() => "");
+      const msg = `${res.status} ${res.statusText}: ${body.slice(0, 200)}`;
+
+      if (res.status >= 500 || res.status === 404) {
+        throw new Error(msg);
+      }
+      // Non-retriable 4xx
+      const err = new Error(msg);
+      err.status = res.status;
+      err.body = body;
+      err.fatal = true;
+      throw err;
+    } catch (e) {
+      lastErr = e;
+      if (e.fatal || i === attempts - 1) break;
+      const delay = baseDelayMs * Math.pow(2, i);
+      console.warn(
+        `fetch ${url} attempt ${i + 1}/${attempts} failed: ${e.message}. Retrying in ${delay}ms...`,
+      );
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastErr;
+}

--- a/scripts/sync-to-d1.js
+++ b/scripts/sync-to-d1.js
@@ -16,6 +16,7 @@ import { readFileSync, readdirSync, existsSync } from "fs";
 import { join, basename } from "path";
 import { parse } from "smol-toml";
 import { execSync } from "child_process";
+import { fetchWithRetry } from "./lib/fetch-with-retry.js";
 
 const DOCS_DIR = join(process.cwd(), "docs");
 const MANUAL_OVERRIDES_FILE = join(DOCS_DIR, "manual-overrides.json");
@@ -335,7 +336,7 @@ async function main() {
   console.log(`Syncing to ${syncUrl}...`);
 
   try {
-    const response = await fetch(syncUrl, {
+    const response = await fetchWithRetry(syncUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -343,13 +344,6 @@ async function main() {
       },
       body: JSON.stringify({ tools }),
     });
-
-    if (!response.ok) {
-      const text = await response.text();
-      console.error(`Sync failed: ${response.status} ${response.statusText}`);
-      console.error(text);
-      process.exit(1);
-    }
 
     const result = await response.json();
     console.log("Sync completed successfully:");

--- a/scripts/sync-versions-to-d1.js
+++ b/scripts/sync-versions-to-d1.js
@@ -16,6 +16,7 @@
 import { readFileSync, readdirSync, existsSync } from "fs";
 import { join, basename } from "path";
 import * as smolToml from "smol-toml";
+import { fetchWithRetry } from "./lib/fetch-with-retry.js";
 
 const DOCS_DIR = join(process.cwd(), "docs");
 const UPDATED_TOOLS_FILE = join(process.cwd(), "updated_tools.txt");
@@ -131,7 +132,7 @@ async function main() {
 
     const results = await Promise.allSettled(
       parallelBatches.map(async (batch, idx) => {
-        const response = await fetch(syncUrl, {
+        const response = await fetchWithRetry(syncUrl, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -139,11 +140,6 @@ async function main() {
           },
           body: JSON.stringify({ tools: batch }),
         });
-
-        if (!response.ok) {
-          const text = await response.text();
-          throw new Error(`${response.status} ${response.statusText}: ${text}`);
-        }
 
         return { batch, result: await response.json() };
       }),

--- a/scripts/sync-versions-to-d1.js
+++ b/scripts/sync-versions-to-d1.js
@@ -165,8 +165,8 @@ async function main() {
   console.log(`  - Errors: ${errors}`);
 
   if (errors > 0) {
-    console.warn(`\nWarning: ${errors} errors occurred during sync`);
-    // Don't exit with error - partial sync is acceptable
+    console.error(`\n${errors} errors occurred during sync after retries`);
+    process.exit(1);
   }
 }
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -611,8 +611,8 @@ if setup_token_management; then
 		fi
 
 		git commit -m "$commit_msg"
-		git pull --autostash --rebase origin main
-		git push
+		# Push is deferred to the workflow so it only happens after D1 sync
+		# succeeds, preventing orphaned commits when sync fails.
 	fi
 
 	# Save updated tools list for D1 sync (one tool per line)


### PR DESCRIPTION
## Problem

`http://mise-versions.jdx.dev/hk.toml` was missing `1.43.0` for ~37h even though it had been on `main` since [b9a06f88](https://github.com/jdx/mise-versions/commit/b9a06f88) on 2026-04-16. Investigation traced it to [run 24533384996](https://github.com/jdx/mise-versions/actions/runs/24533384996): `update.sh` committed and **pushed** `hk 1.43.0`, then the "Sync tools to D1" step failed with `404 Not Found` on `mise-tools.jdx.dev/api/admin/tools/sync`. The commit was already on main and every subsequent run did an incremental sync based on its own `updated_tools.txt` (which didn't include `hk`), so the version stayed orphaned.

Same pattern has produced drift in 13 tools over the last 5 days (hk, mirrord, clusterawsadm, rtk, rumdl, rush, podman, skaffold, smithy, prek, regctl, regsync, sbt).

## Changes

- **`scripts/update.sh`**: commit locally, don't push. The workflow owns the push now.
- **`.github/workflows/update.yml`**: new `Push committed versions` step runs _after_ both D1 sync steps. If sync fails, the commit stays on the runner and the next scheduled run re-fetches & retries.
- **`scripts/lib/fetch-with-retry.js`** (new) + both sync scripts: retry transient failures (5xx, 404) with exponential backoff so worker cold-start blips don't fail the whole workflow. Non-retriable 4xx still fail fast.

## Invariant after this change

> If a `versions:` commit is on `main`, those versions are in D1.

## Test plan

- [ ] Land PR, watch next scheduled run succeed end-to-end
- [ ] Confirm `git log --all --oneline -- docs/` still advances on `main` at the usual cadence
- [ ] Force a sync failure (e.g. break API_SECRET temporarily in a workflow_dispatch run) and verify the commit does not reach `main`
- [ ] Check that retries actually trigger on a transient 5xx — look for `fetch … attempt N/M failed` warnings in logs

## Notes / follow-ups

- Already triggered a one-shot `full_sync=true` ([run 24602886105](https://github.com/jdx/mise-versions/actions/runs/24602886105)) to backfill the 13 drifted tools. Not scheduled — one-off.
- The underlying 404 on the worker sync endpoint is probably worth investigating separately (cold-start race against deploys?). Retry here only hides symptoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI update workflow’s commit/push ordering and makes D1 sync failures fail the job after retries, which can affect automation cadence and requires correct git state handling on the runner.
> 
> **Overview**
> Ensures `versions:` commits only land on `main` *after* both D1 sync steps succeed by removing the `git push` from `scripts/update.sh` and adding a post-sync "Push committed versions" step in `.github/workflows/update.yml`.
> 
> Adds a shared `fetchWithRetry` helper and switches both D1 sync scripts to use it, retrying transient network/`5xx`/intermittent `404` responses with exponential backoff; `sync-versions-to-d1.js` now exits non-zero if any errors remain after retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d1538c7a7513063bd9547a63723dba990d3d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->