### PR TITLE
refactor: remove prerelease regex fallback

### DIFF
--- a/scripts/sync-to-d1.js
+++ b/scripts/sync-to-d1.js
@@ -21,14 +21,8 @@ import { fetchWithRetry } from "./lib/fetch-with-retry.js";
 const DOCS_DIR = join(process.cwd(), "docs");
 const MANUAL_OVERRIDES_FILE = join(DOCS_DIR, "manual-overrides.json");
 
-// Fallback for tools that do not expose explicit prerelease metadata in TOML.
-// Prefer `prerelease = true` from mise where present; this catches older and
-// non-metadata sources so latest_stable_version does not regress.
-const PRERELEASE_REGEX =
-  /(-src|-dev|-latest|-stm|[-.](rc|pre)|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
-
-function isPrerelease(version, data) {
-  return data?.prerelease === true || PRERELEASE_REGEX.test(version);
+function isPrerelease(data) {
+  return data?.prerelease === true;
 }
 
 function toISOString(value) {
@@ -193,7 +187,7 @@ function processTomlFile(filePath) {
     let latestStableVersion = null;
     for (let i = versions.length - 1; i >= 0; i--) {
       const [version, data] = versions[i];
-      if (!isPrerelease(version, data)) {
+      if (!isPrerelease(data)) {
         latestStableVersion = version;
         break;
       }

--- a/web/src/lib/versions.ts
+++ b/web/src/lib/versions.ts
@@ -1,20 +1,7 @@
-/**
- * Regex fallback for backends that do not expose explicit prerelease metadata.
- * Prefer stored `prerelease = true` where available; this only covers older
- * and non-metadata sources such as Java/Core plugin version lists.
- */
-const PRERELEASE_REGEX =
-  /(-src|-dev|-latest|-stm|[-.](rc|pre)|-milestone|-alpha|-beta|-next|([abc])\d+$|snapshot|master)/i;
-
-export function isPrereleaseVersion(version: string): boolean {
-  return PRERELEASE_REGEX.test(version);
-}
-
 export function isPrerelease(version: {
-  version: string;
   prerelease?: boolean | null;
 }): boolean {
-  return version.prerelease === true || isPrereleaseVersion(version.version);
+  return version.prerelease === true;
 }
 
 /**


### PR DESCRIPTION
## Summary

- remove the prerelease-name regex fallback from the web UI version helper
- make `sync-to-d1` compute `latest_stable_version` solely from TOML `prerelease = true` metadata
- leave explicit prerelease metadata handling intact for generated TOML, D1 version sync, and hosted endpoints

## Why

mise now has a follow-up path for setting `prerelease` on metadata-free backends, and mise-versions should stop carrying its own independent prerelease classifier. This makes missing prerelease metadata visible instead of being silently hidden by a second regex in the UI/sync layer.

## Data note

I checked live hosted data before opening this PR. Gradle is correct now (`9.6.0-M1` has `prerelease = true` and plain `/gradle` ends at `9.5.0`), but some live tools still have unflagged prerelease-looking entries such as `ansible-core`, `astro`, and `black`. This PR intentionally removes the masking fallback; those remaining gaps need to be fixed by producing/backfilling explicit prerelease metadata.

## Validation

- npm test
- npx tsc --noEmit
- npx prettier --check scripts/sync-to-d1.js web/src/lib/versions.ts

*This PR description was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prerelease detection to rely solely on explicit `prerelease = true` metadata, which can alter `latest_stable_version` computation and UI prerelease handling for tools with missing flags.
> 
> **Overview**
> Removes the regex-based prerelease name heuristic and makes prerelease detection depend only on explicit `prerelease` metadata.
> 
> `scripts/sync-to-d1.js` now computes `latest_stable_version` by scanning for the most recent version **without** `prerelease = true` (no string-pattern fallback), and `web/src/lib/versions.ts` similarly stops classifying prereleases based on the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e5676876e18b4a0b1a1f2cb309a2363c881109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->