### PR TITLE
ci: make GitHub Pages deploy steps non-fatal

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -58,10 +58,18 @@ jobs:
           else
             echo "No local commits to push"
           fi
+      # Pages configuration + upload are marked continue-on-error so transient
+      # GitHub-side flakiness (installation-scoped API rate limits have hit
+      # `configure-pages` in the past) doesn't fail the whole workflow after
+      # the real data pipeline (update.sh + D1 sync) has already succeeded.
+      # A missed Pages deploy just means the site serves the previous snapshot
+      # until the next scheduled run redeploys.
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+        continue-on-error: true
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        continue-on-error: true
         with:
           path: docs/
 
@@ -75,3 +83,4 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        continue-on-error: true


### PR DESCRIPTION
## Summary
Run [24907967849](https://github.com/jdx/mise-versions/actions/runs/24907967849/job/72942098970) showed the full data pipeline (update.sh + both D1 syncs) succeed and then the workflow fail at `actions/configure-pages`:

```
HttpError: API rate limit exceeded for installation.
```

That's a GitHub-side installation-scoped rate limit, not anything we can fix in our code. But it marks the whole workflow red and hides the fact that the commit + D1 sync actually succeeded.

Mark the three Pages-related steps (`configure-pages`, `upload-pages-artifact`, and the deploy job's `deploy-pages`) as `continue-on-error: true`. A transient Pages failure now leaves the site on its previous snapshot and the next scheduled run (30 min later) redeploys.

## Before/after
- Before: red X across entire run despite successful D1 sync and commit
- After: green check when data pipeline succeeds; Pages failure shows as a yellow warning on the individual step

## Test plan
- [x] `prettier --check` clean
- [ ] First post-merge run: confirm workflow reports success even if Pages is flaky, and confirms Pages eventually redeploys on the next healthy run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but it can mask genuine GitHub Pages deployment issues by allowing runs to succeed with a stale site snapshot.
> 
> **Overview**
> Ensures the `update` workflow reports success when the core data pipeline completes, even if GitHub Pages is temporarily flaky.
> 
> Marks `actions/configure-pages`, `actions/upload-pages-artifact`, and the `deploy-pages` step as `continue-on-error: true`, with inline rationale that a missed deploy simply serves the previous site snapshot until the next run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d729765c7fe50a071761a2606999ab4aff0affb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->