### PR TITLE
feat(api): add tool-scoped tracking endpoint

### DIFF
--- a/pipelines/telemetry.schema.json
+++ b/pipelines/telemetry.schema.json
@@ -1,7 +1,15 @@
 {
   "description": "mise-versions telemetry events mirrored from the Worker into Cloudflare Pipelines",
   "type": "object",
-  "required": ["schema_version", "type", "ts", "tool", "ip_hash", "source"],
+  "required": [
+    "schema_version",
+    "type",
+    "ts",
+    "tool",
+    "ip_hash",
+    "source",
+    "is_ci"
+  ],
   "properties": {
     "schema_version": { "type": "integer", "enum": [1] },
     "type": { "type": "string", "enum": ["download", "version_request"] },
@@ -16,7 +24,11 @@
     },
     "ip_hash": { "type": "string" },
     "mise_version": { "type": ["string", "null"] },
-    "source": { "type": "string", "enum": ["api/track", "toml"] }
+    "source": {
+      "type": "string",
+      "enum": ["api/track", "api/tools/:tool", "toml"]
+    },
+    "is_ci": { "type": "boolean" }
   },
   "additionalProperties": false
 }

--- a/scripts/api-track.test.js
+++ b/scripts/api-track.test.js
@@ -63,6 +63,7 @@ async function handleTrackRequest(request, locals, deps = {}) {
   const {
     hashIP = async () => "test-hash",
     trackDownload = async () => ({ deduplicated: false }),
+    pathTool,
   } = deps;
 
   try {
@@ -70,7 +71,9 @@ async function handleTrackRequest(request, locals, deps = {}) {
 
     // Validate required fields (matches real implementation)
     // Note: !body.tool catches both missing and empty string cases since !"" is true
-    if (!body.tool || !body.version) {
+    const tool = pathTool || body.tool;
+
+    if (!tool || !body.version) {
       return new Response(
         JSON.stringify({ error: "Missing required fields: tool, version" }),
         {
@@ -83,7 +86,7 @@ async function handleTrackRequest(request, locals, deps = {}) {
     // Track the download
     const ipHash = await hashIP("127.0.0.1", locals.runtime.env.API_SECRET);
     const result = await trackDownload(
-      body.tool,
+      tool,
       body.version,
       ipHash,
       body.os || null,
@@ -243,6 +246,29 @@ describe("/api/track endpoint", () => {
       assert.strictEqual(response.status, 200);
       assert.strictEqual(body.success, true);
       assert.strictEqual(body.deduplicated, true);
+    });
+
+    it("should track with tool from path when body omits tool", async () => {
+      const request = createMockRequest({
+        version: "20.10.0",
+      });
+      const locals = createMockLocals();
+      let trackedData = null;
+
+      const response = await handleTrackRequest(request, locals, {
+        pathTool: "node",
+        trackDownload: async (tool, version, ipHash, os, arch, full) => {
+          trackedData = { tool, version, ipHash, os, arch, full };
+          return { deduplicated: false };
+        },
+      });
+
+      const body = JSON.parse(await response.text());
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(body.success, true);
+      assert.strictEqual(trackedData.tool, "node");
+      assert.strictEqual(trackedData.version, "20.10.0");
     });
   });
 

--- a/src/pipelines.ts
+++ b/src/pipelines.ts
@@ -14,7 +14,8 @@ export type TelemetryEventV1 =
       full: string | null; // backend identifier (e.g. "aqua:nektos/act")
       ip_hash: string;
       mise_version: string | null;
-      source: "api/track";
+      source: "api/track" | "api/tools/:tool";
+      is_ci: boolean;
     }
   | {
       schema_version: 1;
@@ -24,6 +25,7 @@ export type TelemetryEventV1 =
       ip_hash: string;
       mise_version: string | null;
       source: "toml";
+      is_ci: boolean;
     };
 
 export function getMiseVersionFromUserAgent(

--- a/web/src/pages/api/tools/[...tool].ts
+++ b/web/src/pages/api/tools/[...tool].ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { trackDownloadRequest } from "../track";
+
+export const POST: APIRoute = async ({ request, locals, params }) => {
+  return trackDownloadRequest({
+    request,
+    locals,
+    tool: params.tool,
+    source: "api/tools/:tool",
+  });
+};

--- a/web/src/pages/api/track.ts
+++ b/web/src/pages/api/track.ts
@@ -6,6 +6,7 @@ import { env } from "cloudflare:workers";
 import {
   emitTelemetry,
   getMiseVersionFromHeaders,
+  type TelemetryEventV1,
 } from "../../../../src/pipelines";
 import { keyPart } from "../../lib/kv-cache";
 
@@ -21,16 +22,36 @@ function downloadDedupeKey(
 }
 
 export const POST: APIRoute = async ({ request, locals }) => {
+  return trackDownloadRequest({
+    request,
+    locals,
+    source: "api/track",
+  });
+};
+
+export async function trackDownloadRequest({
+  request,
+  locals,
+  tool: pathTool,
+  source,
+}: {
+  request: Parameters<APIRoute>[0]["request"];
+  locals: Parameters<APIRoute>[0]["locals"];
+  tool?: string;
+  source: Extract<TelemetryEventV1, { type: "download" }>["source"];
+}) {
   try {
     const body = (await request.json()) as {
-      tool: string;
+      tool?: string;
       version: string;
       os?: string;
       arch?: string;
       full?: string;
     };
 
-    if (!body.tool || !body.version) {
+    const tool = pathTool || body.tool;
+
+    if (!tool || !body.version) {
       return new Response(
         JSON.stringify({ error: "Missing required fields: tool, version" }),
         {
@@ -53,14 +74,14 @@ export const POST: APIRoute = async ({ request, locals }) => {
         schema_version: 1,
         type: "download",
         ts: Date.now(),
-        tool: body.tool,
+        tool,
         version: body.version,
         os: body.os ?? null,
         arch: body.arch ?? null,
         full: body.full ?? null,
         ip_hash: ipHash,
         mise_version: miseVersion,
-        source: "api/track",
+        source,
         is_ci: isCI,
       }),
     );
@@ -84,7 +105,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const analytics = setupAnalytics(db, {
       trackingCache: env.DOWNLOAD_DEDUPE,
     });
-    const dedupeKey = downloadDedupeKey(body.tool, body.version, ipHash);
+    const dedupeKey = downloadDedupeKey(tool, body.version, ipHash);
 
     const seen = await env.DOWNLOAD_DEDUPE.get(dedupeKey);
     if (seen) {
@@ -105,7 +126,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     });
 
     const result = await analytics.trackDownload(
-      body.tool,
+      tool,
       body.version,
       ipHash,
       body.os || null,
@@ -130,4 +151,4 @@ export const POST: APIRoute = async ({ request, locals }) => {
       headers: { "Content-Type": "application/json" },
     });
   }
-};
+}


### PR DESCRIPTION
## Summary

- add `POST /api/tools/:tool` tracking while keeping `/api/track` for older mise clients
- share the existing download tracking/dedupe path and take `tool` from the route for the new endpoint
- update telemetry typing/schema for the new source and the already-emitted `is_ci` flag

## Validation

- `node --test scripts/api-track.test.js`
- `prettier --check web/src/pages/api/track.ts web/src/pages/api/tools/[...tool].ts src/pipelines.ts pipelines/telemetry.schema.json scripts/api-track.test.js`
- root `tsc --noEmit` using the installed dependency tree from `/Users/jdx/src/mise-versions/node_modules`

Notes: `npm run test:js` in the fresh worktree also requires installed package deps and prebuilt web assets; `web` typecheck/build are currently blocked by existing TS/env/dependency issues unrelated to this route change.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public API route and changes telemetry schema/contracts (`source` values and required `is_ci`), which could break clients or downstream ingestion if any producer/consumer isn’t updated in lockstep.
> 
> **Overview**
> Adds `POST /api/tools/:tool` as a new download-tracking endpoint that reuses the existing `/api/track` logic, taking `tool` from the route when present and allowing the request body to omit it.
> 
> Refactors `web/src/pages/api/track.ts` to a shared `trackDownloadRequest` helper and updates tests to cover the path-derived tool behavior.
> 
> Updates telemetry typing/schema to require `is_ci` and to expand `source` to include `api/tools/:tool` (in both `TelemetryEventV1` and `pipelines/telemetry.schema.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40b001e795dd31b0b35a94f2e6f31dbe0cf59aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->