### PR TITLE
Reduce download stats row reads

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -28,6 +28,9 @@ export {
   dailyCombinedStats,
   dailyMauStats,
   versionUpdates,
+  toolDownloadSummaries,
+  toolPlatformDownloadSummaries,
+  toolVersionDownloadSummaries,
 } from "./schema.js";
 
 // Re-export migrations
@@ -82,6 +85,7 @@ export function setupAnalytics(
     populateDailyMauStats: rollups.populateDailyMauStats,
     populateVersionStatsRollup: rollups.populateVersionStatsRollup,
     backfillArchivedToolStats: rollups.backfillArchivedToolStats,
+    populateToolDownloadSummaries: rollups.populateToolDownloadSummaries,
     backfillRollupTables: rollups.backfillRollupTables,
 
     // Growth functions

--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -37,6 +37,97 @@ const analyticsMigrations: AnalyticsMigration[] = [
       `);
     },
   },
+  {
+    id: 2,
+    name: "populate_download_summaries",
+    async up(db) {
+      const now = Math.floor(Date.now() / 1000);
+      const thirtyDaysAgo = new Date((now - 30 * 86400) * 1000)
+        .toISOString()
+        .split("T")[0];
+      const updatedAt = new Date().toISOString();
+
+      await db.run(sql`
+        INSERT OR REPLACE INTO tool_download_summaries (
+          tool_id,
+          downloads_30d,
+          downloads_all_time,
+          updated_at
+        )
+        WITH all_time AS (
+          SELECT tool_id, SUM(downloads) AS downloads_all_time
+          FROM (
+            SELECT tool_id, COUNT(*) AS downloads
+            FROM downloads
+            GROUP BY tool_id
+            UNION ALL
+            SELECT tool_id, SUM(count) AS downloads
+            FROM downloads_daily
+            GROUP BY tool_id
+          )
+          GROUP BY tool_id
+        ),
+        recent AS (
+          SELECT tool_id, SUM(downloads) AS downloads_30d
+          FROM daily_tool_stats
+          WHERE date >= ${thirtyDaysAgo}
+          GROUP BY tool_id
+        )
+        SELECT
+          t.id,
+          COALESCE(r.downloads_30d, 0),
+          COALESCE(a.downloads_all_time, 0),
+          ${updatedAt}
+        FROM tools t
+        LEFT JOIN all_time a ON a.tool_id = t.id
+        LEFT JOIN recent r ON r.tool_id = t.id
+      `);
+
+      await db.run(sql`
+        INSERT OR REPLACE INTO tool_platform_download_summaries (
+          tool_id,
+          platform_id,
+          downloads_all_time
+        )
+        SELECT
+          tool_id,
+          COALESCE(platform_id, 0) AS platform_id,
+          SUM(downloads) AS downloads_all_time
+        FROM (
+          SELECT tool_id, platform_id, COUNT(*) AS downloads
+          FROM downloads
+          GROUP BY tool_id, platform_id
+          UNION ALL
+          SELECT tool_id, platform_id, SUM(count) AS downloads
+          FROM downloads_daily
+          GROUP BY tool_id, platform_id
+        )
+        GROUP BY tool_id, COALESCE(platform_id, 0)
+      `);
+
+      await db.run(sql`
+        INSERT OR REPLACE INTO tool_version_download_summaries (
+          tool_id,
+          version,
+          downloads_all_time
+        )
+        SELECT
+          tool_id,
+          version,
+          SUM(downloads) AS downloads_all_time
+        FROM (
+          SELECT tool_id, version, COUNT(*) AS downloads
+          FROM downloads
+          GROUP BY tool_id, version
+          UNION ALL
+          SELECT tool_id, version, SUM(count) AS downloads
+          FROM downloads_daily
+          GROUP BY tool_id, version
+        )
+        GROUP BY tool_id, version
+      `);
+    },
+  },
 ];
 
 async function runAnalyticsDataMigrations(db: AnalyticsDb): Promise<void> {
@@ -510,6 +601,50 @@ export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
   await db.run(
     sql`CREATE INDEX IF NOT EXISTS idx_daily_tool_backend_stats_backend ON daily_tool_backend_stats(backend_type)`,
   );
+
+  // Summary tables for hot read paths. These are maintained by scheduled
+  // rollups and let UI requests avoid scanning downloads/downloads_daily.
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS tool_download_summaries (
+      tool_id INTEGER PRIMARY KEY,
+      downloads_30d INTEGER NOT NULL DEFAULT 0,
+      downloads_all_time INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (tool_id) REFERENCES tools(id)
+    )
+  `);
+  await db.run(sql`
+    CREATE INDEX IF NOT EXISTS idx_tool_download_summaries_30d
+    ON tool_download_summaries(downloads_30d DESC, tool_id)
+  `);
+
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS tool_platform_download_summaries (
+      tool_id INTEGER NOT NULL,
+      platform_id INTEGER NOT NULL,
+      downloads_all_time INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (tool_id, platform_id),
+      FOREIGN KEY (tool_id) REFERENCES tools(id)
+    )
+  `);
+  await db.run(sql`
+    CREATE INDEX IF NOT EXISTS idx_tool_platform_download_summaries_platform
+    ON tool_platform_download_summaries(platform_id)
+  `);
+
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS tool_version_download_summaries (
+      tool_id INTEGER NOT NULL,
+      version TEXT NOT NULL,
+      downloads_all_time INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (tool_id, version),
+      FOREIGN KEY (tool_id) REFERENCES tools(id)
+    )
+  `);
+  await db.run(sql`
+    CREATE INDEX IF NOT EXISTS idx_tool_version_download_summaries_tool_downloads
+    ON tool_version_download_summaries(tool_id, downloads_all_time DESC)
+  `);
 
   await runAnalyticsDataMigrations(db);
 

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -1,6 +1,6 @@
 // Rollup table population functions
 import type { drizzle } from "drizzle-orm/d1";
-import { sql, eq, and } from "drizzle-orm";
+import { sql, eq, and, type SQL } from "drizzle-orm";
 import {
   backends,
   downloads,
@@ -405,11 +405,260 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
     return { rowsInserted: 0 };
   }
 
+  async function runStatement(
+    query: SQL,
+    d1?: D1Database,
+    d1Query?: string,
+    bindings: (string | number)[] = [],
+  ): Promise<void> {
+    if (d1) {
+      if (!d1Query) {
+        throw new Error("D1 query is required when running against D1");
+      }
+      await d1
+        .prepare(d1Query)
+        .bind(...bindings)
+        .run();
+      return;
+    }
+
+    await db.run(query);
+  }
+
+  async function countSummaryRows(d1?: D1Database): Promise<{
+    toolSummaries: number;
+    platformSummaries: number;
+    versionSummaries: number;
+  }> {
+    if (d1) {
+      const [toolRows, platformRows, versionRows] = await Promise.all([
+        d1
+          .prepare("SELECT COUNT(*) AS count FROM tool_download_summaries")
+          .first<{ count: number }>(),
+        d1
+          .prepare(
+            "SELECT COUNT(*) AS count FROM tool_platform_download_summaries",
+          )
+          .first<{ count: number }>(),
+        d1
+          .prepare(
+            "SELECT COUNT(*) AS count FROM tool_version_download_summaries",
+          )
+          .first<{ count: number }>(),
+      ]);
+      return {
+        toolSummaries: toolRows?.count ?? 0,
+        platformSummaries: platformRows?.count ?? 0,
+        versionSummaries: versionRows?.count ?? 0,
+      };
+    }
+
+    const [toolRows, platformRows, versionRows] = await Promise.all([
+      db.get<{ count: number }>(
+        sql`SELECT COUNT(*) AS count FROM tool_download_summaries`,
+      ),
+      db.get<{ count: number }>(
+        sql`SELECT COUNT(*) AS count FROM tool_platform_download_summaries`,
+      ),
+      db.get<{ count: number }>(
+        sql`SELECT COUNT(*) AS count FROM tool_version_download_summaries`,
+      ),
+    ]);
+
+    return {
+      toolSummaries: toolRows?.count ?? 0,
+      platformSummaries: platformRows?.count ?? 0,
+      versionSummaries: versionRows?.count ?? 0,
+    };
+  }
+
+  async function populateToolDownloadSummaries(d1?: D1Database): Promise<{
+    toolSummaries: number;
+    platformSummaries: number;
+    versionSummaries: number;
+  }> {
+    const now = Math.floor(Date.now() / 1000);
+    const thirtyDaysAgo = new Date((now - 30 * 86400) * 1000)
+      .toISOString()
+      .split("T")[0];
+    const updatedAt = new Date().toISOString();
+
+    await runStatement(
+      sql`
+        INSERT OR REPLACE INTO tool_download_summaries (
+          tool_id,
+          downloads_30d,
+          downloads_all_time,
+          updated_at
+        )
+        WITH all_time AS (
+          SELECT tool_id, SUM(downloads) AS downloads_all_time
+          FROM (
+            SELECT tool_id, COUNT(*) AS downloads
+            FROM downloads
+            GROUP BY tool_id
+            UNION ALL
+            SELECT tool_id, SUM(count) AS downloads
+            FROM downloads_daily
+            GROUP BY tool_id
+          )
+          GROUP BY tool_id
+        ),
+        recent AS (
+          SELECT tool_id, SUM(downloads) AS downloads_30d
+          FROM daily_tool_stats
+          WHERE date >= ${thirtyDaysAgo}
+          GROUP BY tool_id
+        )
+        SELECT
+          t.id,
+          COALESCE(r.downloads_30d, 0),
+          COALESCE(a.downloads_all_time, 0),
+          ${updatedAt}
+        FROM tools t
+        LEFT JOIN all_time a ON a.tool_id = t.id
+        LEFT JOIN recent r ON r.tool_id = t.id
+      `,
+      d1,
+      `
+        INSERT OR REPLACE INTO tool_download_summaries (
+          tool_id,
+          downloads_30d,
+          downloads_all_time,
+          updated_at
+        )
+        WITH all_time AS (
+          SELECT tool_id, SUM(downloads) AS downloads_all_time
+          FROM (
+            SELECT tool_id, COUNT(*) AS downloads
+            FROM downloads
+            GROUP BY tool_id
+            UNION ALL
+            SELECT tool_id, SUM(count) AS downloads
+            FROM downloads_daily
+            GROUP BY tool_id
+          )
+          GROUP BY tool_id
+        ),
+        recent AS (
+          SELECT tool_id, SUM(downloads) AS downloads_30d
+          FROM daily_tool_stats
+          WHERE date >= ?
+          GROUP BY tool_id
+        )
+        SELECT
+          t.id,
+          COALESCE(r.downloads_30d, 0),
+          COALESCE(a.downloads_all_time, 0),
+          ?
+        FROM tools t
+        LEFT JOIN all_time a ON a.tool_id = t.id
+        LEFT JOIN recent r ON r.tool_id = t.id
+      `,
+      [thirtyDaysAgo, updatedAt],
+    );
+
+    await runStatement(
+      sql`
+        INSERT OR REPLACE INTO tool_platform_download_summaries (
+          tool_id,
+          platform_id,
+          downloads_all_time
+        )
+        SELECT
+          tool_id,
+          COALESCE(platform_id, 0) AS platform_id,
+          SUM(downloads) AS downloads_all_time
+        FROM (
+          SELECT tool_id, platform_id, COUNT(*) AS downloads
+          FROM downloads
+          GROUP BY tool_id, platform_id
+          UNION ALL
+          SELECT tool_id, platform_id, SUM(count) AS downloads
+          FROM downloads_daily
+          GROUP BY tool_id, platform_id
+        )
+        GROUP BY tool_id, COALESCE(platform_id, 0)
+      `,
+      d1,
+      `
+        INSERT OR REPLACE INTO tool_platform_download_summaries (
+          tool_id,
+          platform_id,
+          downloads_all_time
+        )
+        SELECT
+          tool_id,
+          COALESCE(platform_id, 0) AS platform_id,
+          SUM(downloads) AS downloads_all_time
+        FROM (
+          SELECT tool_id, platform_id, COUNT(*) AS downloads
+          FROM downloads
+          GROUP BY tool_id, platform_id
+          UNION ALL
+          SELECT tool_id, platform_id, SUM(count) AS downloads
+          FROM downloads_daily
+          GROUP BY tool_id, platform_id
+        )
+        GROUP BY tool_id, COALESCE(platform_id, 0)
+      `,
+    );
+
+    await runStatement(
+      sql`
+        INSERT OR REPLACE INTO tool_version_download_summaries (
+          tool_id,
+          version,
+          downloads_all_time
+        )
+        SELECT
+          tool_id,
+          version,
+          SUM(downloads) AS downloads_all_time
+        FROM (
+          SELECT tool_id, version, COUNT(*) AS downloads
+          FROM downloads
+          GROUP BY tool_id, version
+          UNION ALL
+          SELECT tool_id, version, SUM(count) AS downloads
+          FROM downloads_daily
+          GROUP BY tool_id, version
+        )
+        GROUP BY tool_id, version
+      `,
+      d1,
+      `
+        INSERT OR REPLACE INTO tool_version_download_summaries (
+          tool_id,
+          version,
+          downloads_all_time
+        )
+        SELECT
+          tool_id,
+          version,
+          SUM(downloads) AS downloads_all_time
+        FROM (
+          SELECT tool_id, version, COUNT(*) AS downloads
+          FROM downloads
+          GROUP BY tool_id, version
+          UNION ALL
+          SELECT tool_id, version, SUM(count) AS downloads
+          FROM downloads_daily
+          GROUP BY tool_id, version
+        )
+        GROUP BY tool_id, version
+      `,
+    );
+
+    return countSummaryRows(d1);
+  }
+
   return {
     populateVersionStatsRollup,
     populateRollupTables,
     populateDailyMauStats,
     backfillArchivedToolStats,
+    populateToolDownloadSummaries,
 
     // Backfill rollup tables for the last N days (one-time migration)
     async backfillRollupTables(
@@ -443,6 +692,7 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
       }
 
       const archived = await backfillArchivedToolStats(d1);
+      await populateToolDownloadSummaries(d1);
 
       return {
         daysProcessed,

--- a/src/analytics/schema.ts
+++ b/src/analytics/schema.ts
@@ -110,3 +110,30 @@ export const dailyToolBackendStats = sqliteTable("daily_tool_backend_stats", {
   backend_type: text("backend_type").notNull(), // "aqua", "core", etc.
   downloads: integer("downloads").notNull(),
 });
+
+// Per-tool summary stats for hot UI queries. These are refreshed by scheduled
+// rollups so request paths do not need to scan raw download tables.
+export const toolDownloadSummaries = sqliteTable("tool_download_summaries", {
+  tool_id: integer("tool_id").primaryKey(),
+  downloads_30d: integer("downloads_30d").notNull(),
+  downloads_all_time: integer("downloads_all_time").notNull(),
+  updated_at: text("updated_at").notNull(),
+});
+
+export const toolPlatformDownloadSummaries = sqliteTable(
+  "tool_platform_download_summaries",
+  {
+    tool_id: integer("tool_id").notNull(),
+    platform_id: integer("platform_id").notNull(), // 0 represents unknown
+    downloads_all_time: integer("downloads_all_time").notNull(),
+  },
+);
+
+export const toolVersionDownloadSummaries = sqliteTable(
+  "tool_version_download_summaries",
+  {
+    tool_id: integer("tool_id").notNull(),
+    version: text("version").notNull(),
+    downloads_all_time: integer("downloads_all_time").notNull(),
+  },
+);

--- a/src/analytics/stats.ts
+++ b/src/analytics/stats.ts
@@ -8,6 +8,9 @@ import {
   downloadsDaily,
   dailyToolStats,
   dailyMauStats,
+  toolDownloadSummaries,
+  toolPlatformDownloadSummaries,
+  toolVersionDownloadSummaries,
 } from "./schema.js";
 
 export function createStatsFunctions(db: ReturnType<typeof drizzle>) {
@@ -26,44 +29,98 @@ export function createStatsFunctions(db: ReturnType<typeof drizzle>) {
 
       const toolId = toolRecord.id;
 
-      // Total downloads (raw + aggregated)
-      const rawTotal = await db
-        .select({ count: sql<number>`count(*)` })
-        .from(downloads)
-        .where(eq(downloads.tool_id, toolId))
+      const summary = await db
+        .select({ count: toolDownloadSummaries.downloads_all_time })
+        .from(toolDownloadSummaries)
+        .where(eq(toolDownloadSummaries.tool_id, toolId))
         .get();
 
-      const aggTotal = await db
-        .select({ count: sql<number>`coalesce(sum(count), 0)` })
-        .from(downloadsDaily)
-        .where(eq(downloadsDaily.tool_id, toolId))
-        .get();
+      let total = summary?.count ?? 0;
+      if (!summary) {
+        const rawTotal = await db
+          .select({ count: sql<number>`count(*)` })
+          .from(downloads)
+          .where(eq(downloads.tool_id, toolId))
+          .get();
 
-      const total = (rawTotal?.count ?? 0) + (aggTotal?.count ?? 0);
+        const aggTotal = await db
+          .select({ count: sql<number>`coalesce(sum(count), 0)` })
+          .from(downloadsDaily)
+          .where(eq(downloadsDaily.tool_id, toolId))
+          .get();
+
+        total = (rawTotal?.count ?? 0) + (aggTotal?.count ?? 0);
+      }
 
       // Downloads by version
-      const byVersion = await db
+      let byVersion = await db
         .select({
-          version: downloads.version,
-          count: sql<number>`count(*)`,
+          version: toolVersionDownloadSummaries.version,
+          count: toolVersionDownloadSummaries.downloads_all_time,
         })
-        .from(downloads)
-        .where(eq(downloads.tool_id, toolId))
-        .groupBy(downloads.version)
-        .orderBy(sql`count(*) DESC`)
+        .from(toolVersionDownloadSummaries)
+        .where(eq(toolVersionDownloadSummaries.tool_id, toolId))
+        .orderBy(sql`${toolVersionDownloadSummaries.downloads_all_time} DESC`)
         .all();
 
+      if (byVersion.length === 0 && total > 0) {
+        byVersion = await db.all<{
+          version: string;
+          count: number;
+        }>(sql`
+          SELECT version, SUM(downloads) AS count
+          FROM (
+            SELECT version, COUNT(*) AS downloads
+            FROM downloads
+            WHERE tool_id = ${toolId}
+            GROUP BY version
+            UNION ALL
+            SELECT version, SUM(count) AS downloads
+            FROM downloads_daily
+            WHERE tool_id = ${toolId}
+            GROUP BY version
+          )
+          GROUP BY version
+          ORDER BY count DESC
+        `);
+      }
+
       // Downloads by OS (join with platforms)
-      const byOs = await db
+      let byOs = await db
         .select({
           os: platforms.os,
-          count: sql<number>`count(*)`,
+          count: sql<number>`sum(${toolPlatformDownloadSummaries.downloads_all_time})`,
         })
-        .from(downloads)
-        .leftJoin(platforms, eq(downloads.platform_id, platforms.id))
-        .where(eq(downloads.tool_id, toolId))
+        .from(toolPlatformDownloadSummaries)
+        .leftJoin(
+          platforms,
+          eq(toolPlatformDownloadSummaries.platform_id, platforms.id),
+        )
+        .where(eq(toolPlatformDownloadSummaries.tool_id, toolId))
         .groupBy(platforms.os)
         .all();
+
+      if (byOs.length === 0 && total > 0) {
+        byOs = await db.all<{
+          os: string | null;
+          count: number;
+        }>(sql`
+          SELECT p.os, SUM(d.downloads) AS count
+          FROM (
+            SELECT platform_id, COUNT(*) AS downloads
+            FROM downloads
+            WHERE tool_id = ${toolId}
+            GROUP BY platform_id
+            UNION ALL
+            SELECT platform_id, SUM(count) AS downloads
+            FROM downloads_daily
+            WHERE tool_id = ${toolId}
+            GROUP BY platform_id
+          ) d
+          LEFT JOIN platforms p ON d.platform_id = p.id
+          GROUP BY p.os
+        `);
+      }
 
       // Daily downloads (last 30 days from rollups, excluding current day)
       const now = Math.floor(Date.now() / 1000);
@@ -118,22 +175,57 @@ export function createStatsFunctions(db: ReturnType<typeof drizzle>) {
 
     // Get top downloaded tools (all time)
     async getTopTools(limit: number = 20) {
-      const topTools = await db
+      let topTools = await db
         .select({
           name: tools.name,
-          count: sql<number>`count(*)`,
+          count: toolDownloadSummaries.downloads_all_time,
         })
-        .from(downloads)
-        .innerJoin(tools, eq(downloads.tool_id, tools.id))
-        .groupBy(tools.name)
-        .orderBy(sql`count(*) DESC`)
+        .from(toolDownloadSummaries)
+        .innerJoin(tools, eq(toolDownloadSummaries.tool_id, tools.id))
+        .where(sql`${toolDownloadSummaries.downloads_all_time} > 0`)
+        .orderBy(sql`${toolDownloadSummaries.downloads_all_time} DESC`)
         .limit(limit)
         .all();
 
-      const total = await db
-        .select({ count: sql<number>`count(*)` })
-        .from(downloads)
+      let total = await db
+        .select({
+          count: sql<number>`coalesce(sum(${toolDownloadSummaries.downloads_all_time}), 0)`,
+        })
+        .from(toolDownloadSummaries)
         .get();
+
+      if (topTools.length === 0 && (total?.count ?? 0) === 0) {
+        topTools = await db.all<{
+          name: string;
+          count: number;
+        }>(sql`
+          SELECT t.name, SUM(d.downloads) AS count
+          FROM (
+            SELECT tool_id, COUNT(*) AS downloads
+            FROM downloads
+            GROUP BY tool_id
+            UNION ALL
+            SELECT tool_id, SUM(count) AS downloads
+            FROM downloads_daily
+            GROUP BY tool_id
+          ) d
+          INNER JOIN tools t ON d.tool_id = t.id
+          GROUP BY t.name
+          ORDER BY count DESC
+          LIMIT ${limit}
+        `);
+
+        total = await db.get<{ count: number }>(sql`
+          SELECT COALESCE(SUM(downloads), 0) AS count
+          FROM (
+            SELECT COUNT(*) AS downloads
+            FROM downloads
+            UNION ALL
+            SELECT SUM(count) AS downloads
+            FROM downloads_daily
+          )
+        `);
+      }
 
       return {
         total: total?.count ?? 0,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -103,6 +103,14 @@ export async function scheduled(
       `MAU stats for ${todayStr}: ${todayMauStats ? "updated" : "no data"}`,
     );
 
+    // 5. Refresh summary tables used by hot UI read paths
+    const summaries = await analytics.populateToolDownloadSummaries(
+      env.ANALYTICS_DB,
+    );
+    console.log(
+      `Download summaries refreshed: ${summaries.toolSummaries} tools, ${summaries.platformSummaries} platform rows, ${summaries.versionSummaries} version rows`,
+    );
+
     console.log("Scheduled tasks completed successfully");
   } catch (error) {
     console.error("Scheduled task error:", error);

--- a/web/scripts/seed-local-db.ts
+++ b/web/scripts/seed-local-db.ts
@@ -109,6 +109,27 @@ CREATE TABLE IF NOT EXISTS daily_backend_stats (
   PRIMARY KEY (date, backend_type)
 );
 
+CREATE TABLE IF NOT EXISTS tool_download_summaries (
+  tool_id INTEGER PRIMARY KEY,
+  downloads_30d INTEGER NOT NULL DEFAULT 0,
+  downloads_all_time INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tool_platform_download_summaries (
+  tool_id INTEGER NOT NULL,
+  platform_id INTEGER NOT NULL,
+  downloads_all_time INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (tool_id, platform_id)
+);
+
+CREATE TABLE IF NOT EXISTS tool_version_download_summaries (
+  tool_id INTEGER NOT NULL,
+  version TEXT NOT NULL,
+  downloads_all_time INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (tool_id, version)
+);
+
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_downloads_tool_id ON downloads(tool_id);
 CREATE INDEX IF NOT EXISTS idx_downloads_backend_id ON downloads(backend_id);
@@ -117,6 +138,9 @@ CREATE INDEX IF NOT EXISTS idx_downloads_dedup ON downloads(tool_id, version, ip
 CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_tool ON daily_tool_stats(tool_id);
 CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_date_tool_downloads ON daily_tool_stats(date, tool_id, downloads);
 CREATE INDEX IF NOT EXISTS idx_daily_backend_stats_type ON daily_backend_stats(backend_type);
+CREATE INDEX IF NOT EXISTS idx_tool_download_summaries_30d ON tool_download_summaries(downloads_30d DESC, tool_id);
+CREATE INDEX IF NOT EXISTS idx_tool_platform_download_summaries_platform ON tool_platform_download_summaries(platform_id);
+CREATE INDEX IF NOT EXISTS idx_tool_version_download_summaries_tool_downloads ON tool_version_download_summaries(tool_id, downloads_all_time DESC);
 
 -- Insert tools
 `);
@@ -182,6 +206,44 @@ for (let d = 0; d < 45; d++) {
     );
   });
 }
+
+const thirtyDaysAgo = new Date(now - 30 * day).toISOString().split("T")[0];
+console.log("\n-- Insert tool download summaries");
+console.log(`
+INSERT OR REPLACE INTO tool_download_summaries (
+  tool_id,
+  downloads_30d,
+  downloads_all_time,
+  updated_at
+)
+WITH all_time AS (
+  SELECT tool_id, SUM(downloads) AS downloads_all_time
+  FROM (
+    SELECT tool_id, COUNT(*) AS downloads
+    FROM downloads
+    GROUP BY tool_id
+    UNION ALL
+    SELECT tool_id, SUM(count) AS downloads
+    FROM downloads_daily
+    GROUP BY tool_id
+  )
+  GROUP BY tool_id
+),
+recent AS (
+  SELECT tool_id, SUM(downloads) AS downloads_30d
+  FROM daily_tool_stats
+  WHERE date >= '${thirtyDaysAgo}'
+  GROUP BY tool_id
+)
+SELECT
+  t.id,
+  COALESCE(r.downloads_30d, 0),
+  COALESCE(a.downloads_all_time, 0),
+  '${new Date(now).toISOString()}'
+FROM tools t
+LEFT JOIN all_time a ON a.tool_id = t.id
+LEFT JOIN recent r ON r.tool_id = t.id;
+`);
 
 console.log("\n-- Insert daily backend stats");
 for (let d = 0; d < 45; d++) {

--- a/web/scripts/seed.sql
+++ b/web/scripts/seed.sql
@@ -65,6 +65,27 @@ CREATE TABLE IF NOT EXISTS daily_backend_stats (
   PRIMARY KEY (date, backend_type)
 );
 
+CREATE TABLE IF NOT EXISTS tool_download_summaries (
+  tool_id INTEGER PRIMARY KEY,
+  downloads_30d INTEGER NOT NULL DEFAULT 0,
+  downloads_all_time INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tool_platform_download_summaries (
+  tool_id INTEGER NOT NULL,
+  platform_id INTEGER NOT NULL,
+  downloads_all_time INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (tool_id, platform_id)
+);
+
+CREATE TABLE IF NOT EXISTS tool_version_download_summaries (
+  tool_id INTEGER NOT NULL,
+  version TEXT NOT NULL,
+  downloads_all_time INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (tool_id, version)
+);
+
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_downloads_tool_id ON downloads(tool_id);
 CREATE INDEX IF NOT EXISTS idx_downloads_backend_id ON downloads(backend_id);
@@ -73,6 +94,9 @@ CREATE INDEX IF NOT EXISTS idx_downloads_dedup ON downloads(tool_id, version, ip
 CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_tool ON daily_tool_stats(tool_id);
 CREATE INDEX IF NOT EXISTS idx_daily_tool_stats_date_tool_downloads ON daily_tool_stats(date, tool_id, downloads);
 CREATE INDEX IF NOT EXISTS idx_daily_backend_stats_type ON daily_backend_stats(backend_type);
+CREATE INDEX IF NOT EXISTS idx_tool_download_summaries_30d ON tool_download_summaries(downloads_30d DESC, tool_id);
+CREATE INDEX IF NOT EXISTS idx_tool_platform_download_summaries_platform ON tool_platform_download_summaries(platform_id);
+CREATE INDEX IF NOT EXISTS idx_tool_version_download_summaries_tool_downloads ON tool_version_download_summaries(tool_id, downloads_all_time DESC);
 
 -- Insert tools
 
@@ -1470,3 +1494,37 @@ INSERT OR REPLACE INTO daily_backend_stats (date, backend_type, downloads, uniqu
 INSERT OR REPLACE INTO daily_backend_stats (date, backend_type, downloads, unique_users) VALUES ('2025-11-03', 'npm', 403, 161);
 INSERT OR REPLACE INTO daily_backend_stats (date, backend_type, downloads, unique_users) VALUES ('2025-11-03', 'go', 405, 162);
 INSERT OR REPLACE INTO daily_backend_stats (date, backend_type, downloads, unique_users) VALUES ('2025-11-03', 'pipx', 340, 136);
+
+INSERT OR REPLACE INTO tool_download_summaries (
+  tool_id,
+  downloads_30d,
+  downloads_all_time,
+  updated_at
+)
+WITH all_time AS (
+  SELECT tool_id, SUM(downloads) AS downloads_all_time
+  FROM (
+    SELECT tool_id, COUNT(*) AS downloads
+    FROM downloads
+    GROUP BY tool_id
+    UNION ALL
+    SELECT tool_id, SUM(count) AS downloads
+    FROM downloads_daily
+    GROUP BY tool_id
+  )
+  GROUP BY tool_id
+),
+recent AS (
+  SELECT tool_id, SUM(downloads) AS downloads_30d
+  FROM daily_tool_stats
+  WHERE date >= (SELECT date(max(date), '-30 days') FROM daily_tool_stats)
+  GROUP BY tool_id
+)
+SELECT
+  t.id,
+  COALESCE(r.downloads_30d, 0),
+  COALESCE(a.downloads_all_time, 0),
+  datetime('now')
+FROM tools t
+LEFT JOIN all_time a ON a.tool_id = t.id
+LEFT JOIN recent r ON r.tool_id = t.id;

--- a/web/src/lib/data-loader.ts
+++ b/web/src/lib/data-loader.ts
@@ -168,10 +168,6 @@ export async function loadToolsPaginated(
   const { page = 1, limit = 50, search, sort = "downloads", backends } = params;
 
   const offset = (page - 1) * limit;
-  const now = Math.floor(Date.now() / 1000);
-  const thirtyDaysAgo = new Date((now - 30 * 86400) * 1000)
-    .toISOString()
-    .split("T")[0];
 
   // Build WHERE conditions
   const conditions: string[] = ["t.latest_version IS NOT NULL"];
@@ -208,14 +204,8 @@ export async function loadToolsPaginated(
       break;
   }
 
-  // Main query with CTE for downloads
+  // Main query uses summary tables populated by scheduled rollups.
   const mainQuery = `
-    WITH downloads_30d AS (
-      SELECT tool_id, SUM(downloads) as downloads_30d
-      FROM daily_tool_stats
-      WHERE date >= ?
-      GROUP BY tool_id
-    )
     SELECT
       t.name,
       t.latest_version,
@@ -232,9 +222,9 @@ export async function loadToolsPaginated(
       t.security,
       t.package_urls,
       t.aqua_link,
-      COALESCE(d.downloads_30d, 0) as downloads_30d
+      COALESCE(s.downloads_30d, 0) as downloads_30d
     FROM tools t
-    LEFT JOIN downloads_30d d ON d.tool_id = t.id
+    LEFT JOIN tool_download_summaries s ON s.tool_id = t.id
     WHERE ${whereClause}
     ORDER BY ${orderClause}
     LIMIT ? OFFSET ?
@@ -261,7 +251,7 @@ export async function loadToolsPaginated(
   `;
 
   // Execute queries with individual error handling
-  const mainBindParams = [thirtyDaysAgo, ...bindParams, limit, offset];
+  const mainBindParams = [...bindParams, limit, offset];
   const countBindParams = [...bindParams];
 
   let mainResults: D1Result<PaginatedToolRow>;

--- a/web/src/pages/api/admin/scheduled.ts
+++ b/web/src/pages/api/admin/scheduled.ts
@@ -93,6 +93,14 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
     console.log(`MAU stats recalculated for ${mauDaysUpdated} of 31 days`);
 
+    // 5. Refresh summary tables used by hot UI read paths
+    const summaries = await analytics.populateToolDownloadSummaries(
+      env.ANALYTICS_DB,
+    );
+    console.log(
+      `Download summaries refreshed: ${summaries.toolSummaries} tools, ${summaries.platformSummaries} platform rows, ${summaries.versionSummaries} version rows`,
+    );
+
     return jsonResponse({
       success: true,
       aggregation: {
@@ -122,6 +130,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
       mauStats: {
         daysUpdated: mauDaysUpdated,
       },
+      summaries,
     });
   } catch (error) {
     console.error("Scheduled task error:", error);


### PR DESCRIPTION
## Summary

- add scheduled summary tables for per-tool, per-platform, and per-version download totals
- switch hot stats/detail/homepage reads to use the summaries instead of scanning raw download tables
- populate summaries during analytics migrations and refresh them from cron/admin scheduled jobs

## Testing

- `bunx tsc --noEmit`
- `npm run test`
- `npm run build -w web`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persistent summary tables and scheduled refresh logic that changes how download totals are computed and served; risk is mainly around data correctness/staleness if rollups/migrations fail or lag.
> 
> **Overview**
> Introduces **download summary tables** (`tool_download_summaries`, plus per-*platform* and per-*version* all-time totals) to avoid scanning `downloads`/`downloads_daily` for hot UI/stat read paths.
> 
> Updates analytics migrations and rollups to create, backfill, and periodically refresh these summaries (including from cron and the admin scheduled endpoint), and switches `getDownloadStats`, `getTopTools`, and the web tools pagination query to read primarily from the summary tables with fallbacks to raw aggregation when summaries are missing. Also updates local seed scripts/SQL to create and populate the new tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e867b110a0ecd6911252d6432095921368c47696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->