### PR TITLE
Use KV for tracking caches

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -34,8 +34,15 @@ export {
 export { runAnalyticsMigrations };
 
 // Main factory function that composes all analytics functions
-export function setupAnalytics(db: ReturnType<typeof drizzle>) {
-  const tracking = createTrackingFunctions(db);
+type AnalyticsOptions = {
+  trackingCache?: KVNamespace;
+};
+
+export function setupAnalytics(
+  db: ReturnType<typeof drizzle>,
+  options: AnalyticsOptions = {},
+) {
+  const tracking = createTrackingFunctions(db, { kv: options.trackingCache });
   const stats = createStatsFunctions(db);
   const backendStats = createBackendStatsFunctions(db);
   const trends = createTrendsFunctions(db);

--- a/src/analytics/tracking.ts
+++ b/src/analytics/tracking.ts
@@ -8,17 +8,65 @@ import {
   downloads,
   versionRequests,
 } from "./schema.js";
+import { keyPart } from "../../web/src/lib/kv-cache.js";
 
 // Caches for ID lookups (shared within the tracking module)
 const toolCache = new Map<string, number>();
 const backendCache = new Map<string, number>();
 const platformCache = new Map<string, number>();
 
-export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
+const ID_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
+const DAILY_DEDUPE_TTL_SECONDS = 2 * 24 * 60 * 60;
+
+type TrackingCache = {
+  kv?: KVNamespace;
+};
+
+async function getCachedId(
+  cache: TrackingCache,
+  key: string,
+): Promise<number | null> {
+  if (!cache.kv) return null;
+
+  const value = await cache.kv.get(key);
+  if (!value) return null;
+
+  const id = Number(value);
+  return Number.isInteger(id) ? id : null;
+}
+
+async function putCachedId(
+  cache: TrackingCache,
+  key: string,
+  id: number,
+): Promise<void> {
+  if (!cache.kv) return;
+
+  await cache.kv.put(key, String(id), {
+    expirationTtl: ID_CACHE_TTL_SECONDS,
+  });
+}
+
+function dailyDedupeKey(name: string, ipHash: string): string {
+  const day = Math.floor(Date.now() / 86400000);
+  return `tracking-dedupe:${name}:${day}:${ipHash}`;
+}
+
+export function createTrackingFunctions(
+  db: ReturnType<typeof drizzle>,
+  cache: TrackingCache = {},
+) {
   async function getOrCreateToolId(name: string): Promise<number> {
     // Check cache first
     if (toolCache.has(name)) {
       return toolCache.get(name)!;
+    }
+
+    const cacheKey = `tracking-id:tool:${keyPart(name)}`;
+    const cachedId = await getCachedId(cache, cacheKey);
+    if (cachedId) {
+      toolCache.set(name, cachedId);
+      return cachedId;
     }
 
     // Try to find existing
@@ -30,6 +78,7 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
 
     if (existing) {
       toolCache.set(name, existing.id);
+      await putCachedId(cache, cacheKey, existing.id);
       return existing.id;
     }
 
@@ -43,6 +92,7 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
 
     const id = inserted!.id;
     toolCache.set(name, id);
+    await putCachedId(cache, cacheKey, id);
     return id;
   }
 
@@ -56,6 +106,13 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
       return backendCache.get(full)!;
     }
 
+    const cacheKey = `tracking-id:backend:${keyPart(full)}`;
+    const cachedId = await getCachedId(cache, cacheKey);
+    if (cachedId) {
+      backendCache.set(full, cachedId);
+      return cachedId;
+    }
+
     // Try to find existing
     const existing = await db
       .select({ id: backends.id })
@@ -65,6 +122,7 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
 
     if (existing) {
       backendCache.set(full, existing.id);
+      await putCachedId(cache, cacheKey, existing.id);
       return existing.id;
     }
 
@@ -78,6 +136,7 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
 
     const id = inserted!.id;
     backendCache.set(full, id);
+    await putCachedId(cache, cacheKey, id);
     return id;
   }
 
@@ -90,6 +149,15 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
     const key = `${os || ""}:${arch || ""}`;
     if (platformCache.has(key)) {
       return platformCache.get(key)!;
+    }
+
+    const cacheKey = `tracking-id:platform:${keyPart(os || "")}:${keyPart(
+      arch || "",
+    )}`;
+    const cachedId = await getCachedId(cache, cacheKey);
+    if (cachedId) {
+      platformCache.set(key, cachedId);
+      return cachedId;
     }
 
     // Try to find existing
@@ -106,6 +174,7 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
 
     if (existing) {
       platformCache.set(key, existing.id);
+      await putCachedId(cache, cacheKey, existing.id);
       return existing.id;
     }
 
@@ -124,6 +193,7 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
 
     const id = inserted!.id;
     platformCache.set(key, id);
+    await putCachedId(cache, cacheKey, id);
     return id;
   }
 
@@ -139,6 +209,25 @@ export function createTrackingFunctions(db: ReturnType<typeof drizzle>) {
     ): Promise<{ deduplicated: boolean }> {
       const now = Math.floor(Date.now() / 1000);
       const todayStart = Math.floor(now / 86400) * 86400; // Start of today (UTC)
+
+      if (cache.kv) {
+        const key = dailyDedupeKey("version-request", ipHash);
+        const seen = await cache.kv.get(key);
+        if (seen) {
+          return { deduplicated: true };
+        }
+
+        await cache.kv.put(key, "1", {
+          expirationTtl: DAILY_DEDUPE_TTL_SECONDS,
+        });
+
+        await db.insert(versionRequests).values({
+          ip_hash: ipHash,
+          created_at: now,
+        });
+
+        return { deduplicated: false };
+      }
 
       // Check if already tracked today for this IP
       const existing = await db

--- a/web/src/lib/kv-cache.ts
+++ b/web/src/lib/kv-cache.ts
@@ -1,0 +1,59 @@
+const TEXT_DECODER = new TextDecoder();
+
+export function keyPart(value: string): string {
+  return encodeURIComponent(value).replace(/\./g, "%2E");
+}
+
+async function sha256(value: string): Promise<string> {
+  const bytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(bytes)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function requestCacheKey(
+  prefix: string,
+  url: URL | Request | string,
+): Promise<string> {
+  const value =
+    typeof url === "string" ? url : url instanceof Request ? url.url : url.href;
+  return `response-cache:${prefix}:${await sha256(value)}`;
+}
+
+export async function getCachedJson<T>(
+  kv: KVNamespace,
+  key: string,
+): Promise<T | null> {
+  const value = await kv.get(key, "arrayBuffer");
+  if (!value) return null;
+
+  return JSON.parse(TEXT_DECODER.decode(value)) as T;
+}
+
+export async function putCachedJson(
+  kv: KVNamespace,
+  key: string,
+  value: unknown,
+  expirationTtl: number,
+): Promise<void> {
+  await kv.put(key, JSON.stringify(value), { expirationTtl });
+}
+
+export async function getCachedText(
+  kv: KVNamespace,
+  key: string,
+): Promise<string | null> {
+  return kv.get(key);
+}
+
+export async function putCachedText(
+  kv: KVNamespace,
+  key: string,
+  value: string,
+  expirationTtl: number,
+): Promise<void> {
+  await kv.put(key, value, { expirationTtl });
+}

--- a/web/src/lib/version-files.ts
+++ b/web/src/lib/version-files.ts
@@ -1,5 +1,9 @@
 import { sql } from "drizzle-orm";
 import type { drizzle } from "drizzle-orm/d1";
+import {
+  getCachedText as getKvCachedText,
+  putCachedText as putKvCachedText,
+} from "./kv-cache";
 
 type Db = ReturnType<typeof drizzle>;
 
@@ -51,6 +55,36 @@ export async function putCachedText(
         "Cache-Control": `public, max-age=${VERSION_FILE_TTL_SECONDS}`,
       },
     }),
+  );
+}
+
+function versionRowsCacheKey(
+  tool: string,
+  options: { stableOnly?: boolean } = {},
+): string {
+  return `version-rows:${options.stableOnly ? "stable" : "all"}:${encodeURIComponent(tool).replace(/\./g, "%2E")}`;
+}
+
+export async function getCachedVersionRows(
+  kv: KVNamespace,
+  tool: string,
+  options: { stableOnly?: boolean } = {},
+): Promise<VersionRow[] | null> {
+  const cached = await getKvCachedText(kv, versionRowsCacheKey(tool, options));
+  return cached ? (JSON.parse(cached) as VersionRow[]) : null;
+}
+
+export async function putCachedVersionRows(
+  kv: KVNamespace,
+  tool: string,
+  options: { stableOnly?: boolean } = {},
+  rows: VersionRow[],
+): Promise<void> {
+  await putKvCachedText(
+    kv,
+    versionRowsCacheKey(tool, options),
+    JSON.stringify(rows),
+    VERSION_FILE_TTL_SECONDS,
   );
 }
 

--- a/web/src/pages/[...tool].toml.ts
+++ b/web/src/pages/[...tool].toml.ts
@@ -7,8 +7,10 @@ import {
   getMiseVersionFromHeaders,
 } from "../../../src/pipelines";
 import {
+  getCachedVersionRows,
   getCachedText,
   loadVersionRows,
+  putCachedVersionRows,
   putCachedText,
   versionsToToml,
 } from "../lib/version-files";
@@ -39,7 +41,23 @@ export const GET: APIRoute = async ({ request, params, locals }) => {
 
     let toml = await getCachedText(request, ":toml");
     if (toml === null) {
-      const versions = await loadVersionRows(db, tool);
+      let versions = await getCachedVersionRows(
+        runtime.env.DOWNLOAD_DEDUPE,
+        tool,
+      );
+      if (versions === null) {
+        versions = await loadVersionRows(db, tool);
+        if (versions !== null) {
+          runtime.ctx.waitUntil(
+            putCachedVersionRows(
+              runtime.env.DOWNLOAD_DEDUPE,
+              tool,
+              {},
+              versions,
+            ),
+          );
+        }
+      }
       if (versions === null) {
         return new Response(`Tool "${tool}" not found`, {
           status: 404,
@@ -72,7 +90,9 @@ export const GET: APIRoute = async ({ request, params, locals }) => {
           });
           // Skip database storage for CI requests (excludes from MAU calculations)
           if (!isCI) {
-            const analytics = setupAnalytics(db);
+            const analytics = setupAnalytics(db, {
+              trackingCache: runtime.env.DOWNLOAD_DEDUPE,
+            });
             await analytics.trackVersionRequest(ipHash);
           }
         } catch (e) {

--- a/web/src/pages/[...tool].ts
+++ b/web/src/pages/[...tool].ts
@@ -1,8 +1,10 @@
 import type { APIRoute } from "astro";
 import { drizzle } from "drizzle-orm/d1";
 import {
+  getCachedVersionRows,
   getCachedText,
   loadVersionRows,
+  putCachedVersionRows,
   putCachedText,
   versionsToText,
 } from "../lib/version-files";
@@ -58,7 +60,25 @@ export const GET: APIRoute = async ({ request, params, locals }) => {
     }
 
     const db = drizzle(runtime.env.ANALYTICS_DB);
-    const versions = await loadVersionRows(db, tool, { stableOnly: true });
+    const options = { stableOnly: true };
+    let versions = await getCachedVersionRows(
+      runtime.env.DOWNLOAD_DEDUPE,
+      tool,
+      options,
+    );
+    if (versions === null) {
+      versions = await loadVersionRows(db, tool, options);
+      if (versions !== null) {
+        runtime.ctx.waitUntil(
+          putCachedVersionRows(
+            runtime.env.DOWNLOAD_DEDUPE,
+            tool,
+            options,
+            versions,
+          ),
+        );
+      }
+    }
     if (versions === null) {
       return new Response(`Tool "${tool}" not found`, {
         status: 404,

--- a/web/src/pages/api/downloads/30d.ts
+++ b/web/src/pages/api/downloads/30d.ts
@@ -1,14 +1,44 @@
 import type { APIRoute } from "astro";
 import { drizzle } from "drizzle-orm/d1";
 import { setupAnalytics } from "../../../../../src/analytics";
+import {
+  getCachedJson,
+  putCachedJson,
+  requestCacheKey,
+} from "../../../lib/kv-cache";
 
-export const GET: APIRoute = async ({ locals }) => {
+const DOWNLOADS_CACHE_TTL_SECONDS = 300;
+
+export const GET: APIRoute = async ({ request, locals }) => {
   try {
     const runtime = locals.runtime;
+    const cacheKey = await requestCacheKey("downloads-30d", request);
+    const cached = await getCachedJson<Record<string, number>>(
+      runtime.env.DOWNLOAD_DEDUPE,
+      cacheKey,
+    );
+    if (cached) {
+      return new Response(JSON.stringify(cached), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+        },
+      });
+    }
+
     const db = drizzle(runtime.env.ANALYTICS_DB);
     const analytics = setupAnalytics(db);
 
     const counts = await analytics.getAll30DayDownloads();
+    runtime.ctx.waitUntil(
+      putCachedJson(
+        runtime.env.DOWNLOAD_DEDUPE,
+        cacheKey,
+        counts,
+        DOWNLOADS_CACHE_TTL_SECONDS,
+      ),
+    );
 
     return new Response(JSON.stringify(counts), {
       status: 200,

--- a/web/src/pages/api/downloads/[tool]/version-trends.ts
+++ b/web/src/pages/api/downloads/[tool]/version-trends.ts
@@ -1,6 +1,13 @@
 import type { APIRoute } from "astro";
 import { drizzle } from "drizzle-orm/d1";
 import { setupAnalytics } from "../../../../../../src/analytics";
+import {
+  getCachedJson,
+  putCachedJson,
+  requestCacheKey,
+} from "../../../../lib/kv-cache";
+
+const VERSION_TRENDS_CACHE_TTL_SECONDS = 300;
 
 export const GET: APIRoute = async ({ params, request, locals }) => {
   const { tool } = params;
@@ -17,10 +24,30 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
 
   try {
     const runtime = locals.runtime;
+    const cacheKey = await requestCacheKey("version-trends", request);
+    const cached = await getCachedJson(runtime.env.DOWNLOAD_DEDUPE, cacheKey);
+    if (cached) {
+      return new Response(JSON.stringify(cached), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+        },
+      });
+    }
+
     const db = drizzle(runtime.env.ANALYTICS_DB);
     const analytics = setupAnalytics(db);
 
     const data = await analytics.getVersionTrends(tool, days);
+    runtime.ctx.waitUntil(
+      putCachedJson(
+        runtime.env.DOWNLOAD_DEDUPE,
+        cacheKey,
+        data,
+        VERSION_TRENDS_CACHE_TTL_SECONDS,
+      ),
+    );
 
     return new Response(JSON.stringify(data), {
       status: 200,

--- a/web/src/pages/api/downloads/[tool]/versions.ts
+++ b/web/src/pages/api/downloads/[tool]/versions.ts
@@ -1,8 +1,15 @@
 import type { APIRoute } from "astro";
 import { drizzle } from "drizzle-orm/d1";
 import { setupAnalytics } from "../../../../../../src/analytics";
+import {
+  getCachedJson,
+  putCachedJson,
+  requestCacheKey,
+} from "../../../../lib/kv-cache";
 
-export const GET: APIRoute = async ({ params, url, locals }) => {
+const VERSION_TRENDS_CACHE_TTL_SECONDS = 300;
+
+export const GET: APIRoute = async ({ params, url, request, locals }) => {
   try {
     const { tool } = params;
     if (!tool) {
@@ -15,10 +22,30 @@ export const GET: APIRoute = async ({ params, url, locals }) => {
     const days = parseInt(url.searchParams.get("days") || "30", 10);
 
     const runtime = locals.runtime;
+    const cacheKey = await requestCacheKey("download-versions", request);
+    const cached = await getCachedJson(runtime.env.DOWNLOAD_DEDUPE, cacheKey);
+    if (cached) {
+      return new Response(JSON.stringify(cached), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+        },
+      });
+    }
+
     const db = drizzle(runtime.env.ANALYTICS_DB);
     const analytics = setupAnalytics(db);
 
     const stats = await analytics.getVersionTrends(tool, days);
+    runtime.ctx.waitUntil(
+      putCachedJson(
+        runtime.env.DOWNLOAD_DEDUPE,
+        cacheKey,
+        stats,
+        VERSION_TRENDS_CACHE_TTL_SECONDS,
+      ),
+    );
 
     return new Response(JSON.stringify(stats), {
       status: 200,

--- a/web/src/pages/api/tools/index.ts
+++ b/web/src/pages/api/tools/index.ts
@@ -1,9 +1,27 @@
 import type { APIRoute } from "astro";
 import { loadToolsPaginated } from "../../../lib/data-loader";
+import {
+  getCachedJson,
+  putCachedJson,
+  requestCacheKey,
+} from "../../../lib/kv-cache";
+
+const TOOLS_CACHE_TTL_SECONDS = 300;
 
 export const GET: APIRoute = async ({ url, locals }) => {
   try {
     const runtime = locals.runtime;
+    const cacheKey = await requestCacheKey("api-tools", url);
+    const cached = await getCachedJson(runtime.env.DOWNLOAD_DEDUPE, cacheKey);
+    if (cached) {
+      return new Response(JSON.stringify(cached), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",
+        },
+      });
+    }
 
     // Parse query parameters
     const page = parseInt(url.searchParams.get("page") || "1", 10);
@@ -32,6 +50,14 @@ export const GET: APIRoute = async ({ url, locals }) => {
       sort,
       backends,
     });
+    runtime.ctx.waitUntil(
+      putCachedJson(
+        runtime.env.DOWNLOAD_DEDUPE,
+        cacheKey,
+        result,
+        TOOLS_CACHE_TTL_SECONDS,
+      ),
+    );
 
     return new Response(JSON.stringify(result), {
       status: 200,

--- a/web/src/pages/api/track.ts
+++ b/web/src/pages/api/track.ts
@@ -6,12 +6,9 @@ import {
   emitTelemetry,
   getMiseVersionFromHeaders,
 } from "../../../../src/pipelines";
+import { keyPart } from "../../lib/kv-cache";
 
 const DOWNLOAD_DEDUPE_TTL_SECONDS = 2 * 24 * 60 * 60;
-
-function dedupePart(value: string): string {
-  return encodeURIComponent(value).replace(/\./g, "%2E");
-}
 
 function downloadDedupeKey(
   tool: string,
@@ -19,7 +16,7 @@ function downloadDedupeKey(
   ipHash: string,
 ): string {
   const day = Math.floor(Date.now() / 86400000);
-  return `download-dedupe:${day}:${dedupePart(tool)}:${dedupePart(version)}:${ipHash}`;
+  return `download-dedupe:${day}:${keyPart(tool)}:${keyPart(version)}:${ipHash}`;
 }
 
 export const POST: APIRoute = async ({ request, locals }) => {
@@ -85,7 +82,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
 
     const db = drizzle(runtime.env.ANALYTICS_DB);
-    const analytics = setupAnalytics(db);
+    const analytics = setupAnalytics(db, {
+      trackingCache: runtime.env.DOWNLOAD_DEDUPE,
+    });
     const dedupeKey = downloadDedupeKey(body.tool, body.version, ipHash);
 
     const seen = await runtime.env.DOWNLOAD_DEDUPE.get(dedupeKey);

--- a/web/src/pages/tools/[...tool].ts
+++ b/web/src/pages/tools/[...tool].ts
@@ -1,8 +1,10 @@
 import type { APIRoute } from "astro";
 import { drizzle } from "drizzle-orm/d1";
 import {
+  getCachedVersionRows,
   getCachedText,
   loadVersionRows,
+  putCachedVersionRows,
   putCachedText,
   versionsToText,
 } from "../../lib/version-files";
@@ -43,7 +45,25 @@ export const GET: APIRoute = async ({ request, params, locals }) => {
     }
 
     const db = drizzle(runtime.env.ANALYTICS_DB);
-    const versions = await loadVersionRows(db, tool, { stableOnly: true });
+    const options = { stableOnly: true };
+    let versions = await getCachedVersionRows(
+      runtime.env.DOWNLOAD_DEDUPE,
+      tool,
+      options,
+    );
+    if (versions === null) {
+      versions = await loadVersionRows(db, tool, options);
+      if (versions !== null) {
+        runtime.ctx.waitUntil(
+          putCachedVersionRows(
+            runtime.env.DOWNLOAD_DEDUPE,
+            tool,
+            options,
+            versions,
+          ),
+        );
+      }
+    }
     if (versions === null) {
       return new Response(`Tool "${tool}" not found`, {
         status: 404,

--- a/web/src/pages/tools/[tool].toml.ts
+++ b/web/src/pages/tools/[tool].toml.ts
@@ -7,8 +7,10 @@ import {
   getMiseVersionFromHeaders,
 } from "../../../../src/pipelines";
 import {
+  getCachedVersionRows,
   getCachedText,
   loadVersionRows,
+  putCachedVersionRows,
   putCachedText,
   versionsToToml,
 } from "../../lib/version-files";
@@ -37,7 +39,23 @@ export const GET: APIRoute = async ({ request, params, locals }) => {
 
     let toml = await getCachedText(request, ":toml");
     if (toml === null) {
-      const versions = await loadVersionRows(db, tool);
+      let versions = await getCachedVersionRows(
+        runtime.env.DOWNLOAD_DEDUPE,
+        tool,
+      );
+      if (versions === null) {
+        versions = await loadVersionRows(db, tool);
+        if (versions !== null) {
+          runtime.ctx.waitUntil(
+            putCachedVersionRows(
+              runtime.env.DOWNLOAD_DEDUPE,
+              tool,
+              {},
+              versions,
+            ),
+          );
+        }
+      }
       if (versions === null) {
         return new Response(`Tool "${tool}" not found`, {
           status: 404,
@@ -70,7 +88,9 @@ export const GET: APIRoute = async ({ request, params, locals }) => {
           });
           // Skip database storage for CI requests (excludes from MAU calculations)
           if (!isCI) {
-            const analytics = setupAnalytics(db);
+            const analytics = setupAnalytics(db, {
+              trackingCache: runtime.env.DOWNLOAD_DEDUPE,
+            });
             await analytics.trackVersionRequest(ipHash);
           }
         } catch (e) {


### PR DESCRIPTION
## Summary

- pass the `DOWNLOAD_DEDUPE` KV namespace into analytics as a tracking cache
- cache tool, backend, and platform ID lookups in KV for the `/api/track` path
- use KV for version-request daily dedupe on TOML endpoints, avoiding the hot `version_requests` D1 lookup when KV is present
- add KV response caching for hot read endpoints that show up in D1 analytics: `/api/tools`, `/api/downloads/30d`, and per-tool version trend endpoints
- add KV caching for version rows used by plain text and TOML version file endpoints, reducing repeated `versions` table reads across colos

## Verification

- `npm run test:js`
- `npx tsc --noEmit`
- `npx prettier --write src/analytics/index.ts src/analytics/tracking.ts web/src/lib/kv-cache.ts web/src/lib/version-files.ts web/src/pages/api/track.ts web/src/pages/api/tools/index.ts web/src/pages/api/downloads/30d.ts 'web/src/pages/api/downloads/[tool]/versions.ts' 'web/src/pages/api/downloads/[tool]/version-trends.ts' 'web/src/pages/[...tool].ts' 'web/src/pages/tools/[...tool].ts' 'web/src/pages/[...tool].toml.ts' 'web/src/pages/tools/[tool].toml.ts'`
- `git diff --check`
- commit and push hooks ran prettier/tsc

Note: `cd web && bunx tsc` is currently blocked by existing web type errors around `Response.json()` returning `unknown` and telemetry `is_ci` type coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request tracking/deduplication and adds KV caching layers around several hot endpoints, so cache-key/TTL mistakes could skew analytics or serve stale data. Changes are localized but affect high-traffic paths and persistence behavior.
> 
> **Overview**
> Adds optional KV-backed caching to analytics tracking via `setupAnalytics(..., { trackingCache })`, using KV to cache tool/backend/platform ID lookups and to perform daily deduplication for `trackVersionRequest` when available.
> 
> Introduces shared KV helpers in `web/src/lib/kv-cache.ts`, and uses KV to cache version-row lookups for the plain-text/TOML version-file endpoints (reducing repeated D1 reads across colos).
> 
> Adds KV response caching (with short TTL + `stale-while-revalidate`) for hot JSON endpoints like `/api/tools`, `/api/downloads/30d`, and per-tool version trend endpoints, plus reuses `keyPart` for consistent KV-safe key construction in `/api/track`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647f97b1d560cafd086bd7ab8ffcccfed1c559fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->