### PR TITLE
fix(update): pass rotated token to mise ls-remote --json

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -322,11 +322,10 @@ mark_token_rate_limited() {
 # updated serially in the parent after all parallel workers finish.
 #
 # Refuses to overwrite the existing TOML with an empty `[versions]` table:
-# the local `mise ls-remote --json` call on the runner shares a single
-# GitHub token across all parallel workers and frequently returns `[]`
-# when rate-limited. Prior to this check, that empty result would wipe
-# out hundreds of tools' version history and trip the D1 sync safety
-# check on the next run.
+# even with a per-tool rotated token, transient API failures could
+# theoretically still produce empty output. Prior to this check, an empty
+# result would wipe out hundreds of tools' version history and trip the
+# D1 sync safety check on the next run.
 generate_toml_file() {
 	local tool="$1"
 	local token="$2"
@@ -342,12 +341,16 @@ generate_toml_file() {
 	error_output=$(mktemp)
 
 	# Try to get JSON with timestamps from mise ls-remote --json.
-	# An empty or 0-length array here means the call was rate-limited or
-	# the tool isn't resolvable on this runner — NOT a legitimate "no
-	# versions" result (which `fetch()` would have already filtered out
-	# based on the docker-fetched plain text).
+	# Pass the rotated per-tool token via GITHUB_API_TOKEN so this call
+	# isn't rate-limited by the workflow's single shared MISE_GITHUB_TOKEN.
+	# Without this, ~58% of tools per run hit GitHub's 5000/hr authenticated
+	# rate limit (8 parallel workers × paginated `/releases` calls all on
+	# one token), aqua's `_list_remote_versions` swallows the 403 into
+	# `Ok(vec![])`, mise emits `[]`, and we'd silently fall through to the
+	# plain-text path — losing `release_url` and `created_at` for any new
+	# version that wasn't already in the existing TOML.
 	local json_output
-	if json_output=$(mise ls-remote --json "$tool" 2>/dev/null) && [ -n "$json_output" ]; then
+	if json_output=$(GITHUB_API_TOKEN="$token" mise ls-remote --json "$tool" 2>/dev/null) && [ -n "$json_output" ]; then
 		local json_count
 		json_count=$(printf '%s' "$json_output" | jq 'if type == "array" then length else 0 end' 2>/dev/null || echo 0)
 		if [ "${json_count:-0}" -gt 0 ]; then


### PR DESCRIPTION
## Summary

The host-side `mise ls-remote --json` call in [generate_toml_file](scripts/update.sh:330) was inheriting the workflow's single shared `MISE_GITHUB_TOKEN`, which 8 parallel workers were hammering with paginated `/releases` requests across ~1000 tools per run. That blew through GitHub's 5000/hr authenticated limit; aqua's `_list_remote_versions` swallowed the resulting 403 into `Ok(vec![])`; mise emitted `[]`; and the script fell through to the plain-text path — losing `release_url` and `created_at` for any new version that wasn't already in the existing TOML.

## Evidence

Workflow run [24931988048](https://github.com/jdx/mise-versions/actions/runs/24931988048) shows 593 of 1021 tools logged `mise ls-remote --json returned empty, falling back` — including `code` at 13:31:32.424Z, 88ms before our `now`-fallback timestamp landed in [e1ff2c2f](https://github.com/jdx/mise-versions/commit/e1ff2c2fa31dec4871d88c21bdaff26f71b82d98).

Reproduced locally with 8 parallel `mise ls-remote --json` calls, no token, fresh cache. Debug log:

```
DEBUG GET https://api.github.com/repos/cargo-bins/cargo-binstall/releases 403 Forbidden
WARN  GitHub rate limit exceeded. Resets at 2026-04-25 14:38:20
WARN  Remote versions cannot be fetched: 403 Forbidden ... /tags
WARN  No versions found for cargo-binstall
```

## Fix

Pass the per-tool rotated token (already obtained for the docker call and threaded into `generate_toml_file` as `$2`) to the JSON call via `GITHUB_API_TOKEN`. Each token then carries ~12 API calls per tool instead of thousands of calls per run, comfortably under the rate limit.

## Test plan

- [x] `shellcheck scripts/update.sh` clean
- [x] Existing shell tests still pass (`scripts/update.test.sh` doesn't cover this code path; pre-existing skip in the suite is unrelated)
- [x] Local repro: 5 parallel `mise ls-remote --json` calls
  - **Without token**: `cargo-binstall: 0`, `cheat: 0`, `claude: 0`, `zellij: 0`, `cfssl: 11` (4/5 fall back)
  - **With token**: `cargo-binstall: 140`, `cheat: 56`, `claude: 97`, `zellij: 66`, `cfssl: 11` (5/5 succeed)
- [ ] Watch the next scheduled run after merge — `returned empty, falling back` warnings should drop from ~593/run to near zero

## Notes

I initially mis-diagnosed this as a transient `list_releases` error inside mise and shipped [jdx/mise#9394](https://github.com/jdx/mise/pull/9394) (now closed). Reproducing locally surfaced that `/tags` shares the same rate-limit bucket as `/releases`, so the mise-side fallback I added would still bubble up empty. The rate-limit volume is the actual cause, and the fix belongs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change isolated to the update script’s version-metadata fetch; main impact is altering which GitHub token is used for `mise ls-remote --json`, with minimal chance of unintended side effects beyond CI update behavior.
> 
> **Overview**
> Ensures `generate_toml_file` runs `mise ls-remote --json` with the *per-tool rotated* GitHub token by exporting it as `GITHUB_API_TOKEN`, reducing authenticated rate-limit failures and preventing silent fallbacks that drop `release_url`/`created_at` metadata.
> 
> Updates the related inline documentation to reflect the new failure mode (transient API errors rather than shared-token rate limiting) while keeping the existing guard that refuses to overwrite TOMLs with an empty `[versions]` table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b1f6edde02f918f7b7d157ebaabf12582fc3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->