### PR TITLE
Use KV for download dedupe

### DIFF
--- a/src/analytics/tracking.ts
+++ b/src/analytics/tracking.ts
@@ -179,26 +179,6 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
       const backendId = await getOrCreateBackendId(full);
       const platformId = await getOrCreatePlatformId(os, arch);
       const now = Math.floor(Date.now() / 1000);
-      const todayStart = Math.floor(now / 86400) * 86400; // Start of today (UTC)
-
-      // Check if already tracked today for this IP/tool/version
-      const existing = await db
-        .select({ id: downloads.id })
-        .from(downloads)
-        .where(
-          and(
-            eq(downloads.tool_id, toolId),
-            eq(downloads.version, version),
-            eq(downloads.ip_hash, ipHash),
-            sql`${downloads.created_at} >= ${todayStart}`,
-          ),
-        )
-        .limit(1)
-        .get();
-
-      if (existing) {
-        return { deduplicated: true };
-      }
 
       // Insert new record
       await db.insert(downloads).values({

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -18,6 +18,7 @@ interface Env {
   ANALYTICS_DB: D1Database;
   DATA_BUCKET: R2Bucket;
   GITHUB_CACHE: KVNamespace;
+  DOWNLOAD_DEDUPE: KVNamespace;
   MISE_VERSIONS_STREAM: import("../src/pipelines").PipelinesStreamBinding;
   GITHUB_APP_ID: string;
   GITHUB_PRIVATE_KEY: string;

--- a/web/src/pages/api/track.ts
+++ b/web/src/pages/api/track.ts
@@ -7,6 +7,21 @@ import {
   getMiseVersionFromHeaders,
 } from "../../../../src/pipelines";
 
+const DOWNLOAD_DEDUPE_TTL_SECONDS = 2 * 24 * 60 * 60;
+
+function dedupePart(value: string): string {
+  return encodeURIComponent(value).replace(/\./g, "%2E");
+}
+
+function downloadDedupeKey(
+  tool: string,
+  version: string,
+  ipHash: string,
+): string {
+  const day = Math.floor(Date.now() / 86400000);
+  return `download-dedupe:${day}:${dedupePart(tool)}:${dedupePart(version)}:${ipHash}`;
+}
+
 export const POST: APIRoute = async ({ request, locals }) => {
   try {
     const body = (await request.json()) as {
@@ -71,6 +86,25 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     const db = drizzle(runtime.env.ANALYTICS_DB);
     const analytics = setupAnalytics(db);
+    const dedupeKey = downloadDedupeKey(body.tool, body.version, ipHash);
+
+    const seen = await runtime.env.DOWNLOAD_DEDUPE.get(dedupeKey);
+    if (seen) {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          deduplicated: true,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    await runtime.env.DOWNLOAD_DEDUPE.put(dedupeKey, "1", {
+      expirationTtl: DOWNLOAD_DEDUPE_TTL_SECONDS,
+    });
 
     const result = await analytics.trackDownload(
       body.tool,

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -21,6 +21,10 @@
       "id": "4f4aae307f5e4dfda604e16f239a047b",
     },
     {
+      "binding": "DOWNLOAD_DEDUPE",
+      "id": "812c4a213f404e4badedfc04d63c1ef9",
+    },
+    {
       "binding": "SESSION",
       "id": "placeholder-session-kv",
     },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,6 +29,10 @@
       "binding": "GITHUB_CACHE",
       "id": "4f4aae307f5e4dfda604e16f239a047b",
     },
+    {
+      "binding": "DOWNLOAD_DEDUPE",
+      "id": "812c4a213f404e4badedfc04d63c1ef9",
+    },
   ],
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

- add a dedicated `DOWNLOAD_DEDUPE` Workers KV namespace binding
- dedupe `/api/track` requests in KV by day, tool, version, and IP hash before touching D1
- remove the download D1 dedupe read from `trackDownload`, assuming KV is the required dedupe layer

## Verification

- `npm run test:js`
- `npx tsc --noEmit`
- `npx prettier --write src/analytics/tracking.ts web/env.d.ts web/src/pages/api/track.ts wrangler.jsonc web/wrangler.jsonc`
- `git diff --check`
- commit and push hooks ran prettier/tsc