### PR TITLE
docs: fix stale Cloudflare Pages comments

### DIFF
--- a/web/build-pages.sh
+++ b/web/build-pages.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Build the Astro app for Cloudflare Workers (static client under web/dist/).
+# Build Astro in SSR mode (output: "server", @astrojs/cloudflare) for Workers:
+# a Worker script for server-side routes plus static client assets under web/dist/.
 
 set -e
 

--- a/web/build-pages.sh
+++ b/web/build-pages.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build script for Cloudflare Pages (Astro SSR)
+# Build the Astro app for Cloudflare Workers (static client under web/dist/).
 
 set -e
 

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -17,10 +17,10 @@ export function useAuth(): AuthState {
     async function checkAuth() {
       try {
         const response = await fetch("/auth/me");
-        // Check if response is JSON (Pages Functions return JSON, dev server returns HTML)
+        // Production Worker returns JSON; `astro dev` may serve HTML for this path
         const contentType = response.headers.get("content-type");
         if (!contentType?.includes("application/json")) {
-          // Not running with Pages Functions (local dev), assume not authenticated
+          // Local dev without full Worker routing — assume not authenticated
           setState({ authenticated: false, username: null, loading: false });
           return;
         }


### PR DESCRIPTION
## Summary

Comments still referred to **Cloudflare Pages** / **Pages Functions** after the app moved to **Cloudflare Workers** (see `c958ec31`).

## Changes

- `web/build-pages.sh`: header now describes building for Workers (`web/dist/` client bundle).
- `web/src/hooks/useAuth.ts`: clarify JSON vs HTML as Worker production vs `astro dev`, not Pages Functions.

No runtime behavior changes.

Made with [Cursor](https://cursor.com)