### PR TITLE
Cache backend filter counts

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -31,6 +31,7 @@ export {
   toolDownloadSummaries,
   toolPlatformDownloadSummaries,
   toolVersionDownloadSummaries,
+  backendToolSummaries,
   trendingToolSummaries,
 } from "./schema.js";
 
@@ -87,6 +88,7 @@ export function setupAnalytics(
     populateVersionStatsRollup: rollups.populateVersionStatsRollup,
     backfillArchivedToolStats: rollups.backfillArchivedToolStats,
     populateToolDownloadSummaries: rollups.populateToolDownloadSummaries,
+    populateBackendToolSummaries: rollups.populateBackendToolSummaries,
     populateTrendingToolSummaries: rollups.populateTrendingToolSummaries,
     backfillRollupTables: rollups.backfillRollupTables,
 

--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -647,6 +647,18 @@ export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
   `);
 
   await db.run(sql`
+    CREATE TABLE IF NOT EXISTS backend_tool_summaries (
+      backend_type TEXT PRIMARY KEY,
+      tool_count INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  await db.run(sql`
+    CREATE INDEX IF NOT EXISTS idx_backend_tool_summaries_count
+    ON backend_tool_summaries(tool_count DESC, backend_type)
+  `);
+
+  await db.run(sql`
     CREATE TABLE IF NOT EXISTS trending_tool_summaries (
       tool_id INTEGER PRIMARY KEY,
       downloads_30d INTEGER NOT NULL DEFAULT 0,

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -751,56 +751,49 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
     );
     const sparklineDates = lookupDates.slice(0, SPARKLINE_DAYS).reverse();
 
-    const candidates = await db
-      .select({
-        tool_id: dailyToolStats.tool_id,
-        downloads_30d: sql<number>`sum(${dailyToolStats.downloads})`,
-      })
-      .from(dailyToolStats)
-      .innerJoin(tools, eq(dailyToolStats.tool_id, tools.id))
-      .where(
-        and(
-          sql`${dailyToolStats.date} >= ${thirtyDaysAgo}`,
-          sql`${dailyToolStats.date} < ${today}`,
-          sql`tools.latest_version IS NOT NULL`,
-        ),
+    const dailyData = await db.all<{
+      tool_id: number;
+      downloads_30d: number;
+      date: string;
+      downloads: number;
+    }>(sql`
+      WITH candidates AS (
+        SELECT
+          daily_tool_stats.tool_id,
+          SUM(daily_tool_stats.downloads) AS downloads_30d
+        FROM daily_tool_stats
+          INNER JOIN tools ON daily_tool_stats.tool_id = tools.id
+        WHERE
+          daily_tool_stats.date >= ${thirtyDaysAgo}
+          AND daily_tool_stats.date < ${today}
+          AND tools.latest_version IS NOT NULL
+        GROUP BY daily_tool_stats.tool_id
+        HAVING SUM(daily_tool_stats.downloads) >= ${MIN_DOWNLOADS}
       )
-      .groupBy(dailyToolStats.tool_id)
-      .having(sql`sum(${dailyToolStats.downloads}) >= ${MIN_DOWNLOADS}`)
-      .all();
-    const candidateIds = candidates.map((row) => row.tool_id);
-
-    const dailyData =
-      candidateIds.length === 0
-        ? []
-        : await db
-            .select({
-              tool_id: dailyToolStats.tool_id,
-              date: dailyToolStats.date,
-              downloads: dailyToolStats.downloads,
-            })
-            .from(dailyToolStats)
-            .where(
-              and(
-                sql`${dailyToolStats.tool_id} IN (${sql.join(
-                  candidateIds,
-                  sql`, `,
-                )})`,
-                sql`${dailyToolStats.date} >= ${thirtyDaysAgo}`,
-                sql`${dailyToolStats.date} < ${today}`,
-              ),
-            )
-            .orderBy(dailyToolStats.date)
-            .all();
+      SELECT
+        daily_tool_stats.tool_id,
+        candidates.downloads_30d,
+        daily_tool_stats.date,
+        daily_tool_stats.downloads
+      FROM daily_tool_stats
+        INNER JOIN candidates ON daily_tool_stats.tool_id = candidates.tool_id
+      WHERE
+        daily_tool_stats.date >= ${thirtyDaysAgo}
+        AND daily_tool_stats.date < ${today}
+      ORDER BY daily_tool_stats.date
+    `);
 
     const toolData = new Map<
       number,
       { total: number; daily: Map<string, number> }
     >();
-    for (const row of candidates) {
-      toolData.set(row.tool_id, { total: row.downloads_30d, daily: new Map() });
-    }
     for (const row of dailyData) {
+      if (!toolData.has(row.tool_id)) {
+        toolData.set(row.tool_id, {
+          total: row.downloads_30d,
+          daily: new Map(),
+        });
+      }
       const data = toolData.get(row.tool_id)!;
       data.daily.set(row.date, row.downloads);
     }
@@ -845,22 +838,22 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
       const BATCH_SIZE = 100;
       for (let i = 0; i < rows.length; i += BATCH_SIZE) {
         const batch = rows.slice(i, i + BATCH_SIZE);
-        const placeholders = batch.map(() => "(?, ?, ?, ?, ?, ?)").join(", ");
-        await d1
-          .prepare(
-            `INSERT OR REPLACE INTO trending_tool_summaries (tool_id, downloads_30d, daily_boost, trending_score, sparkline, updated_at) VALUES ${placeholders}`,
-          )
-          .bind(
-            ...batch.flatMap((row) => [
-              row.tool_id,
-              row.downloads_30d,
-              row.daily_boost,
-              row.trending_score,
-              row.sparkline,
-              updatedAt,
-            ]),
-          )
-          .run();
+        await d1.batch(
+          batch.map((row) =>
+            d1
+              .prepare(
+                "INSERT OR REPLACE INTO trending_tool_summaries (tool_id, downloads_30d, daily_boost, trending_score, sparkline, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+              )
+              .bind(
+                row.tool_id,
+                row.downloads_30d,
+                row.daily_boost,
+                row.trending_score,
+                row.sparkline,
+                updatedAt,
+              ),
+          ),
+        );
       }
       if (rows.length > 0) {
         await d1

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -654,6 +654,82 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
     return countSummaryRows(d1);
   }
 
+  async function populateBackendToolSummaries(
+    d1?: D1Database,
+  ): Promise<{ backendSummaries: number }> {
+    const updatedAt = new Date().toISOString();
+
+    await runStatement(
+      sql`
+        INSERT OR REPLACE INTO backend_tool_summaries (
+          backend_type,
+          tool_count,
+          updated_at
+        )
+        SELECT
+          SUBSTR(value, 1, INSTR(value || ':', ':') - 1) AS backend_type,
+          COUNT(DISTINCT tools.id) AS tool_count,
+          ${updatedAt}
+        FROM tools, json_each(backends)
+        WHERE latest_version IS NOT NULL
+          AND backends IS NOT NULL
+        GROUP BY backend_type
+      `,
+      d1,
+      `
+        INSERT OR REPLACE INTO backend_tool_summaries (
+          backend_type,
+          tool_count,
+          updated_at
+        )
+        SELECT
+          SUBSTR(value, 1, INSTR(value || ':', ':') - 1) AS backend_type,
+          COUNT(DISTINCT tools.id) AS tool_count,
+          ?
+        FROM tools, json_each(backends)
+        WHERE latest_version IS NOT NULL
+          AND backends IS NOT NULL
+        GROUP BY backend_type
+      `,
+      [updatedAt],
+    );
+
+    const refreshed = d1
+      ? await d1
+          .prepare(
+            "SELECT COUNT(*) AS count FROM backend_tool_summaries WHERE updated_at = ?",
+          )
+          .bind(updatedAt)
+          .first<{ count: number }>()
+      : await db.get<{ count: number }>(sql`
+          SELECT COUNT(*) AS count
+          FROM backend_tool_summaries
+          WHERE updated_at = ${updatedAt}
+        `);
+
+    if ((refreshed?.count ?? 0) > 0) {
+      await runStatement(
+        sql`
+          DELETE FROM backend_tool_summaries
+          WHERE updated_at != ${updatedAt}
+        `,
+        d1,
+        "DELETE FROM backend_tool_summaries WHERE updated_at != ?",
+        [updatedAt],
+      );
+    }
+
+    const total = d1
+      ? await d1
+          .prepare("SELECT COUNT(*) AS count FROM backend_tool_summaries")
+          .first<{ count: number }>()
+      : await db.get<{ count: number }>(
+          sql`SELECT COUNT(*) AS count FROM backend_tool_summaries`,
+        );
+
+    return { backendSummaries: total?.count ?? 0 };
+  }
+
   async function populateTrendingToolSummaries(
     d1?: D1Database,
   ): Promise<{ trendingSummaries: number }> {
@@ -840,6 +916,7 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
     populateDailyMauStats,
     backfillArchivedToolStats,
     populateToolDownloadSummaries,
+    populateBackendToolSummaries,
     populateTrendingToolSummaries,
 
     // Backfill rollup tables for the last N days (one-time migration)
@@ -875,6 +952,7 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
 
       const archived = await backfillArchivedToolStats(d1);
       await populateToolDownloadSummaries(d1);
+      await populateBackendToolSummaries(d1);
       await populateTrendingToolSummaries(d1);
 
       return {

--- a/src/analytics/schema.ts
+++ b/src/analytics/schema.ts
@@ -138,6 +138,12 @@ export const toolVersionDownloadSummaries = sqliteTable(
   },
 );
 
+export const backendToolSummaries = sqliteTable("backend_tool_summaries", {
+  backend_type: text("backend_type").primaryKey(),
+  tool_count: integer("tool_count").notNull(),
+  updated_at: text("updated_at").notNull(),
+});
+
 export const trendingToolSummaries = sqliteTable("trending_tool_summaries", {
   tool_id: integer("tool_id")
     .primaryKey()

--- a/src/analytics/trends.ts
+++ b/src/analytics/trends.ts
@@ -478,22 +478,22 @@ export function createTrendsFunctions(db: ReturnType<typeof drizzle>) {
         security: string | null;
         version_count: number | null;
       }>(sql`
-	        SELECT
-	          t.name,
-	          s.downloads_30d,
-	          s.trending_score,
-	          s.daily_boost,
-	          s.sparkline,
-	          t.description,
-	          t.backends,
-	          t.security,
-	          t.version_count
-	        FROM trending_tool_summaries s
-	        INNER JOIN tools t ON s.tool_id = t.id
-	        WHERE t.latest_version IS NOT NULL
-	        ORDER BY s.trending_score DESC
-	        LIMIT ${limit}
-	      `);
+        SELECT
+          t.name,
+          s.downloads_30d,
+          s.trending_score,
+          s.daily_boost,
+          s.sparkline,
+          t.description,
+          t.backends,
+          t.security,
+          t.version_count
+        FROM trending_tool_summaries s
+        INNER JOIN tools t ON s.tool_id = t.id
+        WHERE t.latest_version IS NOT NULL
+        ORDER BY s.trending_score DESC
+        LIMIT ${limit}
+      `);
 
       if (summaryRows.length > 0) {
         return summaryRows.map((row) => ({

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -111,6 +111,13 @@ export async function scheduled(
       `Download summaries refreshed: ${summaries.toolSummaries} tools, ${summaries.platformSummaries} platform rows, ${summaries.versionSummaries} version rows`,
     );
 
+    const backendSummaries = await analytics.populateBackendToolSummaries(
+      env.ANALYTICS_DB,
+    );
+    console.log(
+      `Backend summaries refreshed: ${backendSummaries.backendSummaries} backend rows`,
+    );
+
     const trendingSummaries = await analytics.populateTrendingToolSummaries(
       env.ANALYTICS_DB,
     );

--- a/web/scripts/seed-local-db.ts
+++ b/web/scripts/seed-local-db.ts
@@ -130,6 +130,12 @@ CREATE TABLE IF NOT EXISTS tool_version_download_summaries (
   PRIMARY KEY (tool_id, version)
 );
 
+CREATE TABLE IF NOT EXISTS backend_tool_summaries (
+  backend_type TEXT PRIMARY KEY,
+  tool_count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS trending_tool_summaries (
   tool_id INTEGER PRIMARY KEY,
   downloads_30d INTEGER NOT NULL DEFAULT 0,
@@ -150,6 +156,7 @@ CREATE INDEX IF NOT EXISTS idx_daily_backend_stats_type ON daily_backend_stats(b
 CREATE INDEX IF NOT EXISTS idx_tool_download_summaries_30d ON tool_download_summaries(downloads_30d DESC, tool_id);
 CREATE INDEX IF NOT EXISTS idx_tool_platform_download_summaries_platform ON tool_platform_download_summaries(platform_id);
 CREATE INDEX IF NOT EXISTS idx_tool_version_download_summaries_tool_downloads ON tool_version_download_summaries(tool_id, downloads_all_time DESC);
+CREATE INDEX IF NOT EXISTS idx_backend_tool_summaries_count ON backend_tool_summaries(tool_count DESC, backend_type);
 CREATE INDEX IF NOT EXISTS idx_trending_tool_summaries_score ON trending_tool_summaries(trending_score DESC, tool_id);
 
 -- Insert tools

--- a/web/scripts/seed.sql
+++ b/web/scripts/seed.sql
@@ -86,6 +86,12 @@ CREATE TABLE IF NOT EXISTS tool_version_download_summaries (
   PRIMARY KEY (tool_id, version)
 );
 
+CREATE TABLE IF NOT EXISTS backend_tool_summaries (
+  backend_type TEXT PRIMARY KEY,
+  tool_count INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS trending_tool_summaries (
   tool_id INTEGER PRIMARY KEY,
   downloads_30d INTEGER NOT NULL DEFAULT 0,
@@ -106,6 +112,7 @@ CREATE INDEX IF NOT EXISTS idx_daily_backend_stats_type ON daily_backend_stats(b
 CREATE INDEX IF NOT EXISTS idx_tool_download_summaries_30d ON tool_download_summaries(downloads_30d DESC, tool_id);
 CREATE INDEX IF NOT EXISTS idx_tool_platform_download_summaries_platform ON tool_platform_download_summaries(platform_id);
 CREATE INDEX IF NOT EXISTS idx_tool_version_download_summaries_tool_downloads ON tool_version_download_summaries(tool_id, downloads_all_time DESC);
+CREATE INDEX IF NOT EXISTS idx_backend_tool_summaries_count ON backend_tool_summaries(tool_count DESC, backend_type);
 CREATE INDEX IF NOT EXISTS idx_trending_tool_summaries_score ON trending_tool_summaries(trending_score DESC, tool_id);
 
 -- Insert tools

--- a/web/src/lib/data-loader.ts
+++ b/web/src/lib/data-loader.ts
@@ -238,8 +238,18 @@ export async function loadToolsPaginated(
   `;
 
   // Backend counts query (for filter chips - counts across ALL tools, not just current page)
-  // Note: json_each returns value as a plain string, not JSON, so use value directly
+  // Uses a scheduled summary table so the request path avoids json_each(backends).
   const backendCountsQuery = `
+    SELECT
+      backend_type,
+      tool_count as count
+    FROM backend_tool_summaries
+    ORDER BY tool_count DESC, backend_type ASC
+  `;
+
+  // Bootstrap fallback for databases that have not run the scheduled summary refresh yet.
+  // Note: json_each returns value as a plain string, not JSON, so use value directly.
+  const backendCountsFallbackQuery = `
     SELECT
       SUBSTR(value, 1, INSTR(value || ':', ':') - 1) as backend_type,
       COUNT(DISTINCT name) as count
@@ -296,14 +306,29 @@ export async function loadToolsPaginated(
     backendCountsResults = await analyticsDb
       .prepare(backendCountsQuery)
       .all<{ backend_type: string; count: number }>();
+    if ((backendCountsResults.results || []).length === 0) {
+      backendCountsResults = await analyticsDb
+        .prepare(backendCountsFallbackQuery)
+        .all<{ backend_type: string; count: number }>();
+    }
   } catch (e) {
-    console.error(
-      "Backend counts query failed:",
-      e,
-      "\nQuery:",
-      backendCountsQuery,
-    );
-    throw new Error(`Backend counts query failed: ${e}`);
+    try {
+      backendCountsResults = await analyticsDb
+        .prepare(backendCountsFallbackQuery)
+        .all<{ backend_type: string; count: number }>();
+    } catch (fallbackError) {
+      console.error(
+        "Backend counts query failed:",
+        e,
+        "\nQuery:",
+        backendCountsQuery,
+        "\nFallback query:",
+        backendCountsFallbackQuery,
+        "\nFallback error:",
+        fallbackError,
+      );
+      throw new Error(`Backend counts query failed: ${fallbackError}`);
+    }
   }
 
   const totalCount = countResult?.total ?? 0;

--- a/web/src/pages/api/admin/scheduled.ts
+++ b/web/src/pages/api/admin/scheduled.ts
@@ -101,6 +101,13 @@ export const POST: APIRoute = async ({ request, locals }) => {
       `Download summaries refreshed: ${summaries.toolSummaries} tools, ${summaries.platformSummaries} platform rows, ${summaries.versionSummaries} version rows`,
     );
 
+    const backendSummaries = await analytics.populateBackendToolSummaries(
+      env.ANALYTICS_DB,
+    );
+    console.log(
+      `Backend summaries refreshed: ${backendSummaries.backendSummaries} backend rows`,
+    );
+
     const trendingSummaries = await analytics.populateTrendingToolSummaries(
       env.ANALYTICS_DB,
     );
@@ -138,6 +145,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         daysUpdated: mauDaysUpdated,
       },
       summaries,
+      backendSummaries,
       trendingSummaries,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- add a backend_tool_summaries table for homepage filter-chip counts
- refresh backend counts during scheduled/admin rollups and backfills
- read backend counts from the summary table with a bootstrap fallback to the existing json_each query

## Test
- bunx tsc --noEmit
- npm run test
- npm run build -w web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new analytics summary table and scheduled refresh logic that the homepage relies on for backend filter counts; incorrect rollup or refresh timing could show stale/empty counts, mitigated by a runtime fallback query.
> 
> **Overview**
> Speeds up homepage/backend filter-chip counts by introducing a new `backend_tool_summaries` rollup table and reading counts from it (with an automatic fallback to the prior `json_each(backends)` query when the table is empty/unavailable).
> 
> Extends scheduled rollups/backfills (worker cron and admin `scheduled` API) to refresh this new summary table, and updates analytics migrations/seed SQL plus exports/schema to include it. Also refactors trending rollup computation to fetch candidate + daily data in one query and switches D1 inserts to `batch` statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e90966c0539af52eaa26d2fb479a3d64e04f93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->