### PR TITLE
Cache trending tool summaries

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -31,6 +31,7 @@ export {
   toolDownloadSummaries,
   toolPlatformDownloadSummaries,
   toolVersionDownloadSummaries,
+  trendingToolSummaries,
 } from "./schema.js";
 
 // Re-export migrations
@@ -86,6 +87,7 @@ export function setupAnalytics(
     populateVersionStatsRollup: rollups.populateVersionStatsRollup,
     backfillArchivedToolStats: rollups.backfillArchivedToolStats,
     populateToolDownloadSummaries: rollups.populateToolDownloadSummaries,
+    populateTrendingToolSummaries: rollups.populateTrendingToolSummaries,
     backfillRollupTables: rollups.backfillRollupTables,
 
     // Growth functions

--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -646,6 +646,22 @@ export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
     ON tool_version_download_summaries(tool_id, downloads_all_time DESC)
   `);
 
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS trending_tool_summaries (
+      tool_id INTEGER PRIMARY KEY,
+      downloads_30d INTEGER NOT NULL DEFAULT 0,
+      daily_boost REAL NOT NULL DEFAULT 0,
+      trending_score REAL NOT NULL DEFAULT 0,
+      sparkline TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (tool_id) REFERENCES tools(id)
+    )
+  `);
+  await db.run(sql`
+    CREATE INDEX IF NOT EXISTS idx_trending_tool_summaries_score
+    ON trending_tool_summaries(trending_score DESC, tool_id)
+  `);
+
   await runAnalyticsDataMigrations(db);
 
   console.log("Analytics migrations completed");

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -653,12 +653,162 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
     return countSummaryRows(d1);
   }
 
+  async function populateTrendingToolSummaries(
+    d1?: D1Database,
+  ): Promise<{ trendingSummaries: number }> {
+    const now = Math.floor(Date.now() / 1000);
+    const thirtyDaysAgo = new Date((now - 30 * 86400) * 1000)
+      .toISOString()
+      .split("T")[0];
+    const today = new Date(now * 1000).toISOString().split("T")[0];
+    const updatedAt = new Date().toISOString();
+
+    const dailyData = await db
+      .select({
+        tool_id: dailyToolStats.tool_id,
+        date: dailyToolStats.date,
+        downloads: dailyToolStats.downloads,
+      })
+      .from(dailyToolStats)
+      .where(
+        and(
+          sql`${dailyToolStats.date} >= ${thirtyDaysAgo}`,
+          sql`${dailyToolStats.date} < ${today}`,
+        ),
+      )
+      .orderBy(dailyToolStats.date)
+      .all();
+
+    const toolData = new Map<
+      number,
+      { total: number; daily: Map<string, number> }
+    >();
+    for (const row of dailyData) {
+      if (!toolData.has(row.tool_id)) {
+        toolData.set(row.tool_id, { total: 0, daily: new Map() });
+      }
+      const data = toolData.get(row.tool_id)!;
+      data.total += row.downloads;
+      data.daily.set(row.date, row.downloads);
+    }
+
+    const rows: Array<{
+      tool_id: number;
+      downloads_30d: number;
+      daily_boost: number;
+      trending_score: number;
+      sparkline: string;
+    }> = [];
+
+    for (const [toolId, data] of toolData) {
+      const dailyValues: number[] = [];
+      for (let i = 1; i <= 30; i++) {
+        const date = new Date((now - i * 86400) * 1000)
+          .toISOString()
+          .split("T")[0];
+        dailyValues.push(data.daily.get(date) ?? 0);
+      }
+
+      const mean =
+        dailyValues.reduce((sum, value) => sum + value, 0) / dailyValues.length;
+      const variance =
+        dailyValues.reduce((sum, value) => sum + (value - mean) ** 2, 0) /
+        dailyValues.length;
+      const stddev = Math.sqrt(variance);
+
+      if (data.total < 500 || stddev === 0) {
+        continue;
+      }
+
+      const recentAvg = (dailyValues[0] + dailyValues[1] + dailyValues[2]) / 3;
+      const dailyBoost = (recentAvg - mean) / stddev;
+      const sparkline: number[] = [];
+      for (let i = 13; i >= 1; i--) {
+        const date = new Date((now - i * 86400) * 1000)
+          .toISOString()
+          .split("T")[0];
+        sparkline.push(data.daily.get(date) ?? 0);
+      }
+
+      rows.push({
+        tool_id: toolId,
+        downloads_30d: data.total,
+        daily_boost: dailyBoost,
+        trending_score: dailyBoost,
+        sparkline: JSON.stringify(sparkline),
+      });
+    }
+
+    if (d1) {
+      const BATCH_SIZE = 50;
+      for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+        const batch = rows.slice(i, i + BATCH_SIZE);
+        await d1.batch(
+          batch.map((row) =>
+            d1
+              .prepare(
+                "INSERT OR REPLACE INTO trending_tool_summaries (tool_id, downloads_30d, daily_boost, trending_score, sparkline, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+              )
+              .bind(
+                row.tool_id,
+                row.downloads_30d,
+                row.daily_boost,
+                row.trending_score,
+                row.sparkline,
+                updatedAt,
+              ),
+          ),
+        );
+      }
+      await d1
+        .prepare("DELETE FROM trending_tool_summaries WHERE updated_at != ?")
+        .bind(updatedAt)
+        .run();
+    } else {
+      for (const row of rows) {
+        await db.run(sql`
+          INSERT OR REPLACE INTO trending_tool_summaries (
+            tool_id,
+            downloads_30d,
+            daily_boost,
+            trending_score,
+            sparkline,
+            updated_at
+          )
+          VALUES (
+            ${row.tool_id},
+            ${row.downloads_30d},
+            ${row.daily_boost},
+            ${row.trending_score},
+            ${row.sparkline},
+            ${updatedAt}
+          )
+        `);
+      }
+      await db.run(sql`
+        DELETE FROM trending_tool_summaries
+        WHERE updated_at != ${updatedAt}
+      `);
+    }
+
+    const result = d1
+      ? await d1
+          .prepare("SELECT COUNT(*) AS count FROM trending_tool_summaries")
+          .first<{ count: number }>()
+      : await db.get<{ count: number }>(
+          sql`SELECT COUNT(*) AS count FROM trending_tool_summaries`,
+        );
+
+    return { trendingSummaries: result?.count ?? 0 };
+  }
+
   return {
     populateVersionStatsRollup,
     populateRollupTables,
     populateDailyMauStats,
     backfillArchivedToolStats,
     populateToolDownloadSummaries,
+    populateTrendingToolSummaries,
 
     // Backfill rollup tables for the last N days (one-time migration)
     async backfillRollupTables(
@@ -693,6 +843,7 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
 
       const archived = await backfillArchivedToolStats(d1);
       await populateToolDownloadSummaries(d1);
+      await populateTrendingToolSummaries(d1);
 
       return {
         daysProcessed,

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -4,6 +4,7 @@ import { sql, eq, and, type SQL } from "drizzle-orm";
 import {
   backends,
   downloads,
+  tools,
   dailyStats,
   dailyToolStats,
   dailyBackendStats,
@@ -656,39 +657,75 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
   async function populateTrendingToolSummaries(
     d1?: D1Database,
   ): Promise<{ trendingSummaries: number }> {
+    const LOOKBACK_DAYS = 30;
+    const SPARKLINE_DAYS = 13; // yesterday through 13 days ago; today is incomplete.
+    const MIN_DOWNLOADS = 500;
     const now = Math.floor(Date.now() / 1000);
-    const thirtyDaysAgo = new Date((now - 30 * 86400) * 1000)
+    const thirtyDaysAgo = new Date((now - LOOKBACK_DAYS * 86400) * 1000)
       .toISOString()
       .split("T")[0];
     const today = new Date(now * 1000).toISOString().split("T")[0];
     const updatedAt = new Date().toISOString();
+    const lookupDates = Array.from(
+      { length: LOOKBACK_DAYS },
+      (_, index) =>
+        new Date((now - (index + 1) * 86400) * 1000)
+          .toISOString()
+          .split("T")[0],
+    );
+    const sparklineDates = lookupDates.slice(0, SPARKLINE_DAYS).reverse();
 
-    const dailyData = await db
+    const candidates = await db
       .select({
         tool_id: dailyToolStats.tool_id,
-        date: dailyToolStats.date,
-        downloads: dailyToolStats.downloads,
+        downloads_30d: sql<number>`sum(${dailyToolStats.downloads})`,
       })
       .from(dailyToolStats)
+      .innerJoin(tools, eq(dailyToolStats.tool_id, tools.id))
       .where(
         and(
           sql`${dailyToolStats.date} >= ${thirtyDaysAgo}`,
           sql`${dailyToolStats.date} < ${today}`,
+          sql`tools.latest_version IS NOT NULL`,
         ),
       )
-      .orderBy(dailyToolStats.date)
+      .groupBy(dailyToolStats.tool_id)
+      .having(sql`sum(${dailyToolStats.downloads}) >= ${MIN_DOWNLOADS}`)
       .all();
+    const candidateIds = candidates.map((row) => row.tool_id);
+
+    const dailyData =
+      candidateIds.length === 0
+        ? []
+        : await db
+            .select({
+              tool_id: dailyToolStats.tool_id,
+              date: dailyToolStats.date,
+              downloads: dailyToolStats.downloads,
+            })
+            .from(dailyToolStats)
+            .where(
+              and(
+                sql`${dailyToolStats.tool_id} IN (${sql.join(
+                  candidateIds,
+                  sql`, `,
+                )})`,
+                sql`${dailyToolStats.date} >= ${thirtyDaysAgo}`,
+                sql`${dailyToolStats.date} < ${today}`,
+              ),
+            )
+            .orderBy(dailyToolStats.date)
+            .all();
 
     const toolData = new Map<
       number,
       { total: number; daily: Map<string, number> }
     >();
+    for (const row of candidates) {
+      toolData.set(row.tool_id, { total: row.downloads_30d, daily: new Map() });
+    }
     for (const row of dailyData) {
-      if (!toolData.has(row.tool_id)) {
-        toolData.set(row.tool_id, { total: 0, daily: new Map() });
-      }
       const data = toolData.get(row.tool_id)!;
-      data.total += row.downloads;
       data.daily.set(row.date, row.downloads);
     }
 
@@ -701,13 +738,7 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
     }> = [];
 
     for (const [toolId, data] of toolData) {
-      const dailyValues: number[] = [];
-      for (let i = 1; i <= 30; i++) {
-        const date = new Date((now - i * 86400) * 1000)
-          .toISOString()
-          .split("T")[0];
-        dailyValues.push(data.daily.get(date) ?? 0);
-      }
+      const dailyValues = lookupDates.map((date) => data.daily.get(date) ?? 0);
 
       const mean =
         dailyValues.reduce((sum, value) => sum + value, 0) / dailyValues.length;
@@ -716,56 +747,64 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
         dailyValues.length;
       const stddev = Math.sqrt(variance);
 
-      if (data.total < 500 || stddev === 0) {
+      if (stddev === 0) {
         continue;
       }
 
       const recentAvg = (dailyValues[0] + dailyValues[1] + dailyValues[2]) / 3;
       const dailyBoost = (recentAvg - mean) / stddev;
-      const sparkline: number[] = [];
-      for (let i = 13; i >= 1; i--) {
-        const date = new Date((now - i * 86400) * 1000)
-          .toISOString()
-          .split("T")[0];
-        sparkline.push(data.daily.get(date) ?? 0);
-      }
+      const sparkline = sparklineDates.map((date) => data.daily.get(date) ?? 0);
 
       rows.push({
         tool_id: toolId,
         downloads_30d: data.total,
         daily_boost: dailyBoost,
+        // Keep this separate so the ranking formula can evolve without a schema change.
         trending_score: dailyBoost,
         sparkline: JSON.stringify(sparkline),
       });
     }
 
     if (d1) {
-      const BATCH_SIZE = 50;
+      const BATCH_SIZE = 100;
       for (let i = 0; i < rows.length; i += BATCH_SIZE) {
         const batch = rows.slice(i, i + BATCH_SIZE);
-        await d1.batch(
-          batch.map((row) =>
-            d1
-              .prepare(
-                "INSERT OR REPLACE INTO trending_tool_summaries (tool_id, downloads_30d, daily_boost, trending_score, sparkline, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-              )
-              .bind(
-                row.tool_id,
-                row.downloads_30d,
-                row.daily_boost,
-                row.trending_score,
-                row.sparkline,
-                updatedAt,
-              ),
-          ),
-        );
+        const placeholders = batch.map(() => "(?, ?, ?, ?, ?, ?)").join(", ");
+        await d1
+          .prepare(
+            `INSERT OR REPLACE INTO trending_tool_summaries (tool_id, downloads_30d, daily_boost, trending_score, sparkline, updated_at) VALUES ${placeholders}`,
+          )
+          .bind(
+            ...batch.flatMap((row) => [
+              row.tool_id,
+              row.downloads_30d,
+              row.daily_boost,
+              row.trending_score,
+              row.sparkline,
+              updatedAt,
+            ]),
+          )
+          .run();
       }
-      await d1
-        .prepare("DELETE FROM trending_tool_summaries WHERE updated_at != ?")
-        .bind(updatedAt)
-        .run();
-    } else {
-      for (const row of rows) {
+      if (rows.length > 0) {
+        await d1
+          .prepare("DELETE FROM trending_tool_summaries WHERE updated_at != ?")
+          .bind(updatedAt)
+          .run();
+      }
+    } else if (rows.length > 0) {
+      const BATCH_SIZE = 100;
+      for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+        const values = rows.slice(i, i + BATCH_SIZE).map(
+          (row) => sql`(
+            ${row.tool_id},
+            ${row.downloads_30d},
+            ${row.daily_boost},
+            ${row.trending_score},
+            ${row.sparkline},
+            ${updatedAt}
+          )`,
+        );
         await db.run(sql`
           INSERT OR REPLACE INTO trending_tool_summaries (
             tool_id,
@@ -775,19 +814,12 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
             sparkline,
             updated_at
           )
-          VALUES (
-            ${row.tool_id},
-            ${row.downloads_30d},
-            ${row.daily_boost},
-            ${row.trending_score},
-            ${row.sparkline},
-            ${updatedAt}
-          )
+          VALUES ${sql.join(values, sql`, `)}
         `);
       }
       await db.run(sql`
-        DELETE FROM trending_tool_summaries
-        WHERE updated_at != ${updatedAt}
+          DELETE FROM trending_tool_summaries
+          WHERE updated_at != ${updatedAt}
       `);
     }
 

--- a/src/analytics/schema.ts
+++ b/src/analytics/schema.ts
@@ -139,7 +139,9 @@ export const toolVersionDownloadSummaries = sqliteTable(
 );
 
 export const trendingToolSummaries = sqliteTable("trending_tool_summaries", {
-  tool_id: integer("tool_id").primaryKey(),
+  tool_id: integer("tool_id")
+    .primaryKey()
+    .references(() => tools.id),
   downloads_30d: integer("downloads_30d").notNull(),
   daily_boost: real("daily_boost").notNull(),
   trending_score: real("trending_score").notNull(),

--- a/src/analytics/schema.ts
+++ b/src/analytics/schema.ts
@@ -1,5 +1,5 @@
 // Analytics schema - normalized tables for download tracking
-import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
 
 // Tools lookup table
 export const tools = sqliteTable("tools", {
@@ -137,3 +137,12 @@ export const toolVersionDownloadSummaries = sqliteTable(
     downloads_all_time: integer("downloads_all_time").notNull(),
   },
 );
+
+export const trendingToolSummaries = sqliteTable("trending_tool_summaries", {
+  tool_id: integer("tool_id").primaryKey(),
+  downloads_30d: integer("downloads_30d").notNull(),
+  daily_boost: real("daily_boost").notNull(),
+  trending_score: real("trending_score").notNull(),
+  sparkline: text("sparkline").notNull(),
+  updated_at: text("updated_at").notNull(),
+});

--- a/src/analytics/trends.ts
+++ b/src/analytics/trends.ts
@@ -467,6 +467,48 @@ export function createTrendsFunctions(db: ReturnType<typeof drizzle>) {
         version_count: number;
       }>
     > {
+      const summaryRows = await db.all<{
+        name: string;
+        downloads_30d: number;
+        trending_score: number;
+        daily_boost: number;
+        sparkline: string;
+        description: string | null;
+        backends: string | null;
+        security: string | null;
+        version_count: number | null;
+      }>(sql`
+	        SELECT
+	          t.name,
+	          s.downloads_30d,
+	          s.trending_score,
+	          s.daily_boost,
+	          s.sparkline,
+	          t.description,
+	          t.backends,
+	          t.security,
+	          t.version_count
+	        FROM trending_tool_summaries s
+	        INNER JOIN tools t ON s.tool_id = t.id
+	        WHERE t.latest_version IS NOT NULL
+	        ORDER BY s.trending_score DESC
+	        LIMIT ${limit}
+	      `);
+
+      if (summaryRows.length > 0) {
+        return summaryRows.map((row) => ({
+          name: row.name,
+          downloads_30d: row.downloads_30d,
+          trendingScore: row.trending_score,
+          dailyBoost: row.daily_boost,
+          sparkline: JSON.parse(row.sparkline),
+          description: row.description || undefined,
+          backends: row.backends ? JSON.parse(row.backends) : undefined,
+          security: row.security ? JSON.parse(row.security) : undefined,
+          version_count: row.version_count || 0,
+        }));
+      }
+
       const now = Math.floor(Date.now() / 1000);
       const thirtyDaysAgo = new Date((now - 30 * 86400) * 1000)
         .toISOString()

--- a/src/analytics/trends.ts
+++ b/src/analytics/trends.ts
@@ -514,6 +514,14 @@ export function createTrendsFunctions(db: ReturnType<typeof drizzle>) {
         .toISOString()
         .split("T")[0];
       const today = new Date(now * 1000).toISOString().split("T")[0];
+      const lookupDates = Array.from(
+        { length: 30 },
+        (_, index) =>
+          new Date((now - (index + 1) * 86400) * 1000)
+            .toISOString()
+            .split("T")[0],
+      );
+      const sparklineDates = lookupDates.slice(0, 13).reverse();
 
       const dailyData = await db
         .select({
@@ -528,6 +536,7 @@ export function createTrendsFunctions(db: ReturnType<typeof drizzle>) {
           and(
             sql`${dailyToolStats.date} >= ${thirtyDaysAgo}`,
             sql`${dailyToolStats.date} < ${today}`,
+            sql`tools.latest_version IS NOT NULL`,
           ),
         )
         .orderBy(dailyToolStats.date)
@@ -561,22 +570,14 @@ export function createTrendsFunctions(db: ReturnType<typeof drizzle>) {
       }> = [];
 
       for (const [name, data] of toolData) {
-        const sparkline: number[] = [];
-        for (let i = 13; i >= 1; i--) {
-          const date = new Date((now - i * 86400) * 1000)
-            .toISOString()
-            .split("T")[0];
-          sparkline.push(data.daily.get(date) ?? 0);
-        }
+        const sparkline = sparklineDates.map(
+          (date) => data.daily.get(date) ?? 0,
+        );
 
         // Collect daily values for the 30-day window
-        const dailyValues: number[] = [];
-        for (let i = 1; i <= 30; i++) {
-          const date = new Date((now - i * 86400) * 1000)
-            .toISOString()
-            .split("T")[0];
-          dailyValues.push(data.daily.get(date) ?? 0);
-        }
+        const dailyValues = lookupDates.map(
+          (date) => data.daily.get(date) ?? 0,
+        );
 
         // Compute mean and standard deviation over the full 30 days
         const mean =

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -111,6 +111,13 @@ export async function scheduled(
       `Download summaries refreshed: ${summaries.toolSummaries} tools, ${summaries.platformSummaries} platform rows, ${summaries.versionSummaries} version rows`,
     );
 
+    const trendingSummaries = await analytics.populateTrendingToolSummaries(
+      env.ANALYTICS_DB,
+    );
+    console.log(
+      `Trending summaries refreshed: ${trendingSummaries.trendingSummaries} tools`,
+    );
+
     console.log("Scheduled tasks completed successfully");
   } catch (error) {
     console.error("Scheduled task error:", error);

--- a/web/scripts/seed-local-db.ts
+++ b/web/scripts/seed-local-db.ts
@@ -130,6 +130,15 @@ CREATE TABLE IF NOT EXISTS tool_version_download_summaries (
   PRIMARY KEY (tool_id, version)
 );
 
+CREATE TABLE IF NOT EXISTS trending_tool_summaries (
+  tool_id INTEGER PRIMARY KEY,
+  downloads_30d INTEGER NOT NULL DEFAULT 0,
+  daily_boost REAL NOT NULL DEFAULT 0,
+  trending_score REAL NOT NULL DEFAULT 0,
+  sparkline TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_downloads_tool_id ON downloads(tool_id);
 CREATE INDEX IF NOT EXISTS idx_downloads_backend_id ON downloads(backend_id);
@@ -141,6 +150,7 @@ CREATE INDEX IF NOT EXISTS idx_daily_backend_stats_type ON daily_backend_stats(b
 CREATE INDEX IF NOT EXISTS idx_tool_download_summaries_30d ON tool_download_summaries(downloads_30d DESC, tool_id);
 CREATE INDEX IF NOT EXISTS idx_tool_platform_download_summaries_platform ON tool_platform_download_summaries(platform_id);
 CREATE INDEX IF NOT EXISTS idx_tool_version_download_summaries_tool_downloads ON tool_version_download_summaries(tool_id, downloads_all_time DESC);
+CREATE INDEX IF NOT EXISTS idx_trending_tool_summaries_score ON trending_tool_summaries(trending_score DESC, tool_id);
 
 -- Insert tools
 `);

--- a/web/scripts/seed.sql
+++ b/web/scripts/seed.sql
@@ -86,6 +86,15 @@ CREATE TABLE IF NOT EXISTS tool_version_download_summaries (
   PRIMARY KEY (tool_id, version)
 );
 
+CREATE TABLE IF NOT EXISTS trending_tool_summaries (
+  tool_id INTEGER PRIMARY KEY,
+  downloads_30d INTEGER NOT NULL DEFAULT 0,
+  daily_boost REAL NOT NULL DEFAULT 0,
+  trending_score REAL NOT NULL DEFAULT 0,
+  sparkline TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_downloads_tool_id ON downloads(tool_id);
 CREATE INDEX IF NOT EXISTS idx_downloads_backend_id ON downloads(backend_id);
@@ -97,6 +106,7 @@ CREATE INDEX IF NOT EXISTS idx_daily_backend_stats_type ON daily_backend_stats(b
 CREATE INDEX IF NOT EXISTS idx_tool_download_summaries_30d ON tool_download_summaries(downloads_30d DESC, tool_id);
 CREATE INDEX IF NOT EXISTS idx_tool_platform_download_summaries_platform ON tool_platform_download_summaries(platform_id);
 CREATE INDEX IF NOT EXISTS idx_tool_version_download_summaries_tool_downloads ON tool_version_download_summaries(tool_id, downloads_all_time DESC);
+CREATE INDEX IF NOT EXISTS idx_trending_tool_summaries_score ON trending_tool_summaries(trending_score DESC, tool_id);
 
 -- Insert tools
 

--- a/web/src/pages/api/admin/scheduled.ts
+++ b/web/src/pages/api/admin/scheduled.ts
@@ -101,6 +101,13 @@ export const POST: APIRoute = async ({ request, locals }) => {
       `Download summaries refreshed: ${summaries.toolSummaries} tools, ${summaries.platformSummaries} platform rows, ${summaries.versionSummaries} version rows`,
     );
 
+    const trendingSummaries = await analytics.populateTrendingToolSummaries(
+      env.ANALYTICS_DB,
+    );
+    console.log(
+      `Trending summaries refreshed: ${trendingSummaries.trendingSummaries} tools`,
+    );
+
     return jsonResponse({
       success: true,
       aggregation: {
@@ -131,6 +138,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         daysUpdated: mauDaysUpdated,
       },
       summaries,
+      trendingSummaries,
     });
   } catch (error) {
     console.error("Scheduled task error:", error);


### PR DESCRIPTION
## Summary

- add `trending_tool_summaries` for precomputed trending scores and sparklines
- refresh trending summaries from scheduled/admin rollup tasks
- switch `getTrendingTools()` to read the summary table first, with the existing 30-day scan retained only as an empty-table fallback

## Testing

- `bunx tsc --noEmit`
- `npm run test`
- `npm run build -w web`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted rollup table and scheduled refresh path for trending calculations, which changes DB schema and introduces new batch upsert/delete logic that could impact analytics query performance or correctness if the scoring/filters are off.
> 
> **Overview**
> Adds a new `trending_tool_summaries` rollup table (schema, migrations, and seed SQL) to cache 30‑day download totals, a computed *daily boost* score, and a 13‑day sparkline per tool.
> 
> Introduces `populateTrendingToolSummaries()` to compute and batch upsert these rows during rollups/backfills, and wires it into both the Cloudflare cron `scheduled` worker and the admin `POST /api/admin/scheduled` task.
> 
> Updates `getTrendingTools()` to read from `trending_tool_summaries` first (with the previous 30‑day scan retained as a fallback when the table is empty), and exports the new table via `src/analytics/index.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e064ce2b253befd0efb4d3027bd7ef71ea9db79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->