### PR TITLE
Fix prerelease D1 backfill

### DIFF
--- a/scripts/sync-versions-to-d1.js
+++ b/scripts/sync-versions-to-d1.js
@@ -38,6 +38,8 @@ async function main() {
     process.exit(1);
   }
 
+  const syncUrl = `${apiUrl}/api/admin/versions/sync`;
+
   // Determine which tools to sync
   let toolsToSync = null; // null means all tools
   if (!fullSync && existsSync(UPDATED_TOOLS_FILE)) {
@@ -105,7 +107,6 @@ async function main() {
   );
 
   // Sync in batches with parallel requests
-  const syncUrl = `${apiUrl}/api/admin/versions/sync`;
   let toolsSynced = 0;
   let versionsSynced = 0;
   let newVersions = 0;

--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -2,9 +2,74 @@
 import type { drizzle } from "drizzle-orm/d1";
 import { sql } from "drizzle-orm";
 
-export async function runAnalyticsMigrations(
-  db: ReturnType<typeof drizzle>,
-): Promise<void> {
+type AnalyticsDb = ReturnType<typeof drizzle>;
+
+interface AnalyticsMigration {
+  id: number;
+  name: string;
+  up: (db: AnalyticsDb) => Promise<void>;
+}
+
+const analyticsMigrations: AnalyticsMigration[] = [
+  {
+    id: 1,
+    name: "backfill_prerelease_flags",
+    async up(db) {
+      await db.run(sql`
+        UPDATE versions
+        SET prerelease = 1
+        WHERE prerelease = 0
+          AND (
+            version GLOB '*-M[0-9]*'
+            OR version GLOB '*-RC[0-9]*'
+            OR lower(version) GLOB '*-m[0-9]*'
+            OR lower(version) GLOB '*-rc[0-9]*'
+            OR lower(version) LIKE '%-alpha%'
+            OR lower(version) LIKE '%-beta%'
+            OR lower(version) LIKE '%-dev%'
+            OR lower(version) LIKE '%-milestone%'
+            OR lower(version) LIKE '%-nightly%'
+            OR lower(version) LIKE '%-pre%'
+            OR lower(version) LIKE '%-preview%'
+            OR lower(version) LIKE '%-snapshot%'
+            OR lower(version) LIKE '%-canary%'
+          )
+      `);
+    },
+  },
+];
+
+async function runAnalyticsDataMigrations(db: AnalyticsDb): Promise<void> {
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS analytics_migrations (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      applied_at TEXT NOT NULL
+    )
+  `);
+
+  const appliedMigrations = await db.all(sql`
+    SELECT id FROM analytics_migrations ORDER BY id
+  `);
+  const appliedIds = new Set(appliedMigrations.map((m: any) => m.id));
+
+  for (const migration of analyticsMigrations) {
+    if (appliedIds.has(migration.id)) {
+      continue;
+    }
+
+    console.log(
+      `Applying analytics migration ${migration.id}: ${migration.name}`,
+    );
+    await migration.up(db);
+    await db.run(sql`
+      INSERT INTO analytics_migrations (id, name, applied_at)
+      VALUES (${migration.id}, ${migration.name}, ${new Date().toISOString()})
+    `);
+  }
+}
+
+export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
   console.log("Running analytics database migrations...");
 
   // Check if we need to migrate from old schema
@@ -427,6 +492,8 @@ export async function runAnalyticsMigrations(
   await db.run(
     sql`CREATE INDEX IF NOT EXISTS idx_daily_tool_backend_stats_backend ON daily_tool_backend_stats(backend_type)`,
   );
+
+  await runAnalyticsDataMigrations(db);
 
   console.log("Analytics migrations completed");
 }

--- a/web/src/lib/version-data.ts
+++ b/web/src/lib/version-data.ts
@@ -5,52 +5,27 @@ export interface VersionRow {
   prerelease: number;
 }
 
-interface VersionsTableColumns {
-  fromMise: boolean;
-  prerelease: boolean;
-  sortOrder: boolean;
-}
-
-async function getVersionsTableColumns(
-  analyticsDb: D1Database,
-): Promise<VersionsTableColumns> {
-  const result = await analyticsDb
-    .prepare("PRAGMA table_info(versions)")
-    .all<{ name: string }>();
-  const names = new Set((result.results ?? []).map((col) => col.name));
-
-  return {
-    fromMise: names.has("from_mise"),
-    prerelease: names.has("prerelease"),
-    sortOrder: names.has("sort_order"),
-  };
-}
-
 export async function loadToolVersions(
   analyticsDb: D1Database,
   toolId: number,
   options: { stableOnly?: boolean } = {},
 ): Promise<VersionRow[]> {
-  const columns = await getVersionsTableColumns(analyticsDb);
-  const selectPrerelease = columns.prerelease ? "prerelease" : "0 AS prerelease";
-  const where = ["tool_id = ?"];
+  const where = ["tool_id = ?", "from_mise = 1"];
 
-  if (columns.fromMise) {
-    where.push("from_mise = 1");
-  }
-
-  if (options.stableOnly && columns.prerelease) {
+  if (options.stableOnly) {
     where.push("prerelease = 0");
   }
 
-  const orderBy = columns.sortOrder ? "sort_order ASC, id ASC" : "id ASC";
   const query = `
-    SELECT version, created_at, release_url, ${selectPrerelease}
+    SELECT version, created_at, release_url, prerelease
     FROM versions
     WHERE ${where.join(" AND ")}
-    ORDER BY ${orderBy}
+    ORDER BY sort_order ASC, id ASC
   `;
 
-  const result = await analyticsDb.prepare(query).bind(toolId).all<VersionRow>();
+  const result = await analyticsDb
+    .prepare(query)
+    .bind(toolId)
+    .all<VersionRow>();
   return result.results ?? [];
 }

--- a/web/src/pages/api/admin/versions/sync.ts
+++ b/web/src/pages/api/admin/versions/sync.ts
@@ -43,16 +43,16 @@ export const POST: APIRoute = async ({ request, locals }) => {
     return errorResponse("Invalid JSON body", 400);
   }
 
-  if (!Array.isArray(body.tools) || body.tools.length === 0) {
-    return errorResponse("tools must be a non-empty array", 400);
-  }
-
   const d1 = runtime.env.ANALYTICS_DB;
   const db = drizzle(d1);
   const analytics = setupAnalytics(db);
 
   // Run migrations to ensure schema is up to date
   await runAnalyticsMigrations(db);
+
+  if (!Array.isArray(body.tools) || body.tools.length === 0) {
+    return errorResponse("tools must be a non-empty array", 400);
+  }
 
   // Step 1: Get all tool names we need
   const toolNames = body.tools.map((t) => t.tool).filter(Boolean);


### PR DESCRIPTION
## Summary
- remove old-schema fallbacks from version reads so current D1 schema is required
- add an `analytics_migrations` ledger for one-time analytics data migrations
- backfill obvious prerelease rows in D1 with a migration instead of forcing a slow full version sync

## Why
Prod already has `from_mise`, `sort_order`, and `prerelease`, but existing rows such as Gradle milestone releases were still `prerelease = 0`. Incremental syncs only touch updated tools, so unchanged stale rows never got corrected. The backfill now happens in D1 during analytics migrations.

## Verification
- `npm test`
- `rm -rf web/dist && npm run build -w web`
- `npx wrangler deploy --dry-run`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics D1 migration logic and changes how prerelease/version ordering are derived, including a mass `UPDATE` on the `versions` table; mistakes could mislabel versions or impact query results/perf.
> 
> **Overview**
> Adds a one-time analytics *data migration* system (`analytics_migrations` ledger) and runs it as part of `runAnalyticsMigrations`, with an initial migration that backfills `versions.prerelease` based on common prerelease suffixes (e.g. `-rc`, `-beta`, `-M#`).
> 
> Removes old-schema fallbacks in web version reads by requiring `versions.from_mise`, `versions.prerelease`, and `versions.sort_order` (always filters `from_mise = 1`, stable filtering uses `prerelease = 0`, and ordering is `sort_order` then `id`).
> 
> Ensures analytics migrations run on the `/api/admin/versions/sync` endpoint even when the request payload is invalid/empty (migrations are executed before validating `tools`), and makes a small refactor in the sync script to define the sync URL once up front.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e63f55c989d3d7e98fc042c9069d95a15c268d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->