### PR TITLE
chore: remove GitHub Pages CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-mise-versions.jdx.dev

--- a/scripts/backfill-toml.sh
+++ b/scripts/backfill-toml.sh
@@ -18,8 +18,6 @@ for tool in docs/*; do
 
 	toolname=$(basename "$tool")
 
-	# Skip special files (CNAME, etc)
-	[[ "$toolname" == "CNAME" ]] && continue
 	[[ "$toolname" =~ ^[A-Z] ]] && continue # Skip uppercase files (likely special)
 
 	toml_file="docs/${toolname}.toml"


### PR DESCRIPTION
## Summary
Remove `docs/CNAME`, which was only used for GitHub Pages custom domain routing. The project is now deployed on Cloudflare Workers.

Also drop the explicit CNAME skip in `scripts/backfill-toml.sh`; filenames that start with an uppercase letter are still skipped, so this behavior is unchanged for any similar special files.

Made with [Cursor](https://cursor.com)