### PR TITLE
Remove trending tools fallback scan

### DIFF
--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -128,6 +128,152 @@ const analyticsMigrations: AnalyticsMigration[] = [
       `);
     },
   },
+  {
+    id: 3,
+    name: "populate_hot_ui_summaries",
+    async up(db) {
+      const LOOKBACK_DAYS = 30;
+      const SPARKLINE_DAYS = 13;
+      const MIN_DOWNLOADS = 500;
+      const now = Math.floor(Date.now() / 1000);
+      const thirtyDaysAgo = new Date((now - LOOKBACK_DAYS * 86400) * 1000)
+        .toISOString()
+        .split("T")[0];
+      const today = new Date(now * 1000).toISOString().split("T")[0];
+      const updatedAt = new Date().toISOString();
+      const lookupDates = Array.from(
+        { length: LOOKBACK_DAYS },
+        (_, index) =>
+          new Date((now - (index + 1) * 86400) * 1000)
+            .toISOString()
+            .split("T")[0],
+      );
+      const sparklineDates = lookupDates.slice(0, SPARKLINE_DAYS).reverse();
+
+      await db.run(sql`
+        INSERT OR REPLACE INTO backend_tool_summaries (
+          backend_type,
+          tool_count,
+          updated_at
+        )
+        SELECT
+          SUBSTR(value, 1, INSTR(value || ':', ':') - 1) AS backend_type,
+          COUNT(DISTINCT tools.id) AS tool_count,
+          ${updatedAt}
+        FROM tools, json_each(backends)
+        WHERE latest_version IS NOT NULL
+          AND backends IS NOT NULL
+        GROUP BY backend_type
+      `);
+
+      const backendRows = await db.get<{ count: number }>(sql`
+        SELECT COUNT(*) AS count
+        FROM backend_tool_summaries
+        WHERE updated_at = ${updatedAt}
+      `);
+      if ((backendRows?.count ?? 0) > 0) {
+        await db.run(sql`
+          DELETE FROM backend_tool_summaries
+          WHERE updated_at != ${updatedAt}
+        `);
+      }
+
+      const dailyData = await db.all<{
+        tool_id: number;
+        downloads_30d: number;
+        date: string;
+        downloads: number;
+      }>(sql`
+        WITH candidates AS (
+          SELECT
+            daily_tool_stats.tool_id,
+            SUM(daily_tool_stats.downloads) AS downloads_30d
+          FROM daily_tool_stats
+            INNER JOIN tools ON daily_tool_stats.tool_id = tools.id
+          WHERE
+            daily_tool_stats.date >= ${thirtyDaysAgo}
+            AND daily_tool_stats.date < ${today}
+            AND tools.latest_version IS NOT NULL
+          GROUP BY daily_tool_stats.tool_id
+          HAVING SUM(daily_tool_stats.downloads) >= ${MIN_DOWNLOADS}
+        )
+        SELECT
+          daily_tool_stats.tool_id,
+          candidates.downloads_30d,
+          daily_tool_stats.date,
+          daily_tool_stats.downloads
+        FROM daily_tool_stats
+          INNER JOIN candidates ON daily_tool_stats.tool_id = candidates.tool_id
+        WHERE
+          daily_tool_stats.date >= ${thirtyDaysAgo}
+          AND daily_tool_stats.date < ${today}
+        ORDER BY daily_tool_stats.date
+      `);
+
+      const toolData = new Map<
+        number,
+        { total: number; daily: Map<string, number> }
+      >();
+      for (const row of dailyData) {
+        if (!toolData.has(row.tool_id)) {
+          toolData.set(row.tool_id, {
+            total: row.downloads_30d,
+            daily: new Map(),
+          });
+        }
+        toolData.get(row.tool_id)!.daily.set(row.date, row.downloads);
+      }
+
+      let trendingRows = 0;
+      for (const [toolId, data] of toolData) {
+        const dailyValues = lookupDates.map(
+          (date) => data.daily.get(date) ?? 0,
+        );
+        const mean =
+          dailyValues.reduce((sum, value) => sum + value, 0) /
+          dailyValues.length;
+        const variance =
+          dailyValues.reduce((sum, value) => sum + (value - mean) ** 2, 0) /
+          dailyValues.length;
+        const stddev = Math.sqrt(variance);
+        if (stddev === 0) continue;
+
+        const recentAvg =
+          (dailyValues[0] + dailyValues[1] + dailyValues[2]) / 3;
+        const dailyBoost = (recentAvg - mean) / stddev;
+        const sparkline = sparklineDates.map(
+          (date) => data.daily.get(date) ?? 0,
+        );
+
+        await db.run(sql`
+          INSERT OR REPLACE INTO trending_tool_summaries (
+            tool_id,
+            downloads_30d,
+            daily_boost,
+            trending_score,
+            sparkline,
+            updated_at
+          )
+          VALUES (
+            ${toolId},
+            ${data.total},
+            ${dailyBoost},
+            ${dailyBoost},
+            ${JSON.stringify(sparkline)},
+            ${updatedAt}
+          )
+        `);
+        trendingRows++;
+      }
+
+      if (trendingRows > 0) {
+        await db.run(sql`
+          DELETE FROM trending_tool_summaries
+          WHERE updated_at != ${updatedAt}
+        `);
+      }
+    },
+  },
 ];
 
 async function runAnalyticsDataMigrations(db: AnalyticsDb): Promise<void> {

--- a/src/analytics/trends.ts
+++ b/src/analytics/trends.ts
@@ -495,157 +495,17 @@ export function createTrendsFunctions(db: ReturnType<typeof drizzle>) {
         LIMIT ${limit}
       `);
 
-      if (summaryRows.length > 0) {
-        return summaryRows.map((row) => ({
-          name: row.name,
-          downloads_30d: row.downloads_30d,
-          trendingScore: row.trending_score,
-          dailyBoost: row.daily_boost,
-          sparkline: JSON.parse(row.sparkline),
-          description: row.description || undefined,
-          backends: row.backends ? JSON.parse(row.backends) : undefined,
-          security: row.security ? JSON.parse(row.security) : undefined,
-          version_count: row.version_count || 0,
-        }));
-      }
-
-      const now = Math.floor(Date.now() / 1000);
-      const thirtyDaysAgo = new Date((now - 30 * 86400) * 1000)
-        .toISOString()
-        .split("T")[0];
-      const today = new Date(now * 1000).toISOString().split("T")[0];
-      const lookupDates = Array.from(
-        { length: 30 },
-        (_, index) =>
-          new Date((now - (index + 1) * 86400) * 1000)
-            .toISOString()
-            .split("T")[0],
-      );
-      const sparklineDates = lookupDates.slice(0, 13).reverse();
-
-      const dailyData = await db
-        .select({
-          tool_id: dailyToolStats.tool_id,
-          name: tools.name,
-          date: dailyToolStats.date,
-          downloads: dailyToolStats.downloads,
-        })
-        .from(dailyToolStats)
-        .innerJoin(tools, eq(dailyToolStats.tool_id, tools.id))
-        .where(
-          and(
-            sql`${dailyToolStats.date} >= ${thirtyDaysAgo}`,
-            sql`${dailyToolStats.date} < ${today}`,
-            sql`tools.latest_version IS NOT NULL`,
-          ),
-        )
-        .orderBy(dailyToolStats.date)
-        .all();
-
-      const toolData = new Map<
-        string,
-        { total: number; daily: Map<string, number> }
-      >();
-      for (const row of dailyData) {
-        if (!toolData.has(row.name)) {
-          toolData.set(row.name, { total: 0, daily: new Map() });
-        }
-        const data = toolData.get(row.name)!;
-        data.total += row.downloads;
-        data.daily.set(row.date, row.downloads);
-      }
-
-      if (toolData.size === 0) return [];
-
-      const results: Array<{
-        name: string;
-        downloads_30d: number;
-        trendingScore: number;
-        dailyBoost: number;
-        sparkline: number[];
-        description?: string;
-        backends?: string[];
-        security?: Array<{ type: string; algorithm?: string }>;
-        version_count: number;
-      }> = [];
-
-      for (const [name, data] of toolData) {
-        const sparkline = sparklineDates.map(
-          (date) => data.daily.get(date) ?? 0,
-        );
-
-        // Collect daily values for the 30-day window
-        const dailyValues = lookupDates.map(
-          (date) => data.daily.get(date) ?? 0,
-        );
-
-        // Compute mean and standard deviation over the full 30 days
-        const mean =
-          dailyValues.reduce((a, b) => a + b, 0) / dailyValues.length;
-        const variance =
-          dailyValues.reduce((sum, v) => sum + (v - mean) ** 2, 0) /
-          dailyValues.length;
-        const stddev = Math.sqrt(variance);
-
-        // Average of last 3 days
-        const recentAvg =
-          (dailyValues[0] + dailyValues[1] + dailyValues[2]) / 3;
-
-        // Z-score: how many standard deviations the recent average is above the mean
-        // Require minimum downloads to filter out noise from tiny tools
-        if (data.total < 500 || stddev === 0) continue;
-        const dailyBoost = (recentAvg - mean) / stddev;
-        const trendingScore = dailyBoost;
-
-        results.push({
-          name,
-          downloads_30d: data.total,
-          trendingScore,
-          dailyBoost,
-          sparkline,
-          version_count: 0,
-        });
-      }
-
-      results.sort((a, b) => b.trendingScore - a.trendingScore);
-      const topResults = results.slice(0, limit);
-
-      // Fetch metadata for trending tools (description, backends, security, version_count)
-      // These columns exist in the DB but aren't in the drizzle schema, so use raw SQL
-      if (topResults.length > 0) {
-        const names = topResults.map((t) => t.name);
-        const metaRows = await db.all<{
-          name: string;
-          description: string | null;
-          backends: string | null;
-          security: string | null;
-          version_count: number | null;
-        }>(sql`
-          SELECT name, description, backends, security, version_count
-          FROM tools
-          WHERE name IN (${sql.join(
-            names.map((n) => sql`${n}`),
-            sql`, `,
-          )})
-        `);
-
-        const metaMap = new Map(metaRows.map((r) => [r.name, r]));
-        for (const result of topResults) {
-          const meta = metaMap.get(result.name);
-          if (meta) {
-            result.description = meta.description || undefined;
-            result.backends = meta.backends
-              ? JSON.parse(meta.backends)
-              : undefined;
-            result.security = meta.security
-              ? JSON.parse(meta.security)
-              : undefined;
-            result.version_count = meta.version_count || 0;
-          }
-        }
-      }
-
-      return topResults;
+      return summaryRows.map((row) => ({
+        name: row.name,
+        downloads_30d: row.downloads_30d,
+        trendingScore: row.trending_score,
+        dailyBoost: row.daily_boost,
+        sparkline: JSON.parse(row.sparkline),
+        description: row.description || undefined,
+        backends: row.backends ? JSON.parse(row.backends) : undefined,
+        security: row.security ? JSON.parse(row.security) : undefined,
+        version_count: row.version_count || 0,
+      }));
     },
   };
 }


### PR DESCRIPTION
## Summary
- remove the getTrendingTools fallback that scanned 30 days of daily_tool_stats on homepage/OG requests
- return trending_tool_summaries rows only, so an empty summary table yields an empty trending list instead of an expensive request-time rebuild
- add a data migration to populate backend and trending UI summaries immediately after deploy

## Test
- bunx tsc --noEmit
- npm run test
- npm run build -w web
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes request-time recomputation of trending results, so incorrect/empty summary tables will now surface as empty UI output. Adds a data migration that bulk-populates `backend_tool_summaries` and `trending_tool_summaries`, which could be moderately expensive on large datasets during deploy.
> 
> **Overview**
> Stops `getTrendingTools` from falling back to a 30-day `daily_tool_stats` scan; it now returns only precomputed rows from `trending_tool_summaries` (empty table => empty trending list).
> 
> Adds analytics migration `populate_hot_ui_summaries` to backfill *hot-path* UI summary tables on deploy by computing `backend_tool_summaries` counts and rebuilding `trending_tool_summaries` (30-day window, min 500 downloads) with sparklines and z-score style `daily_boost`/`trending_score`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313ebf8e4b8fabc07b06e1654695f9a4d0e2132b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->