### PR TITLE
Make scheduled cron resilient; bound aggregateOldData

### DIFF
--- a/src/analytics/maintenance.ts
+++ b/src/analytics/maintenance.ts
@@ -1,101 +1,100 @@
 // Maintenance and data aggregation functions
 import type { drizzle } from "drizzle-orm/d1";
-import { sql, eq, and } from "drizzle-orm";
-import { tools, backends, downloads, downloadsDaily } from "./schema.js";
+import { sql } from "drizzle-orm";
+import { tools, backends, downloads } from "./schema.js";
+
+const AGGREGATE_DAYS_PER_RUN = 7;
 
 export function createMaintenanceFunctions(db: ReturnType<typeof drizzle>) {
   return {
-    // Aggregate old data (call this daily via cron)
-    // Aggregates data older than 90 days into daily summaries
+    // Aggregate old data (call this daily via cron). Aggregates data older
+    // than 90 days into daily summaries, processing up to N oldest days per
+    // invocation to stay under the Workers subrequest limit.
     async aggregateOldData(): Promise<{ aggregated: number; deleted: number }> {
       const ninetyDaysAgo = Math.floor(Date.now() / 1000) - 90 * 86400;
 
-      // Get data to aggregate (grouped by tool, backend, version, platform, date)
-      const toAggregate = await db
-        .select({
-          tool_id: downloads.tool_id,
-          backend_id: downloads.backend_id,
-          version: downloads.version,
-          platform_id: downloads.platform_id,
-          date: sql<string>`date(${downloads.created_at}, 'unixepoch')`,
-          count: sql<number>`count(*)`,
-          unique_ips: sql<number>`count(distinct ip_hash)`,
-        })
-        .from(downloads)
-        .where(sql`${downloads.created_at} < ${ninetyDaysAgo}`)
-        .groupBy(
-          downloads.tool_id,
-          downloads.backend_id,
-          downloads.version,
-          downloads.platform_id,
-          sql`date(${downloads.created_at}, 'unixepoch')`,
-        )
-        .all();
+      // Find the oldest distinct dates that still have raw rows. Each day is
+      // collapsed via bulk SQL, so the per-day cost is ~3 D1 queries.
+      const oldestDates = await db.all<{
+        d: string;
+        min_ts: number;
+        max_ts: number;
+      }>(sql`
+        SELECT
+          date(created_at, 'unixepoch') AS d,
+          MIN(created_at) AS min_ts,
+          MAX(created_at) AS max_ts
+        FROM downloads
+        WHERE created_at < ${ninetyDaysAgo}
+        GROUP BY d
+        ORDER BY d ASC
+        LIMIT ${AGGREGATE_DAYS_PER_RUN}
+      `);
 
-      if (toAggregate.length === 0) {
+      if (oldestDates.length === 0) {
         return { aggregated: 0, deleted: 0 };
       }
 
-      // Insert aggregated data
-      for (const row of toAggregate) {
-        // Check if aggregation already exists for this date
-        const existing = await db
-          .select()
-          .from(downloadsDaily)
-          .where(
-            and(
-              eq(downloadsDaily.tool_id, row.tool_id),
-              eq(downloadsDaily.version, row.version),
-              eq(downloadsDaily.date, row.date),
-              row.backend_id
-                ? eq(downloadsDaily.backend_id, row.backend_id)
-                : sql`${downloadsDaily.backend_id} IS NULL`,
-              row.platform_id
-                ? eq(downloadsDaily.platform_id, row.platform_id)
-                : sql`${downloadsDaily.platform_id} IS NULL`,
-            ),
-          )
-          .get();
+      let aggregated = 0;
+      let deleted = 0;
 
-        if (existing) {
-          // Update existing aggregation
-          await db
-            .update(downloadsDaily)
-            .set({
-              count: sql`${downloadsDaily.count} + ${row.count}`,
-              unique_ips: sql`${downloadsDaily.unique_ips} + ${row.unique_ips}`,
-            })
-            .where(eq(downloadsDaily.id, existing.id));
-        } else {
-          // Insert new aggregation
-          await db.insert(downloadsDaily).values({
-            tool_id: row.tool_id,
-            backend_id: row.backend_id,
-            version: row.version,
-            platform_id: row.platform_id,
-            date: row.date,
-            count: row.count,
-            unique_ips: row.unique_ips,
-          });
-        }
+      for (const { d: date, min_ts, max_ts } of oldestDates) {
+        // Use the timestamp range so the index on created_at is used. The
+        // upper bound is inclusive because max_ts is the largest existing
+        // timestamp on this date.
+        const dayEnd = max_ts + 1;
+
+        // Clear any partial aggregation from a previous failed run so the
+        // re-insert is idempotent.
+        await db.run(sql`
+          DELETE FROM downloads_daily WHERE date = ${date}
+        `);
+
+        const insertResult = await db.run(sql`
+          INSERT INTO downloads_daily
+            (tool_id, backend_id, version, platform_id, date, count, unique_ips)
+          SELECT
+            tool_id,
+            backend_id,
+            version,
+            platform_id,
+            ${date} AS date,
+            COUNT(*) AS count,
+            COUNT(DISTINCT ip_hash) AS unique_ips
+          FROM downloads
+          WHERE created_at >= ${min_ts} AND created_at < ${dayEnd}
+          GROUP BY tool_id, backend_id, version, platform_id
+        `);
+
+        const deleteResult = await db.run(sql`
+          DELETE FROM downloads
+          WHERE created_at >= ${min_ts} AND created_at < ${dayEnd}
+        `);
+
+        // drizzle's run() on D1 returns the underlying meta with rowsWritten
+        // for inserts and changes for deletes; tolerate either field name.
+        const insertedRows =
+          (
+            insertResult as unknown as {
+              meta?: { rows_written?: number; changes?: number };
+            }
+          ).meta?.rows_written ??
+          (insertResult as unknown as { meta?: { changes?: number } }).meta
+            ?.changes ??
+          0;
+        const deletedRows =
+          (deleteResult as unknown as { meta?: { changes?: number } }).meta
+            ?.changes ?? 0;
+
+        aggregated += insertedRows;
+        deleted += deletedRows;
+
+        console.log(
+          `aggregateOldData: ${date} → ${insertedRows} groups, ${deletedRows} raw rows deleted`,
+        );
       }
 
-      // Count rows to delete
-      const countToDelete = await db
-        .select({ count: sql<number>`count(*)` })
-        .from(downloads)
-        .where(sql`${downloads.created_at} < ${ninetyDaysAgo}`)
-        .get();
-
-      // Delete old raw data
-      await db
-        .delete(downloads)
-        .where(sql`${downloads.created_at} < ${ninetyDaysAgo}`);
-
-      return {
-        aggregated: toAggregate.length,
-        deleted: countToDelete?.count ?? 0,
-      };
+      return { aggregated, deleted };
     },
 
     // Backfill backend_id for existing records using default backends from registry

--- a/src/analytics/maintenance.ts
+++ b/src/analytics/maintenance.ts
@@ -1,7 +1,7 @@
 // Maintenance and data aggregation functions
 import type { drizzle } from "drizzle-orm/d1";
 import { sql } from "drizzle-orm";
-import { tools, backends, downloads } from "./schema.js";
+import { tools, backends, downloads, downloadsDaily } from "./schema.js";
 
 const AGGREGATE_DAYS_PER_RUN = 7;
 
@@ -12,9 +12,12 @@ export function createMaintenanceFunctions(db: ReturnType<typeof drizzle>) {
     // invocation to stay under the Workers subrequest limit.
     async aggregateOldData(): Promise<{ aggregated: number; deleted: number }> {
       const ninetyDaysAgo = Math.floor(Date.now() / 1000) - 90 * 86400;
+      // WHERE bounds the scan; HAVING ensures we only pick dates whose entire
+      // span has crossed the 90-day boundary. Without HAVING, a date that
+      // straddles the cutoff would be aggregated as a half-day and the next
+      // run's idempotent re-insert would wipe the previous slice.
+      const scanCutoff = ninetyDaysAgo + 86400;
 
-      // Find the oldest distinct dates that still have raw rows. Each day is
-      // collapsed via bulk SQL, so the per-day cost is ~3 D1 queries.
       const oldestDates = await db.all<{
         d: string;
         min_ts: number;
@@ -24,9 +27,10 @@ export function createMaintenanceFunctions(db: ReturnType<typeof drizzle>) {
           date(created_at, 'unixepoch') AS d,
           MIN(created_at) AS min_ts,
           MAX(created_at) AS max_ts
-        FROM downloads
-        WHERE created_at < ${ninetyDaysAgo}
+        FROM ${downloads}
+        WHERE created_at < ${scanCutoff}
         GROUP BY d
+        HAVING max_ts < ${ninetyDaysAgo}
         ORDER BY d ASC
         LIMIT ${AGGREGATE_DAYS_PER_RUN}
       `);
@@ -39,19 +43,17 @@ export function createMaintenanceFunctions(db: ReturnType<typeof drizzle>) {
       let deleted = 0;
 
       for (const { d: date, min_ts, max_ts } of oldestDates) {
-        // Use the timestamp range so the index on created_at is used. The
-        // upper bound is inclusive because max_ts is the largest existing
-        // timestamp on this date.
+        // dayEnd is exclusive; max_ts is the largest existing ts on this date.
         const dayEnd = max_ts + 1;
 
         // Clear any partial aggregation from a previous failed run so the
         // re-insert is idempotent.
         await db.run(sql`
-          DELETE FROM downloads_daily WHERE date = ${date}
+          DELETE FROM ${downloadsDaily} WHERE date = ${date}
         `);
 
         const insertResult = await db.run(sql`
-          INSERT INTO downloads_daily
+          INSERT INTO ${downloadsDaily}
             (tool_id, backend_id, version, platform_id, date, count, unique_ips)
           SELECT
             tool_id,
@@ -61,30 +63,18 @@ export function createMaintenanceFunctions(db: ReturnType<typeof drizzle>) {
             ${date} AS date,
             COUNT(*) AS count,
             COUNT(DISTINCT ip_hash) AS unique_ips
-          FROM downloads
+          FROM ${downloads}
           WHERE created_at >= ${min_ts} AND created_at < ${dayEnd}
           GROUP BY tool_id, backend_id, version, platform_id
         `);
 
         const deleteResult = await db.run(sql`
-          DELETE FROM downloads
+          DELETE FROM ${downloads}
           WHERE created_at >= ${min_ts} AND created_at < ${dayEnd}
         `);
 
-        // drizzle's run() on D1 returns the underlying meta with rowsWritten
-        // for inserts and changes for deletes; tolerate either field name.
-        const insertedRows =
-          (
-            insertResult as unknown as {
-              meta?: { rows_written?: number; changes?: number };
-            }
-          ).meta?.rows_written ??
-          (insertResult as unknown as { meta?: { changes?: number } }).meta
-            ?.changes ??
-          0;
-        const deletedRows =
-          (deleteResult as unknown as { meta?: { changes?: number } }).meta
-            ?.changes ?? 0;
+        const insertedRows = (insertResult as D1Result).meta?.changes ?? 0;
+        const deletedRows = (deleteResult as D1Result).meta?.changes ?? 0;
 
         aggregated += insertedRows;
         deleted += deletedRows;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -53,47 +53,15 @@ export async function scheduled(
   // Backfill the last 31 days of rollup + MAU tables. This makes the cron
   // self-healing: any day previously missed (e.g. while aggregateOldData was
   // throwing) gets refilled on the next successful run.
-  await runStep("rollup", async () => {
-    let ok = 0;
-    for (let i = 30; i >= 0; i--) {
-      const dateStr = dateStrAgo(now, i);
-      try {
-        await analytics.populateRollupTables(dateStr, env.ANALYTICS_DB);
-        ok++;
-      } catch (e) {
-        console.error(`populateRollupTables failed for ${dateStr}:`, e);
-      }
-    }
-    console.log(`Rollup tables refreshed for ${ok}/31 days`);
-  });
-
-  await runStep("version-stats", async () => {
-    let ok = 0;
-    for (let i = 30; i >= 0; i--) {
-      const dateStr = dateStrAgo(now, i);
-      try {
-        await analytics.populateVersionStatsRollup(dateStr, env.ANALYTICS_DB);
-        ok++;
-      } catch (e) {
-        console.error(`populateVersionStatsRollup failed for ${dateStr}:`, e);
-      }
-    }
-    console.log(`Version stats refreshed for ${ok}/31 days`);
-  });
-
-  await runStep("mau", async () => {
-    let ok = 0;
-    for (let i = 30; i >= 0; i--) {
-      const dateStr = dateStrAgo(now, i);
-      try {
-        await analytics.populateDailyMauStats(dateStr, env.ANALYTICS_DB);
-        ok++;
-      } catch (e) {
-        console.error(`populateDailyMauStats failed for ${dateStr}:`, e);
-      }
-    }
-    console.log(`MAU stats refreshed for ${ok}/31 days`);
-  });
+  await runDailyBackfill("rollup", now, "Rollup tables", (dateStr) =>
+    analytics.populateRollupTables(dateStr, env.ANALYTICS_DB),
+  );
+  await runDailyBackfill("version-stats", now, "Version stats", (dateStr) =>
+    analytics.populateVersionStatsRollup(dateStr, env.ANALYTICS_DB),
+  );
+  await runDailyBackfill("mau", now, "MAU stats", (dateStr) =>
+    analytics.populateDailyMauStats(dateStr, env.ANALYTICS_DB),
+  );
 
   await runStep("download-summaries", async () => {
     const s = await analytics.populateToolDownloadSummaries(env.ANALYTICS_DB);
@@ -115,6 +83,8 @@ export async function scheduled(
   console.log("Scheduled tasks finished");
 }
 
+const BACKFILL_DAYS = 31;
+
 function dateStrAgo(now: Date, daysAgo: number): string {
   const d = new Date(now);
   d.setUTCDate(d.getUTCDate() - daysAgo);
@@ -127,4 +97,25 @@ async function runStep(name: string, fn: () => Promise<void>): Promise<void> {
   } catch (e) {
     console.error(`Scheduled step '${name}' failed:`, e);
   }
+}
+
+async function runDailyBackfill(
+  name: string,
+  now: Date,
+  label: string,
+  fn: (dateStr: string) => Promise<unknown>,
+): Promise<void> {
+  await runStep(name, async () => {
+    let ok = 0;
+    for (let i = BACKFILL_DAYS - 1; i >= 0; i--) {
+      const dateStr = dateStrAgo(now, i);
+      try {
+        await fn(dateStr);
+        ok++;
+      } catch (e) {
+        console.error(`${name} failed for ${dateStr}:`, e);
+      }
+    }
+    console.log(`${label} refreshed for ${ok}/${BACKFILL_DAYS} days`);
+  });
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -28,106 +28,103 @@ export async function scheduled(
 ): Promise<void> {
   console.log("Running scheduled tasks via cron trigger...");
 
+  // Migrations are pre-requisites for everything else, so they run outside
+  // the per-step isolation below. If they fail, fail loud.
+  const db = drizzle(env.DB);
+  await runMigrations(db);
+
+  const analyticsDb = drizzle(env.ANALYTICS_DB);
+  await runAnalyticsMigrations(analyticsDb);
+
+  const analytics = setupAnalytics(analyticsDb);
+
+  const now = new Date();
+
+  // Run each section in isolation. aggregateOldData scans the full downloads
+  // table and has been blowing past D1 subrequest limits, which previously
+  // also took out the rollup steps that ran after it.
+  await runStep("aggregate", async () => {
+    const r = await analytics.aggregateOldData();
+    console.log(
+      `Aggregation: ${r.aggregated} groups aggregated, ${r.deleted} rows deleted`,
+    );
+  });
+
+  // Backfill the last 31 days of rollup + MAU tables. This makes the cron
+  // self-healing: any day previously missed (e.g. while aggregateOldData was
+  // throwing) gets refilled on the next successful run.
+  await runStep("rollup", async () => {
+    let ok = 0;
+    for (let i = 30; i >= 0; i--) {
+      const dateStr = dateStrAgo(now, i);
+      try {
+        await analytics.populateRollupTables(dateStr, env.ANALYTICS_DB);
+        ok++;
+      } catch (e) {
+        console.error(`populateRollupTables failed for ${dateStr}:`, e);
+      }
+    }
+    console.log(`Rollup tables refreshed for ${ok}/31 days`);
+  });
+
+  await runStep("version-stats", async () => {
+    let ok = 0;
+    for (let i = 30; i >= 0; i--) {
+      const dateStr = dateStrAgo(now, i);
+      try {
+        await analytics.populateVersionStatsRollup(dateStr, env.ANALYTICS_DB);
+        ok++;
+      } catch (e) {
+        console.error(`populateVersionStatsRollup failed for ${dateStr}:`, e);
+      }
+    }
+    console.log(`Version stats refreshed for ${ok}/31 days`);
+  });
+
+  await runStep("mau", async () => {
+    let ok = 0;
+    for (let i = 30; i >= 0; i--) {
+      const dateStr = dateStrAgo(now, i);
+      try {
+        await analytics.populateDailyMauStats(dateStr, env.ANALYTICS_DB);
+        ok++;
+      } catch (e) {
+        console.error(`populateDailyMauStats failed for ${dateStr}:`, e);
+      }
+    }
+    console.log(`MAU stats refreshed for ${ok}/31 days`);
+  });
+
+  await runStep("download-summaries", async () => {
+    const s = await analytics.populateToolDownloadSummaries(env.ANALYTICS_DB);
+    console.log(
+      `Download summaries: ${s.toolSummaries} tools, ${s.platformSummaries} platforms, ${s.versionSummaries} versions`,
+    );
+  });
+
+  await runStep("backend-summaries", async () => {
+    const s = await analytics.populateBackendToolSummaries(env.ANALYTICS_DB);
+    console.log(`Backend summaries: ${s.backendSummaries} rows`);
+  });
+
+  await runStep("trending-summaries", async () => {
+    const s = await analytics.populateTrendingToolSummaries(env.ANALYTICS_DB);
+    console.log(`Trending summaries: ${s.trendingSummaries} tools`);
+  });
+
+  console.log("Scheduled tasks finished");
+}
+
+function dateStrAgo(now: Date, daysAgo: number): string {
+  const d = new Date(now);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().split("T")[0];
+}
+
+async function runStep(name: string, fn: () => Promise<void>): Promise<void> {
   try {
-    // Run migrations first
-    const db = drizzle(env.DB);
-    await runMigrations(db);
-
-    const analyticsDb = drizzle(env.ANALYTICS_DB);
-    await runAnalyticsMigrations(analyticsDb);
-
-    const analytics = setupAnalytics(analyticsDb);
-
-    // 1. Aggregate old data (data older than 90 days)
-    const aggregateResult = await analytics.aggregateOldData();
-    console.log(
-      `Aggregation complete: ${aggregateResult.aggregated} groups aggregated, ${aggregateResult.deleted} rows deleted`,
-    );
-
-    // 2. Populate rollup tables for yesterday (and today so far)
-    const now = new Date();
-    const yesterday = new Date(now);
-    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-    const yesterdayStr = yesterday.toISOString().split("T")[0];
-    const todayStr = now.toISOString().split("T")[0];
-
-    // Populate yesterday's full data
-    const yesterdayResult = await analytics.populateRollupTables(
-      yesterdayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Rollup tables populated for ${yesterdayStr}: ${yesterdayResult.toolStats} tools, ${yesterdayResult.backendStats} backends`,
-    );
-
-    // Also update today's partial data
-    const todayResult = await analytics.populateRollupTables(
-      todayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Rollup tables updated for ${todayStr}: ${todayResult.toolStats} tools, ${todayResult.backendStats} backends`,
-    );
-
-    // 3. Populate version stats rollup for DAU/MAU
-    const yesterdayVersionStats = await analytics.populateVersionStatsRollup(
-      yesterdayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Version stats rollup for ${yesterdayStr}: ${yesterdayVersionStats ? "updated" : "no data"}`,
-    );
-
-    const todayVersionStats = await analytics.populateVersionStatsRollup(
-      todayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Version stats rollup for ${todayStr}: ${todayVersionStats ? "updated" : "no data"}`,
-    );
-
-    // 4. Populate daily MAU stats (trailing 30-day MAU for each date)
-    const yesterdayMauStats = await analytics.populateDailyMauStats(
-      yesterdayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `MAU stats for ${yesterdayStr}: ${yesterdayMauStats ? "updated" : "no data"}`,
-    );
-
-    const todayMauStats = await analytics.populateDailyMauStats(
-      todayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `MAU stats for ${todayStr}: ${todayMauStats ? "updated" : "no data"}`,
-    );
-
-    // 5. Refresh summary tables used by hot UI read paths
-    const summaries = await analytics.populateToolDownloadSummaries(
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Download summaries refreshed: ${summaries.toolSummaries} tools, ${summaries.platformSummaries} platform rows, ${summaries.versionSummaries} version rows`,
-    );
-
-    const backendSummaries = await analytics.populateBackendToolSummaries(
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Backend summaries refreshed: ${backendSummaries.backendSummaries} backend rows`,
-    );
-
-    const trendingSummaries = await analytics.populateTrendingToolSummaries(
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Trending summaries refreshed: ${trendingSummaries.trendingSummaries} tools`,
-    );
-
-    console.log("Scheduled tasks completed successfully");
-  } catch (error) {
-    console.error("Scheduled task error:", error);
-    throw error;
+    await fn();
+  } catch (e) {
+    console.error(`Scheduled step '${name}' failed:`, e);
   }
 }


### PR DESCRIPTION
## Summary
- The daily cron stopped populating rollup tables on 2026-05-01. Root cause: `aggregateOldData()` runs first inside one big try/catch, doing a SELECT-then-UPDATE/INSERT loop over 33,509 groups (~67k D1 subrequests) and blowing past D1's 1000-subrequest-per-invocation limit. The throw killed the rollup / MAU / version-stats steps that followed.
- `daily_mau_stats`, `daily_combined_stats`, and `daily_version_stats` last entry: 2026-04-30. Tracking endpoints (`version_requests`, `downloads`) still receiving fresh inserts as of today.

## Changes
- `src/worker.ts`: split `scheduled` into per-step `runStep()` blocks so a single step's failure doesn't cascade. Rollup, version-stats, and MAU each backfill the last 31 days, so the 2026-05-01..06 gap heals on the next successful cron run (or via `POST /api/admin/scheduled`).
- `src/analytics/maintenance.ts`: rewrite `aggregateOldData` to collapse each day with bulk `INSERT … SELECT … GROUP BY` + `DELETE` (3 D1 queries per day), capped at 7 oldest days per run. Drains the ~90-day backlog over multiple runs without exceeding subrequest limits.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `node --test scripts/*.test.js` (39/39 pass)
- [x] `bunx prettier --check`
- [x] `wrangler deploy --dry-run` produces a bundle exporting `scheduled` with the new `runStep` / 31-day backfill / 7-day aggregate logic
- [ ] Post-deploy: verify next cron run populates rollups for 2026-05-01..06 (or hit `/api/admin/scheduled` to trigger immediately); spot-check `daily_mau_stats` and the `/stats` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduled cron orchestration and historical download aggregation/deletion logic; mistakes could drop data or leave rollups stale, though changes are bounded and add idempotency/backfills.
> 
> **Overview**
> Improves cron reliability by running scheduled analytics tasks in isolated steps so a failure in one job (notably `aggregateOldData`) no longer prevents rollups/summaries from refreshing.
> 
> Reworks `aggregateOldData` to process and purge old `downloads` in bounded batches (up to 7 oldest fully-expired days per run) using bulk `INSERT … SELECT … GROUP BY` into `downloads_daily` plus per-day deletes, with idempotent re-runs.
> 
> Adds a 31-day backfill loop for rollups, version stats, and MAU so missed days are automatically recomputed on the next successful cron run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93189a29a27fb5b64e1d1acac2935e41b543df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->