### PR TITLE
Remove GitHub Pages deploy

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -13,8 +13,6 @@ concurrency:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 env:
   GITHUB_API_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,8 +10,6 @@ concurrency:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 env:
   GITHUB_API_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/tool-analysis.yml
+++ b/.github/workflows/tool-analysis.yml
@@ -10,8 +10,6 @@ concurrency:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 env:
   GITHUB_API_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,8 +16,6 @@ concurrency:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 env:
   GITHUB_API_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
@@ -70,19 +68,3 @@ jobs:
           else
             echo "No local commits to push"
           fi
-      - name: Upload static files as artifact
-        id: deployment
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-        with:
-          path: docs/
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: update
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 mise-versions is a service that tracks and stores version numbers for tools supported by [mise](https://mise.jdx.dev/). It consists of:
 
 1. **Version collection**: Shell scripts run via GitHub Actions (every 15 min) that fetch versions using `mise ls-remote` in Docker
-2. **Static hosting**: Plain text version files and TOML files (with timestamps) served via GitHub Pages at `mise.jdx.dev/<tool>`
+2. **Version data files**: Plain text version files and TOML files (with timestamps) committed under `docs/`
 3. **Web app**: Astro-based frontend deployed to Cloudflare Workers at `mise-tools.jdx.dev`
 4. **Analytics API**: Download tracking and statistics via Cloudflare D1 database
 
@@ -59,7 +59,7 @@ mise run deploy            # builds then deploys
    - Syncs directly to D1 via `/api/admin/metadata/sync`
 
 3. **Storage**:
-   - **GitHub Pages** (`docs/`): Plain text version files for `mise.jdx.dev/<tool>`
+   - **Git repository** (`docs/`): Plain text and TOML version files used as the source for sync jobs and raw GitHub-backed data endpoints
    - **Cloudflare R2** (`DATA_BUCKET`): Binary .gz files only (python-precompiled)
    - **Cloudflare D1** (`ANALYTICS_DB`): Tool metadata, version data, and download analytics
 


### PR DESCRIPTION
## Summary
- remove the GitHub Pages artifact upload/deploy job from the update workflow
- drop unused pages/id-token permissions from workflows that only push repo changes
- update CLAUDE/AGENTS guidance to describe docs/ as committed version data, not GitHub Pages hosting

## Test
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions configuration and documentation, primarily removing Pages deployment steps/permissions. Main risk is that anything still expecting `docs/` to be published via GitHub Pages will no longer update automatically.
> 
> **Overview**
> Stops deploying `docs/` to GitHub Pages by removing the Pages artifact upload and `deploy` job from the `update` workflow.
> 
> Drops `pages` and `id-token` permissions from multiple workflows (`aqua`, `python-precompiled`, `tool-analysis`, `update`) so they only request `contents: write`, and updates `CLAUDE.md` to describe `docs/` as committed version data rather than GitHub Pages hosting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45019cdf9df7017f54ff03c6b3f4a9541dafd7e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->