### PR TITLE
Add web build CSS regression test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: bun install
+      - run: npm run build -w web
       - run: bun run test
 
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: bun install
+      - run: bun install --cwd web
       - run: npm run build -w web
       - run: bun run test
 

--- a/scripts/web-build.test.js
+++ b/scripts/web-build.test.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for the built Astro/Tailwind output.
+ *
+ * These assume `npm run build -w web` has already run. CI does that before
+ * `npm run test`, which keeps this test focused on verifying the artifact.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DIST_CLIENT_DIR = new URL("../web/dist/client", import.meta.url).pathname;
+const ASTRO_ASSET_DIR = join(DIST_CLIENT_DIR, "_astro");
+
+function readBuiltCss() {
+  assert.ok(
+    existsSync(ASTRO_ASSET_DIR),
+    "web build assets are missing; run `npm run build -w web` before tests",
+  );
+
+  const cssFiles = readdirSync(ASTRO_ASSET_DIR)
+    .filter((file) => file.endsWith(".css"))
+    .sort();
+
+  assert.ok(cssFiles.length > 0, "web build did not emit a CSS asset");
+
+  return cssFiles
+    .map((file) => readFileSync(join(ASTRO_ASSET_DIR, file), "utf8"))
+    .join("\n");
+}
+
+describe("web build CSS", () => {
+  it("includes Tailwind preflight and project utilities", () => {
+    const css = readBuiltCss();
+
+    assert.match(
+      css,
+      /a\{color:inherit;[-a-z:]+text-decoration:inherit/,
+      "Tailwind preflight reset is missing",
+    );
+
+    const expectedUtilities = [
+      ".bg-dark-900{background-color:#0a0a0f}",
+      ".bg-dark-800{background-color:#12121a}",
+      ".text-neon-purple{color:#b026ff}",
+      ".hover\\:text-neon-pink:hover{color:#ff2d95}",
+      ".px-4{padding-inline:calc(var(--spacing) * 4)}",
+      ".py-8{padding-block:calc(var(--spacing) * 8)}",
+      ".text-xl{font-size:var(--text-xl)",
+      ".max-w-6xl{max-width:var(--container-6xl)}",
+    ];
+
+    for (const utility of expectedUtilities) {
+      assert.ok(css.includes(utility), `missing CSS utility: ${utility}`);
+    }
+  });
+});

--- a/scripts/web-build.test.js
+++ b/scripts/web-build.test.js
@@ -9,8 +9,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const DIST_CLIENT_DIR = new URL("../web/dist/client", import.meta.url).pathname;
+const DIST_CLIENT_DIR = fileURLToPath(
+  new URL("../web/dist/client", import.meta.url),
+);
 const ASTRO_ASSET_DIR = join(DIST_CLIENT_DIR, "_astro");
 
 function readBuiltCss() {
@@ -36,7 +39,7 @@ describe("web build CSS", () => {
 
     assert.match(
       css,
-      /a\{color:inherit;[-a-z:]+text-decoration:inherit/,
+      /a\{color:inherit;[-a-z:]*text-decoration:inherit/,
       "Tailwind preflight reset is missing",
     );
 
@@ -47,7 +50,7 @@ describe("web build CSS", () => {
       ".hover\\:text-neon-pink:hover{color:#ff2d95}",
       ".px-4{padding-inline:calc(var(--spacing) * 4)}",
       ".py-8{padding-block:calc(var(--spacing) * 8)}",
-      ".text-xl{font-size:var(--text-xl)",
+      ".text-xl{font-size:var(--text-xl);",
       ".max-w-6xl{max-width:var(--container-6xl)}",
     ];
 


### PR DESCRIPTION
## Summary
- build the Astro web app in the test workflow before running tests
- add a `node:test` regression that verifies the emitted CSS contains Tailwind preflight, custom `dark`/`neon` utilities, and core layout utilities

## Why
This should catch the failure mode from the Tailwind/Vite upgrade work where the page built successfully but shipped an incomplete stylesheet.

## Verification
- `npm run build -w web`
- `npx tsc --noEmit`
- `npm run test:js`
- `npm run test`
- `git diff --check`
- `npx wrangler deploy --dry-run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a CI build step and a `node:test` regression that reads built CSS artifacts; failures would only block builds if the web build output changes or is missing.
> 
> **Overview**
> CI now builds the `web` workspace (`bun install --cwd web` + `npm run build -w web`) before running the repository test suite.
> 
> Adds `scripts/web-build.test.js`, a regression test that inspects the generated `web/dist/client/_astro` CSS bundle and asserts Tailwind preflight plus key project utilities are present, catching cases where the web build succeeds but emits an incomplete stylesheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c6c3b6ab752e9f5911b0df624b8e9580cfec79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->