### PR TITLE
fix(generate-toml): semver-sort unstable tools to stop reorder churn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@octokit/auth-oauth-user": "^6.0.0",
         "@octokit/rest": "^22.0.0",
         "drizzle-orm": "^0.45.0",
+        "semver": "^7.7.4",
         "smol-toml": "^1.5.2",
         "workers-og": "^0.0.27"
       },
@@ -393,6 +394,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
@@ -435,6 +445,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -3948,19 +3967,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.58.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
@@ -4743,19 +4749,6 @@
       "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/astro/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/astro/node_modules/vite": {
@@ -9361,12 +9354,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/sharp": {
@@ -9411,18 +9407,6 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -11731,18 +11715,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "web/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "web/node_modules/shiki": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@octokit/auth-oauth-user": "^6.0.0",
     "@octokit/rest": "^22.0.0",
     "drizzle-orm": "^0.45.0",
+    "semver": "^7.7.4",
     "smol-toml": "^1.5.2",
     "workers-og": "^0.0.27"
   }

--- a/scripts/generate-toml.js
+++ b/scripts/generate-toml.js
@@ -17,8 +17,23 @@
 
 import { readFileSync, existsSync } from "fs";
 import { parse, stringify } from "smol-toml";
+import semver from "semver";
 
 const [, , tool, existingTomlPath] = process.argv;
+
+// Tools whose upstream version order is unstable across runs (e.g. backport
+// patches on old majors interleaved by created_at) get force-sorted by semver
+// to prevent endless no-op TOML reorderings.
+const UNSTABLE_TOOLS_PATH = new URL("./unstable-tools.txt", import.meta.url)
+  .pathname;
+const UNSTABLE_TOOLS = existsSync(UNSTABLE_TOOLS_PATH)
+  ? new Set(
+      readFileSync(UNSTABLE_TOOLS_PATH, "utf-8")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l && !l.startsWith("#")),
+    )
+  : new Set();
 
 if (!tool) {
   console.error(
@@ -94,6 +109,25 @@ if (existingTomlPath && existsSync(existingTomlPath)) {
 
 // Parse new version data (preserves order from mise ls-remote)
 const newVersions = parseNdjson(stdinData);
+
+// For "unstable" tools, sort by semver ascending so the output is
+// deterministic regardless of which fetch path produced the input. Versions
+// that don't parse as semver fall back to natural string compare.
+if (UNSTABLE_TOOLS.has(tool)) {
+  newVersions.sort((a, b) => {
+    const av = semver.coerce(a.version);
+    const bv = semver.coerce(b.version);
+    if (av && bv) {
+      const cmp = semver.compare(av, bv);
+      if (cmp !== 0) return cmp;
+    } else if (av) {
+      return -1;
+    } else if (bv) {
+      return 1;
+    }
+    return a.version.localeCompare(b.version);
+  });
+}
 
 // Build output with inline tables for compactness
 const lines = ["[versions]"];

--- a/scripts/generate-toml.test.js
+++ b/scripts/generate-toml.test.js
@@ -252,6 +252,78 @@ describe("generate-toml.js", () => {
     });
   });
 
+  describe("unstable tool sorting", () => {
+    it("should preserve input order for tools not in the unstable list", async () => {
+      // terraform-style backport pattern: 0.12.30 published after 0.14.3
+      const input = [
+        '{"version":"0.12.29"}',
+        '{"version":"0.13.0"}',
+        '{"version":"0.14.3"}',
+        '{"version":"0.12.30"}',
+        '{"version":"0.14.4"}',
+      ].join("\n");
+
+      const { stdout, code } = await runGenerateToml(input, ["random-tool"]);
+      assert.strictEqual(code, 0);
+
+      const parsed = parse(stdout);
+      assert.deepStrictEqual(Object.keys(parsed.versions), [
+        "0.12.29",
+        "0.13.0",
+        "0.14.3",
+        "0.12.30",
+        "0.14.4",
+      ]);
+    });
+
+    it("should semver-sort tools in the unstable list", async () => {
+      // Same input as above, but for terraform — output must be ascending
+      // semver regardless of input order.
+      const input = [
+        '{"version":"0.12.29"}',
+        '{"version":"0.13.0"}',
+        '{"version":"0.14.3"}',
+        '{"version":"0.12.30"}',
+        '{"version":"0.14.4"}',
+      ].join("\n");
+
+      const { stdout, code } = await runGenerateToml(input, ["terraform"]);
+      assert.strictEqual(code, 0);
+
+      const parsed = parse(stdout);
+      assert.deepStrictEqual(Object.keys(parsed.versions), [
+        "0.12.29",
+        "0.12.30",
+        "0.13.0",
+        "0.14.3",
+        "0.14.4",
+      ]);
+    });
+
+    it("should produce identical output for the same versions in different input orders", async () => {
+      const versions = [
+        { version: "1.5.0", created_at: "2024-05-01T00:00:00Z" },
+        { version: "1.4.10", created_at: "2024-03-01T00:00:00Z" },
+        { version: "1.3.10", created_at: "2024-09-01T00:00:00Z" },
+        { version: "1.4.0", created_at: "2024-01-01T00:00:00Z" },
+        { version: "0.15.5", created_at: "2024-08-01T00:00:00Z" },
+      ];
+      const orderA = versions.map((v) => JSON.stringify(v)).join("\n");
+      const orderB = versions
+        .slice()
+        .reverse()
+        .map((v) => JSON.stringify(v))
+        .join("\n");
+
+      const a = await runGenerateToml(orderA, ["consul"]);
+      const b = await runGenerateToml(orderB, ["consul"]);
+
+      assert.strictEqual(a.code, 0);
+      assert.strictEqual(b.code, 0);
+      assert.strictEqual(a.stdout, b.stdout);
+    });
+  });
+
   describe("TOML output format", () => {
     it("should produce valid TOML output", async () => {
       const input = '{"version":"1.0.0"}\n{"version":"2.0.0"}\n';

--- a/scripts/unstable-tools.txt
+++ b/scripts/unstable-tools.txt
@@ -1,0 +1,15 @@
+# Tools whose upstream version order is unstable across runs and must be
+# sorted deterministically by semver before writing the TOML. Without this,
+# tools that publish backport patch releases on old major branches (e.g.
+# terraform 0.12.30 released after 0.14.x) will reorder on every run as
+# the JSON path (sorted by created_at) and the plain-text path (sorted by
+# semver) compete, producing endless no-op commits.
+#
+# One tool name per line. Blank lines and lines starting with # are ignored.
+
+boundary
+consul
+nomad
+protobuf
+terraform
+vault


### PR DESCRIPTION
## Summary
- Tools like `terraform`, `consul`, `nomad`, `vault`, `boundary`, `protobuf` ship backport patches on old majors (e.g. `terraform 0.12.30` released after `0.14.x`). The JSON fetch path in `update.sh` sorts those by `created_at` while the plain-text fallback sorts by semver — so the same data produces different `*.toml` files each run, generating endless no-op commits like `versions: update 5 tools (consul nomad protobuf terraform vault)` (e.g. `cc103f9c4`: 236 insertions / 236 deletions, all reorderings).
- Add `scripts/unstable-tools.txt` and force a deterministic semver-asc sort in `generate-toml.js` for tools in that list. Other tools keep their input order unchanged.
- Promote `semver` to a direct dependency (was already in the lockfile transitively).

## Test plan
- [x] `node --test scripts/generate-toml.test.js` — 20 pass (3 new tests covering input-order preservation for non-listed tools, semver sort for listed tools, and identical output across scrambled input orders)
- [x] `bun run test` — full suite green
- [x] Fed two random shuffles of `docs/terraform.toml`'s 250 versions back through the script — both produced byte-identical output, matching the current file (no churn after merge)
- [x] Verified the same for `boundary` (6 lines change one-time), `consul` (156 lines change one-time), `nomad`/`protobuf`/`vault` (already canonical, zero change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to deterministic ordering in a build script plus dependency/lockfile updates, with tests covering the new behavior. Main risk is unintended reordering for tools added to the unstable list or odd version strings affecting sort results.
> 
> **Overview**
> Prevents endless no-op `*.toml` reorder churn by teaching `scripts/generate-toml.js` to **semver-sort versions for a curated set of “unstable” tools** loaded from new `scripts/unstable-tools.txt`, while leaving other tools’ input order unchanged.
> 
> Adds `semver` as a direct dependency and expands `scripts/generate-toml.test.js` with coverage that non-listed tools preserve input order, listed tools sort ascending, and different input orders produce byte-identical output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc01462063b7c59f0705acea16e2bbc2009c61b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->