### PR TITLE
ci: enable MISE_PRERELEASES so the new `prerelease` field populates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -30,6 +30,13 @@ env:
   # entry (e.g. a version added without metadata after a GitHub rate limit)
   # gets re-ingested on the next run instead of being corrected from upstream.
   MISE_USE_VERSIONS_HOST: "false"
+  # Include pre-release versions globally so the JSON output of
+  # `mise ls-remote --json` carries `prerelease = true` for tags upstream
+  # has flagged as pre-releases. Without this, mise filters them out before
+  # emitting JSON and the rendered TOML never gets the new `prerelease`
+  # field that scripts/generate-toml.js plumbs through (#135). Requires
+  # mise >= the release containing jdx/mise#9415.
+  MISE_PRERELEASES: "1"
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -474,7 +474,7 @@ fetch() {
 	local stderr_file
 	stderr_file=$(mktemp)
 
-	if ! docker run --rm -e GITHUB_TOKEN="$token" -e MISE_USE_VERSIONS_HOST -e MISE_LIST_ALL_VERSIONS -e MISE_LOG_HTTP -e MISE_EXPERIMENTAL -e MISE_TRUSTED_CONFIG_PATHS=/ \
+	if ! docker run --rm -e GITHUB_TOKEN="$token" -e MISE_USE_VERSIONS_HOST -e MISE_LIST_ALL_VERSIONS -e MISE_LOG_HTTP -e MISE_EXPERIMENTAL -e MISE_PRERELEASES -e MISE_TRUSTED_CONFIG_PATHS=/ \
 		jdxcode/mise -y ls-remote "$tool" >"docs/$tool" 2>"$stderr_file"; then
 		log_error "Failed to fetch versions" "tool=$tool"
 		cat "$stderr_file" >&2


### PR DESCRIPTION
## Summary

Sibling to #135. That PR plumbed `prerelease = true` through the TOML pipeline, but on its own the field is dead code: `mise ls-remote --json` filters pre-release tags out before emitting JSON unless the caller has opted in. With ~900 tools, per-tool config isn't viable.

[jdx/mise#9415](https://github.com/jdx/mise/pull/9415) adds a global `MISE_PRERELEASES` env var (and a matching `--prerelease` CLI flag) that flips the filter for every tool at once.

## Changes

- **`.github/workflows/update.yml`** — set `MISE_PRERELEASES: "1"` at the job env level. Covers the host-side `mise ls-remote --json` call in `generate_toml_file` (the JSON path that actually feeds `generate-toml.js`).

- **`scripts/update.sh`** — forward `-e MISE_PRERELEASES` into the Docker container. Covers the plain-text `docker run jdxcode/mise -y ls-remote` call in `fetch()`.

## Verification (after deploy)

After the next run, expect to see `prerelease = true` flags on tools whose upstream releases are flagged as pre-releases — e.g. tools with `-rc1` / `-beta` / `-dev.N` GitHub releases. Until then: zero hits, despite #135 being merged. Confirmed against the most recent run ([24968319913](https://github.com/jdx/mise-versions/actions/runs/24968319913)) which touched 646 tools through the JSON path with zero `prerelease = true` flags emitted.

## Sequencing

Optimistic — depends on:

1. A mise release containing jdx/mise#9415 in the host mise installed by `aube install` / `mise.run`. (Today's host mise = v2026.4.23, which has #9329 but not #9415.)
2. A rebuild of the `jdxcode/mise` Docker image with the same release for the plain-text fallback path.

Until both ship, `MISE_PRERELEASES` is silently ignored — same TOML output as today, no regression. Safe to merge whenever; it activates on its own as soon as the upstream pieces land.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only toggles an environment flag and forwards it into the Dockerized `mise ls-remote` call, changing which versions are included but not altering control flow or security-sensitive logic.
> 
> **Overview**
> Enables global inclusion of prerelease tags during the automated versions update run by setting `MISE_PRERELEASES=1` in the `update` GitHub Actions workflow.
> 
> Also forwards `MISE_PRERELEASES` into the `docker run jdxcode/mise ... ls-remote` invocation in `scripts/update.sh`, allowing downstream TOML generation to populate the new `prerelease = true` metadata when upstream marks releases as prereleases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f30b5f82947f951dde52be950f60a930d01477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->