### PR TITLE
Reduce D1 query reads

### DIFF
--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -315,6 +315,9 @@ export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
     sql`CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_date ON daily_tool_stats(date)`,
   );
   await db.run(
+    sql`CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_date_tool_downloads ON daily_tool_stats(date, tool_id, downloads)`,
+  );
+  await db.run(
     sql`CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_tool_date ON daily_tool_stats(tool_id, date)`,
   );
   await db.run(
@@ -453,6 +456,9 @@ export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
       sql`ALTER TABLE versions ADD COLUMN prerelease INTEGER NOT NULL DEFAULT 0`,
     );
   }
+  await db.run(
+    sql`CREATE INDEX IF NOT EXISTS idx_versions_tool_mise_prerelease_order ON versions(tool_id, from_mise, prerelease, sort_order, id)`,
+  );
 
   // Create version_updates table for tracking when new versions are discovered
   await db.run(sql`

--- a/src/analytics/tracking.ts
+++ b/src/analytics/tracking.ts
@@ -183,7 +183,7 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
 
       // Check if already tracked today for this IP/tool/version
       const existing = await db
-        .select()
+        .select({ id: downloads.id })
         .from(downloads)
         .where(
           and(

--- a/web/scripts/seed-local-db.ts
+++ b/web/scripts/seed-local-db.ts
@@ -115,6 +115,7 @@ CREATE INDEX IF NOT EXISTS idx_downloads_backend_id ON downloads(backend_id);
 CREATE INDEX IF NOT EXISTS idx_downloads_created_at ON downloads(created_at);
 CREATE INDEX IF NOT EXISTS idx_downloads_dedup ON downloads(tool_id, version, ip_hash, created_at);
 CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_tool ON daily_tool_stats(tool_id);
+CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_date_tool_downloads ON daily_tool_stats(date, tool_id, downloads);
 CREATE INDEX IF NOT EXISTS idx_daily_backend_stats_type ON daily_backend_stats(backend_type);
 
 -- Insert tools

--- a/web/scripts/seed.sql
+++ b/web/scripts/seed.sql
@@ -71,6 +71,7 @@ CREATE INDEX IF NOT EXISTS idx_downloads_backend_id ON downloads(backend_id);
 CREATE INDEX IF NOT EXISTS idx_downloads_created_at ON downloads(created_at);
 CREATE INDEX IF NOT EXISTS idx_downloads_dedup ON downloads(tool_id, version, ip_hash, created_at);
 CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_tool ON daily_tool_stats(tool_id);
+CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_date_tool_downloads ON daily_tool_stats(date, tool_id, downloads);
 CREATE INDEX IF NOT EXISTS idx_daily_backend_stats_type ON daily_backend_stats(backend_type);
 
 -- Insert tools

--- a/web/src/lib/version-files.ts
+++ b/web/src/lib/version-files.ts
@@ -59,38 +59,39 @@ export async function loadVersionRows(
   tool: string,
   options: { stableOnly?: boolean } = {},
 ): Promise<VersionRow[] | null> {
-  const rows = await db.all<{
-    tool_id: number;
-    version: string | null;
-    created_at: string | null;
-    release_url: string | null;
-    prerelease: number | null;
-  }>(sql`
-    SELECT
-      t.id as tool_id,
-      v.version,
-      v.created_at,
-      v.release_url,
-      v.prerelease
-    FROM tools t
-    LEFT JOIN versions v
-      ON v.tool_id = t.id
-      AND v.from_mise = 1
-      AND (${options.stableOnly ? 1 : 0} = 0 OR v.prerelease = 0)
-    WHERE t.name = ${tool}
-    ORDER BY v.sort_order ASC, v.id ASC
+  const toolRow = await db.get<{ id: number }>(sql`
+    SELECT id
+    FROM tools
+    WHERE name = ${tool}
   `);
 
-  if (rows.length === 0) return null;
+  if (!toolRow) return null;
 
-  return rows
-    .filter((row) => row.version !== null)
-    .map((row) => ({
-      version: row.version!,
-      created_at: row.created_at,
-      release_url: row.release_url,
-      prerelease: row.prerelease ?? 0,
-    }));
+  const stableFilter = options.stableOnly ? sql`AND prerelease = 0` : sql``;
+  const rows = await db.all<{
+    version: string;
+    created_at: string | null;
+    release_url: string | null;
+    prerelease: number;
+  }>(sql`
+    SELECT
+      version,
+      created_at,
+      release_url,
+      prerelease
+    FROM versions
+    WHERE tool_id = ${toolRow.id}
+      AND from_mise = 1
+      ${stableFilter}
+    ORDER BY sort_order ASC, id ASC
+  `);
+
+  return rows.map((row) => ({
+    version: row.version,
+    created_at: row.created_at,
+    release_url: row.release_url,
+    prerelease: row.prerelease,
+  }));
 }
 
 export function versionsToText(versions: Pick<VersionRow, "version">[]) {


### PR DESCRIPTION
## Summary
- split version-file loading into a tool-id lookup plus direct `versions` query, avoiding the `LEFT JOIN` and prerelease `OR` condition that made D1 scan more work
- add a prerelease-aware `versions` index for stable-only version file requests
- make download dedupe checks index-only by selecting only `downloads.id`
- add a covering date/tool/downloads index for 30-day `daily_tool_stats` rollup scans and mirror it in local seed schemas

## Verification
- `npm run test:js`
- `npx tsc --noEmit`
- push hooks also ran prettier and `bunx tsc --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily performance-oriented query/index changes, but it subtly changes `loadVersionRows` behavior (tool-with-no-versions now returns an empty list instead of `null`) and adds new production indexes that could affect query plans.
> 
> **Overview**
> Reduces D1 read cost by reshaping a few hot queries to be more index-friendly.
> 
> `loadVersionRows` now does a tool-id lookup followed by a direct `versions` query (with a stable-only filter that avoids the previous join/OR pattern), and analytics migrations add a prerelease-aware `versions` covering index to speed stable version-file requests.
> 
> Download dedupe checks in `trackDownload` are made index-only by selecting only `downloads.id`, and rollup scans gain a new covering index on `daily_tool_stats(date, tool_id, downloads)` that’s also mirrored in the local seed schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da06014d9bb1f9bac406a4bc8b898e4e81e6250b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->