### PR TITLE
feat: plumb prerelease metadata through the TOML pipeline

### DIFF
--- a/scripts/generate-toml.js
+++ b/scripts/generate-toml.js
@@ -9,11 +9,12 @@
  *   {"version":"1.1.0"}
  *   {"version":"1.0.0","created_at":"2024-01-15T10:30:00Z","release_url":"https://github.com/...","prerelease":false}
  *
- * Output TOML format (same order as input):
+ * Output TOML format (same order as input). Note that created_at is emitted
+ * as a TOML offset datetime (unquoted), not a string:
  *   [versions]
- *   "1.1.0" = { created_at = "2024-02-20T14:45:00Z" }
- *   "1.0.0" = { created_at = "2024-01-15T10:30:00Z", release_url = "https://github.com/..." }
- *   "1.2.0-rc1" = { created_at = "2024-02-25T09:00:00Z", prerelease = true }
+ *   "1.1.0" = { created_at = 2024-02-20T14:45:00.000Z }
+ *   "1.0.0" = { created_at = 2024-01-15T10:30:00.000Z, release_url = "https://github.com/..." }
+ *   "1.2.0-rc1" = { created_at = 2024-02-25T09:00:00.000Z, prerelease = true }
  *
  * `prerelease = true` is emitted only when the upstream signal says so
  * (currently github + aqua via the GitHub release flag). It is omitted when

--- a/scripts/generate-toml.js
+++ b/scripts/generate-toml.js
@@ -7,12 +7,19 @@
  *
  * Input JSON format (NDJSON from stdin):
  *   {"version":"1.1.0"}
- *   {"version":"1.0.0","created_at":"2024-01-15T10:30:00Z","release_url":"https://github.com/..."}
+ *   {"version":"1.0.0","created_at":"2024-01-15T10:30:00Z","release_url":"https://github.com/...","prerelease":false}
  *
  * Output TOML format (same order as input):
  *   [versions]
  *   "1.1.0" = { created_at = "2024-02-20T14:45:00Z" }
  *   "1.0.0" = { created_at = "2024-01-15T10:30:00Z", release_url = "https://github.com/..." }
+ *   "1.2.0-rc1" = { created_at = "2024-02-25T09:00:00Z", prerelease = true }
+ *
+ * `prerelease = true` is emitted only when the upstream signal says so
+ * (currently github + aqua via the GitHub release flag). It is omitted when
+ * false to keep the TOML compact; downstream consumers default false on
+ * absence. Mise versions older than the field's introduction ignore unknown
+ * keys when parsing entries (toml-rs accepts unknown fields by default).
  */
 
 import { readFileSync, existsSync } from "fs";
@@ -60,6 +67,11 @@ function parseNdjson(ndjsonData) {
           version: obj.version,
           created_at: obj.created_at || null,
           release_url: obj.release_url || null,
+          // Treat absent as "unknown" so we can fall back to the existing
+          // TOML for tools whose plain-text fallback path emits no flag.
+          // Only an explicit boolean from the JSON path is definitive.
+          prerelease:
+            typeof obj.prerelease === "boolean" ? obj.prerelease : null,
         });
       }
     } catch (e) {
@@ -99,6 +111,7 @@ if (existingTomlPath && existsSync(existingTomlPath)) {
         existingVersions[version] = {
           created_at: toISOString(data.created_at),
           release_url: data.release_url || null,
+          prerelease: data.prerelease === true,
         };
       }
     }
@@ -138,15 +151,17 @@ for (const v of newVersions) {
   const isoDate = new Date(timestamp).toISOString();
   // Use API release_url, fall back to existing release_url
   const releaseUrl = v.release_url || existing.release_url;
+  // Prefer the API signal when it's definitive; otherwise fall back to the
+  // existing TOML (e.g. plain-text fallback path emits no flag, but a prior
+  // run may have recorded one). Emit the field only when true so the vast
+  // majority of entries stay one column narrower.
+  const prerelease =
+    v.prerelease !== null ? v.prerelease : existing.prerelease === true;
 
-  // Output as inline table
-  if (releaseUrl) {
-    lines.push(
-      `"${v.version}" = { created_at = ${isoDate}, release_url = "${releaseUrl}" }`,
-    );
-  } else {
-    lines.push(`"${v.version}" = { created_at = ${isoDate} }`);
-  }
+  const parts = [`created_at = ${isoDate}`];
+  if (releaseUrl) parts.push(`release_url = "${releaseUrl}"`);
+  if (prerelease) parts.push(`prerelease = true`);
+  lines.push(`"${v.version}" = { ${parts.join(", ")} }`);
 }
 
 console.log(lines.join("\n"));

--- a/scripts/generate-toml.test.js
+++ b/scripts/generate-toml.test.js
@@ -252,6 +252,68 @@ describe("generate-toml.js", () => {
     });
   });
 
+  describe("prerelease", () => {
+    it("should emit prerelease = true when input flags it", async () => {
+      const input =
+        '{"version":"1.0.0-rc1","created_at":"2024-01-15T10:30:00Z","prerelease":true}\n';
+      const { stdout, code } = await runGenerateToml(input, ["test-tool"]);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(parse(stdout).versions["1.0.0-rc1"].prerelease, true);
+    });
+
+    it("should omit prerelease when input is false or missing", async () => {
+      const input = [
+        '{"version":"1.0.0","prerelease":false}',
+        '{"version":"2.0.0"}',
+      ].join("\n");
+      const { stdout, code } = await runGenerateToml(input, ["test-tool"]);
+      assert.strictEqual(code, 0);
+      const parsed = parse(stdout);
+      assert.strictEqual(parsed.versions["1.0.0"].prerelease, undefined);
+      assert.strictEqual(parsed.versions["2.0.0"].prerelease, undefined);
+    });
+
+    it("should preserve prerelease from existing TOML when input lacks it", async () => {
+      // Pre-existing flag (from a prior run that did emit it) survives a
+      // fetch where the API path didn't return JSON and we fell back to
+      // the plain-text path that has no prerelease info.
+      const existingToml = join(tempDir, "existing.toml");
+      writeFileSync(
+        existingToml,
+        `[versions]
+"1.0.0-rc1" = { created_at = 2024-01-15T10:30:00.000Z, prerelease = true }
+`,
+      );
+      const input = '{"version":"1.0.0-rc1"}\n';
+      const { stdout, code } = await runGenerateToml(input, [
+        "test-tool",
+        existingToml,
+      ]);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(parse(stdout).versions["1.0.0-rc1"].prerelease, true);
+    });
+
+    it("should let API value override existing prerelease flag", async () => {
+      // Upstream can re-flag a release (e.g. a maintainer un-marking a
+      // prerelease as stable post-publish). The API value wins over the
+      // TOML's previous answer.
+      const existingToml = join(tempDir, "existing.toml");
+      writeFileSync(
+        existingToml,
+        `[versions]
+"1.0.0" = { created_at = 2024-01-15T10:30:00.000Z, prerelease = true }
+`,
+      );
+      const input = '{"version":"1.0.0","prerelease":false}\n';
+      const { stdout, code } = await runGenerateToml(input, [
+        "test-tool",
+        existingToml,
+      ]);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(parse(stdout).versions["1.0.0"].prerelease, undefined);
+    });
+  });
+
   describe("unstable tool sorting", () => {
     it("should preserve input order for tools not in the unstable list", async () => {
       // terraform-style backport pattern: 0.12.30 published after 0.14.3

--- a/scripts/sync-versions-to-d1.js
+++ b/scripts/sync-versions-to-d1.js
@@ -86,6 +86,7 @@ async function main() {
           version,
           created_at: data?.created_at || null,
           release_url: data?.release_url || null,
+          prerelease: data?.prerelease === true,
           sort_order: index,
         }),
       );

--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -363,6 +363,20 @@ export async function runAnalyticsMigrations(
     `);
   }
 
+  // Add prerelease column to versions table (1 = upstream marked prerelease,
+  // 0 = stable / unknown). Stored as INTEGER to match the rest of the schema's
+  // boolean-as-int convention. Defaults to 0 for existing rows; the sync
+  // script will refresh values on the next run for tools that emit the flag.
+  const hasPrerelease = versionsColumns.some(
+    (col: any) => col.name === "prerelease",
+  );
+  if (!hasPrerelease) {
+    console.log("Adding prerelease column to versions table...");
+    await db.run(
+      sql`ALTER TABLE versions ADD COLUMN prerelease INTEGER NOT NULL DEFAULT 0`,
+    );
+  }
+
   // Create version_updates table for tracking when new versions are discovered
   await db.run(sql`
     CREATE TABLE IF NOT EXISTS version_updates (

--- a/web/src/pages/api/admin/versions/sync.ts
+++ b/web/src/pages/api/admin/versions/sync.ts
@@ -15,6 +15,7 @@ interface VersionData {
   version: string;
   created_at?: string | null;
   release_url?: string | null;
+  prerelease?: boolean;
   sort_order?: number | null;
 }
 
@@ -138,11 +139,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
         d1
           .prepare(
             `
-          INSERT INTO versions (tool_id, version, created_at, release_url, from_mise, sort_order)
-          VALUES (?, ?, ?, ?, 1, ?)
+          INSERT INTO versions (tool_id, version, created_at, release_url, prerelease, from_mise, sort_order)
+          VALUES (?, ?, ?, ?, ?, 1, ?)
           ON CONFLICT(tool_id, version) DO UPDATE SET
             created_at = COALESCE(excluded.created_at, versions.created_at),
             release_url = COALESCE(excluded.release_url, versions.release_url),
+            prerelease = excluded.prerelease,
             from_mise = 1,
             sort_order = COALESCE(excluded.sort_order, versions.sort_order)
         `,
@@ -152,6 +154,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
             v.version,
             v.created_at || null,
             v.release_url || null,
+            v.prerelease === true ? 1 : 0,
             v.sort_order ?? null,
           ),
       );


### PR DESCRIPTION
## Summary

Companion to [jdx/mise#9329](https://github.com/jdx/mise/pull/9329), which adds an opt-in \`prerelease\` tool option for the \`github\` and \`aqua\` backends. That PR plumbs the upstream pre-release flag into mise's \`ls-remote --json\` output and reads it back from the versions-host TOML; this PR is the producer side that makes the flag actually appear in the rendered TOML.

## Changes

- **\`scripts/generate-toml.js\`** — reads \`prerelease\` from the NDJSON stdin and emits \`prerelease = true\` in the inline table when set. False/missing values are omitted to keep the TOML compact.
- **\`scripts/sync-versions-to-d1.js\`** — forwards the field to the sync API.
- **\`web/src/pages/api/admin/versions/sync.ts\`** — includes \`prerelease\` in the upsert SQL.
- **\`src/analytics/migrations.ts\`** — idempotent migration: \`versions.prerelease INTEGER NOT NULL DEFAULT 0\`. Same pattern as the existing \`from_mise\` / \`sort_order\` migrations a few lines up.
- **\`scripts/generate-toml.test.js\`** — round-trip tests for emit, omit, preserve-from-existing, and API-override semantics.

## Design note: definitive vs. unknown

The merge logic distinguishes \"API explicitly said false\" (definitive — overrides any prior state) from \"this fetch fell back to the plain-text path\" (no info — preserve whatever the existing TOML said) by treating absent as \`null\` rather than \`false\`. This matches the existing fallback behavior for \`created_at\` / \`release_url\` and means a prior run's flag survives a transient JSON-fetch failure. Tests cover both paths.

## Compatibility

| Direction | Behavior |
|---|---|
| Old mise clients reading new TOML | \`toml-rs\` ignores unknown fields by default → see exactly today's \`created_at\` + \`release_url\` |
| New mise clients reading old TOML | \`#[serde(default)]\` on the field → absence parses as \`false\` (stable) |
| This pipeline reading old \`mise ls-remote --json\` output | \`obj.prerelease\` is \`undefined\` → treated as unknown, existing TOML wins → no regression while the Docker image is on a pre-mise#9329 build |

## Test plan
- [x] \`bun run test\` — 37/37 pass (24 JS + 13 shell)
- [ ] On the first run after deploy, watch \`updated_tools.txt\` and confirm a github/aqua tool with known prereleases (e.g. tools that already get prereleases via aqua's \`--security\` flag, or post-mise#9329 deploy) renders \`prerelease = true\` in its TOML
- [ ] D1 migration runs idempotently (it's wrapped in a column-existence check)

## Sequencing
This PR is safe to merge in either order with [jdx/mise#9329](https://github.com/jdx/mise/pull/9329). The feature only fully activates once both have shipped *and* the \`jdxcode/mise\` Docker image rebuilds with the new mise version. Until then, the producer side reads \`undefined\` for \`prerelease\` from \`ls-remote --json\` and the rendered TOML simply doesn't carry the field — same as today.

*This pull request was prepared by an AI coding assistant.*