### PR TITLE
[codex] Self-heal partial version syncs

### DIFF
--- a/scripts/generate-toml.js
+++ b/scripts/generate-toml.js
@@ -103,12 +103,14 @@ function toISOString(value) {
 
 // Load existing TOML if provided
 let existingVersions = {};
+let existingVersionOrder = [];
 if (existingTomlPath && existsSync(existingTomlPath)) {
   try {
     const existingContent = readFileSync(existingTomlPath, "utf-8");
     const parsed = parse(existingContent);
     if (parsed.versions) {
       for (const [version, data] of Object.entries(parsed.versions)) {
+        existingVersionOrder.push(version);
         existingVersions[version] = {
           created_at: toISOString(data.created_at),
           release_url: data.release_url || null,
@@ -122,7 +124,46 @@ if (existingTomlPath && existsSync(existingTomlPath)) {
 }
 
 // Parse new version data (preserves order from mise ls-remote)
-const newVersions = parseNdjson(stdinData);
+let newVersions = parseNdjson(stdinData);
+
+// Some backends can transiently return a valid-looking but truncated list
+// during API failures or backend regressions. If the new list looks partial,
+// preserve the old entries and append any genuinely new versions so one bad
+// fetch cannot erase history.
+const existingCount = existingVersionOrder.length;
+if (
+  existingCount > 0 &&
+  newVersions.length > 0 &&
+  newVersions.length < existingCount
+) {
+  const newByVersion = new Map(newVersions.map((v) => [v.version, v]));
+  const overlapCount = [...newByVersion.keys()].filter((version) =>
+    Object.hasOwn(existingVersions, version),
+  ).length;
+  const overlapRatio = overlapCount / newVersions.length;
+  const incomingRatio = newVersions.length / existingCount;
+
+  if (overlapRatio >= 0.8 || incomingRatio < 0.5) {
+    const mergedVersions = [];
+    const seen = new Set();
+
+    for (const version of existingVersionOrder) {
+      mergedVersions.push(newByVersion.get(version) || { version });
+      seen.add(version);
+    }
+
+    for (const version of newByVersion.keys()) {
+      if (!seen.has(version)) {
+        mergedVersions.push(newByVersion.get(version));
+      }
+    }
+
+    console.error(
+      `Warning: ${tool} returned ${newVersions.length}/${existingCount} versions with ${Math.round(overlapRatio * 100)}% overlap; preserving existing TOML entries`,
+    );
+    newVersions = mergedVersions;
+  }
+}
 
 // For "unstable" tools, sort by semver ascending so the output is
 // deterministic regardless of which fetch path produced the input. Versions

--- a/scripts/generate-toml.test.js
+++ b/scripts/generate-toml.test.js
@@ -250,6 +250,53 @@ describe("generate-toml.js", () => {
       assert.strictEqual(code, 0);
       assert.ok(parse(stdout).versions["1.0.0"]);
     });
+
+    it("should preserve existing versions when input is a likely partial fetch", async () => {
+      const existingToml = join(tempDir, "existing.toml");
+      writeFileSync(
+        existingToml,
+        `[versions]
+"1.0.0" = { created_at = 2024-01-01T00:00:00.000Z }
+"1.1.0" = { created_at = 2024-02-01T00:00:00.000Z }
+"1.2.0" = { created_at = 2024-03-01T00:00:00.000Z }
+"1.3.0" = { created_at = 2024-04-01T00:00:00.000Z }
+"1.3.1" = { created_at = 2024-04-02T00:00:00.000Z }
+"1.3.2" = { created_at = 2024-04-03T00:00:00.000Z }
+"1.3.3" = { created_at = 2024-04-04T00:00:00.000Z }
+"1.3.4" = { created_at = 2024-04-05T00:00:00.000Z }
+`,
+      );
+
+      const input = [
+        '{"version":"1.2.0","created_at":"2024-03-02T00:00:00Z"}',
+        '{"version":"1.3.0"}',
+        '{"version":"1.4.0"}',
+      ].join("\n");
+
+      const { stdout, stderr, code } = await runGenerateToml(input, [
+        "test-tool",
+        existingToml,
+      ]);
+      assert.strictEqual(code, 0);
+      assert.ok(stderr.includes("preserving existing TOML entries"));
+
+      const parsed = parse(stdout);
+      assert.deepStrictEqual(Object.keys(parsed.versions), [
+        "1.0.0",
+        "1.1.0",
+        "1.2.0",
+        "1.3.0",
+        "1.3.1",
+        "1.3.2",
+        "1.3.3",
+        "1.3.4",
+        "1.4.0",
+      ]);
+      assert.strictEqual(
+        parsed.versions["1.2.0"].created_at.toISOString(),
+        "2024-03-02T00:00:00.000Z",
+      );
+    });
   });
 
   describe("prerelease", () => {

--- a/web/src/pages/api/admin/versions/sync.ts
+++ b/web/src/pages/api/admin/versions/sync.ts
@@ -112,10 +112,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
   let toolsProcessed = 0;
   let versionsUpserted = 0;
   let errors = 0;
+  let partialSyncsPreserved = 0;
 
   // Step 5: Batch upsert versions for all tools
   const allVersionStatements: D1PreparedStatement[] = [];
   const toolIdToName = new Map<number, string>();
+  const partialSyncToolIds = new Set<number>();
 
   for (const toolData of body.tools) {
     if (!toolData.tool || !Array.isArray(toolData.versions)) {
@@ -132,8 +134,70 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     toolIdToName.set(toolId, toolData.tool);
 
+    const incomingVersions = toolData.versions
+      .map((v) => v.version)
+      .filter((version): version is string => Boolean(version));
+    const incomingVersionSet = new Set(incomingVersions);
+    const beforeCount = beforeCounts.get(toolId) ?? 0;
+    const existingSortOrders = new Map<string, number | null>();
+    let preserveExistingOrder = false;
+    let nextAppendedSortOrder: number | null = null;
+
+    if (
+      beforeCount > 0 &&
+      incomingVersionSet.size > 0 &&
+      incomingVersionSet.size < beforeCount
+    ) {
+      const existingVersions = await d1
+        .prepare(
+          `
+          SELECT version, sort_order
+          FROM versions
+          WHERE tool_id = ? AND from_mise = 1
+          ORDER BY sort_order ASC, id ASC
+        `,
+        )
+        .bind(toolId)
+        .all<{ version: string; sort_order: number | null }>();
+
+      for (const row of existingVersions.results) {
+        existingSortOrders.set(row.version, row.sort_order);
+      }
+
+      const overlapCount = incomingVersions.filter((version) =>
+        existingSortOrders.has(version),
+      ).length;
+      const overlapRatio = overlapCount / incomingVersionSet.size;
+      const incomingRatio = incomingVersionSet.size / beforeCount;
+
+      if (overlapRatio >= 0.8 || incomingRatio < 0.5) {
+        preserveExistingOrder = true;
+        partialSyncToolIds.add(toolId);
+        partialSyncsPreserved++;
+        const maxSortOrder = Math.max(
+          -1,
+          ...existingVersions.results.map((row) => row.sort_order ?? -1),
+        );
+        nextAppendedSortOrder = maxSortOrder + 1;
+        console.warn(
+          `Preserving existing version order for partial sync of ${toolData.tool}: incoming=${incomingVersionSet.size}, existing=${beforeCount}, overlap=${Math.round(overlapRatio * 100)}%`,
+        );
+      }
+    }
+
     for (const v of toolData.versions) {
       if (!v.version) continue;
+
+      let sortOrder = v.sort_order ?? null;
+      if (preserveExistingOrder) {
+        const existingSortOrder = existingSortOrders.get(v.version);
+        if (existingSortOrder !== undefined) {
+          sortOrder = existingSortOrder;
+        } else {
+          sortOrder = nextAppendedSortOrder;
+          if (nextAppendedSortOrder !== null) nextAppendedSortOrder++;
+        }
+      }
 
       allVersionStatements.push(
         d1
@@ -155,7 +219,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
             v.created_at || null,
             v.release_url || null,
             v.prerelease === true ? 1 : 0,
-            v.sort_order ?? null,
+            sortOrder,
           ),
       );
     }
@@ -183,6 +247,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     const toolId = toolIdMap.get(toolData.tool);
     if (!toolId) continue;
+    if (partialSyncToolIds.has(toolId)) continue;
 
     const incomingVersions = new Set(
       toolData.versions
@@ -269,6 +334,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     versions_upserted: versionsUpserted,
     versions_deleted: versionsDeleted,
     new_versions: newVersionsTotal,
+    partial_syncs_preserved: partialSyncsPreserved,
     errors,
   });
 };


### PR DESCRIPTION
## Summary

- Preserve existing TOML entries when a backend returns a likely partial version list.
- Make the D1 version sync preserve existing sort order and skip stale deletion for likely partial payloads.
- Add coverage for partial-fetch TOML generation.

## Root Cause

A valid-looking but truncated `mise ls-remote` result could overwrite a full TOML and then D1 would faithfully sync that partial list. That produced broken `sort_order` data, including the Bun interleaving issue fixed manually in production.

## Validation

- `npm test`
- `npx tsc --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies version ingestion/sync behavior and deletion safeguards in both TOML generation and the admin D1 sync route; incorrect partial-detection heuristics could leave stale versions or skew `sort_order` until the next successful full sync.
> 
> **Overview**
> Prevents *partial* `mise ls-remote` results from erasing version history. `scripts/generate-toml.js` now detects likely-truncated inputs (size drop + high overlap) and merges by preserving existing TOML order/entries while appending genuinely new versions, emitting a warning; tests add coverage for this behavior.
> 
> Hardens `POST /api/admin/versions/sync` to treat similar payloads as partial syncs: it preserves existing `sort_order` (assigning new appended orders for new versions), skips stale-version deletions for affected tools, and returns `partial_syncs_preserved` in the response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad034e8ee32211e74a501ef89a8aae568a0f706f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->