### PR TITLE
ci: remove actions/configure-pages from update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -63,7 +63,6 @@ jobs:
           else
             echo "No local commits to push"
           fi
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5


### PR DESCRIPTION
## Summary

Removes the `actions/configure-pages@v6` step from `update.yml`. Its outputs (`base_url`, `base_path`) aren't referenced anywhere in this workflow — only `upload-pages-artifact` and `deploy-pages` are used, and `deploy-pages` does its own Pages setup.

At the 30-minute cron cadence the action was exhausting the workflow's `GITHUB_TOKEN` installation rate limit, so roughly every other scheduled run failed with \`Get Pages site failed [...] API rate limit exceeded for installation\` — even though `update.sh` and the D1 sync had completed successfully.

## Test plan
- [ ] Next scheduled run completes without the rate-limit failure
- [ ] GitHub Pages deploy still succeeds (the artifact upload + deploy-pages path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow simplification; the main risk is an unexpected GitHub Pages deploy/config dependency on `configure-pages`, but artifact upload and `deploy-pages` remain unchanged.
> 
> **Overview**
> Removes the `actions/configure-pages@v6` step from the scheduled `update` GitHub Actions workflow, leaving Pages deployment to rely solely on `actions/upload-pages-artifact` and `actions/deploy-pages`.
> 
> This reduces GitHub API calls during the 30-minute cron runs, helping avoid Pages-related `GITHUB_TOKEN` installation rate-limit failures while keeping the existing artifact-upload and deploy flow intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df78412d10ab23f6a1cf25ce597e7bd76b094e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->