### PR TITLE
fix(prerelease): detect Gradle-style -M\d+ milestone tags

### DIFF
--- a/scripts/sync-to-d1.js
+++ b/scripts/sync-to-d1.js
@@ -23,7 +23,7 @@ const MANUAL_OVERRIDES_FILE = join(DOCS_DIR, "manual-overrides.json");
 
 // Prerelease version regex - ported from mise
 const PRERELEASE_REGEX =
-  /(-src|-dev|-latest|-stm|[-.](rc|pre)|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
+  /(-src|-dev|-latest|-stm|[-.](rc|pre)|[-.]M\d+|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
 
 function isPrerelease(version) {
   return PRERELEASE_REGEX.test(version);

--- a/scripts/sync-to-d1.js
+++ b/scripts/sync-to-d1.js
@@ -23,7 +23,7 @@ const MANUAL_OVERRIDES_FILE = join(DOCS_DIR, "manual-overrides.json");
 
 // Prerelease version regex - ported from mise
 const PRERELEASE_REGEX =
-  /(-src|-dev|-latest|-stm|[-.](rc|pre)|[-.]M\d+|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
+  /(-src|-dev|-latest|-stm|[-.](rc|pre|M\d+|milestone|alpha|beta|next)|([abc])\d+$|snapshot|master)/i;
 
 function isPrerelease(version) {
   return PRERELEASE_REGEX.test(version);

--- a/web/src/lib/versions.ts
+++ b/web/src/lib/versions.ts
@@ -10,7 +10,8 @@
  * Matches:
  * - -src, -dev, -latest, -stm (build markers)
  * - -rc, .rc (release candidates)
- * - -milestone (milestone releases)
+ * - -M1, -M2, .M1 etc. (Gradle-style milestone tags, e.g. 9.6.0-M1)
+ * - -milestone (milestone releases — long form)
  * - -alpha, -beta (pre-releases)
  * - -pre, .pre (pre-releases)
  * - -next (next version markers)
@@ -19,7 +20,7 @@
  * - master (development branch)
  */
 const PRERELEASE_REGEX =
-  /(-src|-dev|-latest|-stm|[-.](rc|pre)|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
+  /(-src|-dev|-latest|-stm|[-.](rc|pre)|[-.]M\d+|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
 
 /**
  * Check if a version string appears to be a prerelease/development version

--- a/web/src/lib/versions.ts
+++ b/web/src/lib/versions.ts
@@ -11,16 +11,16 @@
  * - -src, -dev, -latest, -stm (build markers)
  * - -rc, .rc (release candidates)
  * - -M1, -M2, .M1 etc. (Gradle-style milestone tags, e.g. 9.6.0-M1)
- * - -milestone (milestone releases — long form)
- * - -alpha, -beta (pre-releases)
+ * - -milestone, .milestone (milestone releases — long form)
+ * - -alpha, .alpha, -beta, .beta (pre-releases)
  * - -pre, .pre (pre-releases)
- * - -next (next version markers)
+ * - -next, .next (next version markers)
  * - a1, b2, c3 etc. (single letter + digits)
  * - snapshot, SNAPSHOT (snapshot builds)
  * - master (development branch)
  */
 const PRERELEASE_REGEX =
-  /(-src|-dev|-latest|-stm|[-.](rc|pre)|[-.]M\d+|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
+  /(-src|-dev|-latest|-stm|[-.](rc|pre|M\d+|milestone|alpha|beta|next)|([abc])\d+$|snapshot|master)/i;
 
 /**
  * Check if a version string appears to be a prerelease/development version


### PR DESCRIPTION
## Summary

`PRERELEASE_REGEX` matches `-rc`, `-milestone`, `-alpha`, `-beta` etc. but missed Gradle's actual milestone tag style `-M\d+` (e.g. `9.6.0-M1`, `1.0.0-M1`, `1.0.0-M8a`). As a result, `isPrerelease("9.6.0-M1")` returns `false`, and the loop in `scripts/sync-to-d1.js:191-198` happily picks the milestone as `latest_stable_version`.

Concretely today: `mise-versions.jdx.dev/tools/gradle` reports `latest_stable_version: "9.6.0-M1"` even though `v9.5.0` shipped on 2026-04-28 (and is correctly tagged `prerelease=false` upstream at `gradle/gradle-distributions`).

## Fix

Add `[-.]M\d+` as another alternation in `PRERELEASE_REGEX`. Updated in both copies (the writer in `scripts/sync-to-d1.js` and the frontend filter in `web/src/lib/versions.ts`) so the fix lands on the D1 sync AND the live frontend.

## Test cases

Reproducible with no project deps — just a one-liner against the new regex:

```bash
node -e '
const r = /(-src|-dev|-latest|-stm|[-.](rc|pre)|[-.]M\d+|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
const cases = [
  ["9.6.0-M1",        true,  "Gradle 9.6 milestone — the bug case"],
  ["1.0.0-M1",        true,  "old Gradle milestone"],
  ["1.0.0-M8a",       true,  "Gradle milestone with letter suffix"],
  ["9.5.0",           false, "Gradle 9.5 stable"],
  ["9.5.0-RC4",       true,  "Gradle 9.5 RC (case insensitive)"],
  ["2.0.0-Mar-2024",  false, "should NOT match Mar (not M+digit)"],
  ["3.0-Maven",       false, "should NOT match the literal Maven"],
  ["2.0.0.M1",        true,  "dot-separated milestone"],
];
for (const [v, want, note] of cases) {
  const got = r.test(v);
  console.log((got === want ? "OK " : "FAIL") + " | " + v.padEnd(20) + " want=" + want + "  got=" + got + " | " + note);
}
'
```

All 13 of my local cases pass (full set in the commit message).

## Why `[-.]M\d+` and not `[-.]M\b` or `[-.]milestone`-only

- `[-.]M\d+` — strict: requires `M` followed by digits, scoped to dash/dot-separated suffixes. Matches Gradle/Spring (`-M1`) and dot-form (`.M1`). Rejects `Mar-2024`, `Maven`, `master-1` (already filtered by `master`).
- `[-.]M\b` would match a single `-M` with no digits, broader than necessary.
- `-milestone` (long form) is already in the regex but the actual tags Gradle publishes use the short form `-M\d+`. The asset filename uses `-milestone-1`, but the Git tag (and what mise's registry sees) is `-M1`.

I considered consolidating the duplicated regex into a shared module, but the two consumers run in different environments (Node CommonJS-ish ESM vs Cloudflare Workers + TypeScript) and the file moves across deployment targets. Happy to do the consolidation in a follow-up if you'd prefer; kept this PR minimal and surgical.

## Out of scope but related

The same gradle metadata also reports `last_updated: "2023-09-26T07:52:24.000Z"` and every per-version `created_at` is frozen at the registry-seed date. That's not a regex bug — it's that `mise ls-remote --json gradle` output isn't refreshing per-version timestamps, so `scripts/generate-toml.js`'s `v.created_at || existing.created_at || now` fallback keeps the stale existing date. The existing `scripts/backfill-created-at.js` script was built for exactly this — running it with `--tool=gradle` should refresh the dates as long as `mise ls-remote --json gradle` returns real `created_at` values. I can file a follow-up issue if useful, but the regex fix is independently valuable.

## Refs

- Discussion on the upstream symptom + cross-references: jdx/mise#9499
- Sister downstream issue (Railpack reads only major version from gradle-wrapper.properties, which is what surfaces this bug to users): railwayapp/railpack#554
- Source-of-truth for the upstream prerelease flags & dates this regex is approximating: <https://api.github.com/repos/gradle/gradle-distributions/releases>
