### PR TITLE
fix(ci): disable mise versions host in update/backfill workflows

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -34,6 +34,9 @@ env:
   GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
   TOKEN_MANAGER_URL: https://mise-tools.jdx.dev
   TOKEN_MANAGER_SECRET: ${{ secrets.TOKEN_MANAGER_SECRET }}
+  # Backfill must read from upstream, not from mise-versions itself —
+  # the whole point is to repair entries the host has wrong/stale.
+  MISE_USE_VERSIONS_HOST: "false"
 
 jobs:
   backfill:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,6 +25,11 @@ env:
   TOKEN_MANAGER_URL: https://mise-tools.jdx.dev
   TOKEN_MANAGER_SECRET: ${{ secrets.TOKEN_MANAGER_SECRET }}
   DRY_RUN: 0
+  # Disable mise's versions host: this workflow IS what populates it, so
+  # reading from it would create a self-referential cache where any bad
+  # entry (e.g. a version added without metadata after a GitHub rate limit)
+  # gets re-ingested on the next run instead of being corrected from upstream.
+  MISE_USE_VERSIONS_HOST: "false"
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`mise ls-remote --json` queries mise-versions.jdx.dev (the "versions host") first, falling back to upstream only when the host returns nothing. But this repo's workflows ARE what populates that host, so the cache was self-referential: when a GitHub rate-limit caused a version to be written without metadata, the next run read that broken entry back through the host and committed it again. (Concrete instance: communique v1.1.1 in b280f4be, written with a fallback `now()` timestamp and no `release_url`.)

Set `MISE_USE_VERSIONS_HOST=false` at the workflow `env:` level for `update.yml` and `backfill.yml` so mise always goes straight to GitHub for metadata in these jobs.

## Test plan
- [ ] Next scheduled `update` run completes and any new version it adds has both `created_at` and `release_url` (no `now()` fallback timestamps with millisecond precision)
- [ ] Manual `backfill` dispatch reads upstream rather than the host (visible in mise debug logs if `-vv` enabled)
- [ ] Other workflows (`test`, `metadata`, `python`, `deploy`) unaffected — they don't read versions metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only env var change that alters where metadata is fetched, with no code/runtime behavior outside CI. Main risk is slower runs or upstream rate-limit impacts since cached host is bypassed.
> 
> **Overview**
> Ensures the `update` and `backfill` workflows set `MISE_USE_VERSIONS_HOST="false"`, so mise does *not* read from the repo’s own versions host when generating/backfilling metadata.
> 
> This prevents self-referential re-ingestion of stale/bad entries during scheduled updates and manual backfills, keeping corrections sourced from upstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43118b19877c253a6e94762e5a39a5e5c3409cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->