### PR TITLE
Add cron health card + run-now button to admin page

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,6 @@ docs/
 # Lock files
 package-lock.json
 bun.lock
+
+# Astro components — prettier-plugin-astro is not installed
+*.astro

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -25,3 +25,22 @@ export async function requireAdminAuth(
 export function isAdmin(username: string | null): boolean {
   return username === ADMIN_USERNAME;
 }
+
+// Accept either a Bearer API_SECRET (for CLI/external callers) or an admin
+// session cookie (for the admin UI). Returns a Response on auth failure.
+export async function requireBearerOrAdmin(
+  request: Request,
+  apiSecret: string,
+): Promise<Response | { source: "bearer" | "cookie" }> {
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader === `Bearer ${apiSecret}`) {
+    return { source: "bearer" };
+  }
+
+  const auth = await getAuthCookie(request, apiSecret);
+  if (auth && isAdmin(auth.username)) {
+    return { source: "cookie" };
+  }
+
+  return errorResponse("Unauthorized", 401);
+}

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -26,6 +26,19 @@ export function isAdmin(username: string | null): boolean {
   return username === ADMIN_USERNAME;
 }
 
+// Constant-time string comparison to avoid leaking the secret's prefix
+// through response-time side channels. Returns false immediately on length
+// mismatch — that's acceptable here because the header format ("Bearer …")
+// fixes the length and an attacker already knows it.
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
 // Accept either a Bearer API_SECRET (for CLI/external callers) or an admin
 // session cookie (for the admin UI). Returns a Response on auth failure.
 export async function requireBearerOrAdmin(
@@ -33,14 +46,11 @@ export async function requireBearerOrAdmin(
   apiSecret: string,
 ): Promise<Response | { source: "bearer" | "cookie" }> {
   const authHeader = request.headers.get("Authorization");
-  if (authHeader === `Bearer ${apiSecret}`) {
+  if (apiSecret && authHeader && safeEqual(authHeader, `Bearer ${apiSecret}`)) {
     return { source: "bearer" };
   }
 
-  const auth = await getAuthCookie(request, apiSecret);
-  if (auth && isAdmin(auth.username)) {
-    return { source: "cookie" };
-  }
-
-  return errorResponse("Unauthorized", 401);
+  const adminAuth = await requireAdminAuth(request, apiSecret);
+  if (adminAuth instanceof Response) return adminAuth;
+  return { source: "cookie" };
 }

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -30,6 +30,33 @@ if (!auth || !isAdmin(auth.username)) {
       </button>
     </div>
 
+    <!-- Maintenance Card -->
+    <div class="bg-dark-800 border border-dark-600 rounded-lg overflow-hidden">
+      <div class="px-4 py-3 flex items-center justify-between gap-4">
+        <div class="flex items-center gap-6 min-w-0">
+          <h2 class="text-lg font-semibold text-gray-200 whitespace-nowrap">Maintenance</h2>
+          <div id="maintenance-inline-stats" class="flex items-center gap-4 text-sm flex-wrap min-w-0">
+            <span class="text-gray-500">Loading...</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-2 flex-shrink-0">
+          <button
+            id="run-scheduled-btn"
+            class="px-3 py-1.5 bg-neon-purple/20 hover:bg-neon-purple/30 border border-neon-purple/40 rounded-lg text-sm text-neon-purple hover:text-white transition-colors flex items-center gap-1"
+            title="Run the same maintenance pipeline as the daily cron"
+          >
+            <svg id="run-scheduled-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span id="run-scheduled-text">Run Scheduled Tasks</span>
+          </button>
+        </div>
+      </div>
+      <div id="run-scheduled-output" class="hidden border-t border-dark-600 px-4 py-3">
+        <pre id="run-scheduled-output-pre" class="text-xs text-gray-300 whitespace-pre-wrap break-words max-h-64 overflow-y-auto"></pre>
+      </div>
+    </div>
+
     <!-- D1 Table Counts Card -->
     <div class="bg-dark-800 border border-dark-600 rounded-lg overflow-hidden">
       <div class="px-4 py-3 flex items-center justify-between">
@@ -735,7 +762,12 @@ if (!auth || !isAdmin(auth.username)) {
         </svg>
       `;
     }
-    await Promise.all([loadAdminData(), loadAsdfPrimaryData(), loadTableCounts()]);
+    await Promise.all([
+      loadAdminData(),
+      loadAsdfPrimaryData(),
+      loadTableCounts(),
+      loadMaintenanceStatus(),
+    ]);
     if (btn) {
       btn.disabled = false;
       btn.innerHTML = `
@@ -746,11 +778,119 @@ if (!auth || !isAdmin(auth.username)) {
     }
   }
 
+  // Maintenance card
+  interface MaintenanceStatus {
+    cron_schedule: string;
+    rollups: Record<string, string | null>;
+    downloads: {
+      oldest_iso: string | null;
+      latest_iso: string | null;
+      rows_older_than_90d: number;
+    };
+  }
+
+  function fmtAge(iso: string | null): string {
+    if (!iso) return 'never';
+    const ms = Date.now() - new Date(iso).getTime();
+    if (ms < 0) return 'in the future';
+    const days = ms / 86400000;
+    if (days < 1) {
+      const hours = ms / 3600000;
+      return hours < 1 ? `${Math.round(ms / 60000)}m ago` : `${Math.round(hours)}h ago`;
+    }
+    return `${Math.round(days)}d ago`;
+  }
+
+  function maintenanceStatusClass(iso: string | null, staleAfterDays: number): string {
+    if (!iso) return 'text-red-400';
+    const days = (Date.now() - new Date(iso).getTime()) / 86400000;
+    if (days > staleAfterDays) return 'text-red-400';
+    if (days > staleAfterDays / 2) return 'text-orange-400';
+    return 'text-green-400';
+  }
+
+  async function loadMaintenanceStatus() {
+    const inline = document.getElementById('maintenance-inline-stats');
+    if (!inline) return;
+    try {
+      const res = await fetch('/api/admin/maintenance/status');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: MaintenanceStatus = await res.json();
+      const mauDate = data.rollups.daily_mau_stats;
+      const mauIso = mauDate ? `${mauDate}T00:00:00Z` : null;
+      const downloadsLatest = data.downloads.latest_iso;
+      const oldestIso = data.downloads.oldest_iso;
+      const oldestDays = oldestIso
+        ? Math.round((Date.now() - new Date(oldestIso).getTime()) / 86400000)
+        : null;
+      const backlog = data.downloads.rows_older_than_90d;
+      inline.innerHTML = `
+        <span title="Latest date in daily_mau_stats">
+          <span class="text-gray-500">MAU:</span>
+          <span class="${maintenanceStatusClass(mauIso, 2)}">${mauDate ?? '—'} (${fmtAge(mauIso)})</span>
+        </span>
+        <span class="text-gray-600">|</span>
+        <span title="Most recent download tracked">
+          <span class="text-gray-500">Last download:</span>
+          <span class="${maintenanceStatusClass(downloadsLatest, 1)}">${fmtAge(downloadsLatest)}</span>
+        </span>
+        <span class="text-gray-600">|</span>
+        <span title="Rows older than 90 days still in downloads (aggregate backlog)">
+          <span class="text-gray-500">Aggregate backlog:</span>
+          <span class="${backlog > 100000 ? 'text-red-400' : backlog > 10000 ? 'text-orange-400' : 'text-green-400'}">${backlog.toLocaleString()} rows${oldestDays !== null ? ` (oldest ${oldestDays}d)` : ''}</span>
+        </span>
+      `;
+    } catch (e) {
+      inline.innerHTML = '<span class="text-red-400">Failed to load</span>';
+      console.error('maintenance status:', e);
+    }
+  }
+
+  async function runScheduled() {
+    const btn = document.getElementById('run-scheduled-btn') as HTMLButtonElement;
+    const text = document.getElementById('run-scheduled-text');
+    const icon = document.getElementById('run-scheduled-icon');
+    const out = document.getElementById('run-scheduled-output');
+    const pre = document.getElementById('run-scheduled-output-pre');
+    if (!btn || !text || !icon || !out || !pre) return;
+    if (!confirm('Run the daily maintenance pipeline now? This may take 30+ seconds.')) {
+      return;
+    }
+    btn.disabled = true;
+    text.textContent = 'Running...';
+    icon.classList.add('animate-spin');
+    out.classList.add('hidden');
+    try {
+      const started = Date.now();
+      const res = await fetch('/api/admin/scheduled', { method: 'POST' });
+      const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+      const body = await res.text();
+      let formatted = body;
+      try {
+        formatted = JSON.stringify(JSON.parse(body), null, 2);
+      } catch {
+        // not JSON
+      }
+      pre.textContent = `HTTP ${res.status} in ${elapsed}s\n\n${formatted}`;
+      out.classList.remove('hidden');
+      // Refresh inline stats so the new "MAU last seen" is reflected
+      await loadMaintenanceStatus();
+    } catch (e) {
+      pre.textContent = `Error: ${e}`;
+      out.classList.remove('hidden');
+    } finally {
+      btn.disabled = false;
+      text.textContent = 'Run Scheduled Tasks';
+      icon.classList.remove('animate-spin');
+    }
+  }
+
   // Initialize
   // Load data
   loadAdminData();
   loadAsdfPrimaryData();
   loadTableCounts();
+  loadMaintenanceStatus();
 
   // Restore panel states from localStorage
   const savedState = loadPanelState();
@@ -765,4 +905,5 @@ if (!auth || !isAdmin(auth.username)) {
   document.getElementById('asdf-expand-btn')?.addEventListener('click', toggleAsdfExpanded);
   document.getElementById('table-counts-expand-btn')?.addEventListener('click', toggleTableCountsExpanded);
   document.getElementById('refresh-btn')?.addEventListener('click', refreshAll);
+  document.getElementById('run-scheduled-btn')?.addEventListener('click', runScheduled);
 </script>

--- a/web/src/pages/api/admin/maintenance/status.ts
+++ b/web/src/pages/api/admin/maintenance/status.ts
@@ -3,17 +3,14 @@ import { drizzle } from "drizzle-orm/d1";
 import { sql } from "drizzle-orm";
 import { env } from "cloudflare:workers";
 import { jsonResponse, errorResponse } from "../../../../lib/api";
-import { isAdmin } from "../../../../lib/admin";
-import { getAuthCookie } from "../../../../lib/auth";
+import { requireAdminAuth } from "../../../../lib/admin";
 
 // GET /api/admin/maintenance/status - Health snapshot for the daily cron.
 // Surfaces whether each rollup table is fresh and whether aggregateOldData
 // is keeping the downloads table within its 90-day retention window.
 export const GET: APIRoute = async ({ request }) => {
-  const auth = await getAuthCookie(request, env.API_SECRET);
-  if (!auth || !isAdmin(auth.username)) {
-    return errorResponse("Unauthorized", 401);
-  }
+  const auth = await requireAdminAuth(request, env.API_SECRET);
+  if (auth instanceof Response) return auth;
 
   try {
     const db = drizzle(env.ANALYTICS_DB);
@@ -63,6 +60,6 @@ export const GET: APIRoute = async ({ request }) => {
     });
   } catch (error) {
     console.error("Maintenance status error:", error);
-    return errorResponse(`Failed to fetch maintenance status: ${error}`, 500);
+    return errorResponse("Failed to fetch maintenance status", 500);
   }
 };

--- a/web/src/pages/api/admin/maintenance/status.ts
+++ b/web/src/pages/api/admin/maintenance/status.ts
@@ -1,0 +1,68 @@
+import type { APIRoute } from "astro";
+import { drizzle } from "drizzle-orm/d1";
+import { sql } from "drizzle-orm";
+import { env } from "cloudflare:workers";
+import { jsonResponse, errorResponse } from "../../../../lib/api";
+import { isAdmin } from "../../../../lib/admin";
+import { getAuthCookie } from "../../../../lib/auth";
+
+// GET /api/admin/maintenance/status - Health snapshot for the daily cron.
+// Surfaces whether each rollup table is fresh and whether aggregateOldData
+// is keeping the downloads table within its 90-day retention window.
+export const GET: APIRoute = async ({ request }) => {
+  const auth = await getAuthCookie(request, env.API_SECRET);
+  if (!auth || !isAdmin(auth.username)) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  try {
+    const db = drizzle(env.ANALYTICS_DB);
+    const ninetyDaysAgo = Math.floor(Date.now() / 1000) - 90 * 86400;
+
+    const [mau, combined, version, dailyTool, downloadsAge, oldDownloads] =
+      await Promise.all([
+        db.get<{ max_date: string | null }>(
+          sql`SELECT MAX(date) AS max_date FROM daily_mau_stats`,
+        ),
+        db.get<{ max_date: string | null }>(
+          sql`SELECT MAX(date) AS max_date FROM daily_combined_stats`,
+        ),
+        db.get<{ max_date: string | null }>(
+          sql`SELECT MAX(date) AS max_date FROM daily_version_stats`,
+        ),
+        db.get<{ max_date: string | null }>(
+          sql`SELECT MAX(date) AS max_date FROM daily_tool_stats`,
+        ),
+        db.get<{ min_ts: number | null; max_ts: number | null }>(
+          sql`SELECT MIN(created_at) AS min_ts, MAX(created_at) AS max_ts FROM downloads`,
+        ),
+        db.get<{ count: number }>(
+          sql`SELECT COUNT(*) AS count FROM downloads WHERE created_at < ${ninetyDaysAgo}`,
+        ),
+      ]);
+
+    return jsonResponse({
+      cron_schedule: "0 1 * * *",
+      rollups: {
+        daily_mau_stats: mau?.max_date ?? null,
+        daily_combined_stats: combined?.max_date ?? null,
+        daily_version_stats: version?.max_date ?? null,
+        daily_tool_stats: dailyTool?.max_date ?? null,
+      },
+      downloads: {
+        oldest_ts: downloadsAge?.min_ts ?? null,
+        oldest_iso: downloadsAge?.min_ts
+          ? new Date(downloadsAge.min_ts * 1000).toISOString()
+          : null,
+        latest_ts: downloadsAge?.max_ts ?? null,
+        latest_iso: downloadsAge?.max_ts
+          ? new Date(downloadsAge.max_ts * 1000).toISOString()
+          : null,
+        rows_older_than_90d: oldDownloads?.count ?? 0,
+      },
+    });
+  } catch (error) {
+    console.error("Maintenance status error:", error);
+    return errorResponse(`Failed to fetch maintenance status: ${error}`, 500);
+  }
+};

--- a/web/src/pages/api/admin/scheduled.ts
+++ b/web/src/pages/api/admin/scheduled.ts
@@ -7,17 +7,15 @@ import {
   setupAnalytics,
 } from "../../../../../src/analytics";
 import { jsonResponse, errorResponse } from "../../../lib/api";
+import { requireBearerOrAdmin } from "../../../lib/admin";
 
-// POST /api/admin/scheduled - Run scheduled tasks (called by cron)
-// This endpoint handles the daily aggregation tasks
+// POST /api/admin/scheduled - Run the same maintenance pipeline as the daily
+// cron. Accepts either Bearer API_SECRET (for external callers) or an admin
+// session cookie (for the admin UI button).
 export const POST: APIRoute = async ({ request, locals }) => {
   try {
-    // Verify admin secret
-    const authHeader = request.headers.get("Authorization");
-    const expectedAuth = `Bearer ${env.API_SECRET}`;
-    if (authHeader !== expectedAuth) {
-      return errorResponse("Unauthorized", 401);
-    }
+    const auth = await requireBearerOrAdmin(request, env.API_SECRET);
+    if (auth instanceof Response) return auth;
 
     console.log("Running scheduled tasks...");
 


### PR DESCRIPTION
## Summary
The MAU outage that #169 fixed was hard to spot because the admin page showed nothing about the daily cron's state. This adds a Maintenance card to `/admin` that surfaces freshness at a glance and lets an admin run the same pipeline the cron runs without needing the API_SECRET on disk.

Inline stats:
- **MAU**: latest date in `daily_mau_stats` + age (red if >2d, orange if >1d, green otherwise)
- **Last download**: most recent ingestion timestamp (so you can tell ingestion from rollups apart)
- **Aggregate backlog**: count of rows in `downloads` older than 90d, plus the oldest row's age (red if >100k rows)

Button:
- **Run Scheduled Tasks** → POST `/api/admin/scheduled`. Renders the JSON response inline (per-step success/error log).

## Changes
- `web/src/lib/admin.ts`: new `requireBearerOrAdmin()` accepting either Bearer `API_SECRET` (CLI/external) or admin session cookie (UI).
- `web/src/pages/api/admin/scheduled.ts`: use the dual-auth helper.
- `web/src/pages/api/admin/maintenance/status.ts`: GET endpoint returning rollup freshness + downloads age/backlog. Cookie auth only.
- `web/src/pages/admin.astro`: new Maintenance card.
- `.prettierignore`: ignore `*.astro` since `prettier-plugin-astro` isn't installed and the pre-commit hook errored on stage.

## Other crons
Audited per request:
- Only Cloudflare worker `mise-versions` has a cron trigger (`0 1 * * *`); the other workers in the account have no schedules.
- GitHub Actions schedules (`update`, `python-precompiled`, `tool-analysis`, `metadata`) are all green per `gh run list`.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `npm run build -w web` succeeds with the new endpoint + page
- [x] `node --test scripts/*.test.js` 39/39 pass
- [ ] Post-deploy: visit `/admin`, confirm Maintenance card loads stats; click Run Scheduled Tasks; verify JSON response and that MAU date refreshes to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new admin endpoints and expands auth for the scheduled maintenance trigger to allow cookie-based admin access, which could impact security and operational behavior if misconfigured. Also introduces new analytics DB queries and a long-running action callable from the UI.
> 
> **Overview**
> Adds a **Maintenance** section to `/admin` that fetches and displays cron/rollup freshness and downloads retention backlog, plus a *Run Scheduled Tasks* button that triggers the same maintenance pipeline as the daily cron and renders the response inline.
> 
> Introduces `GET /api/admin/maintenance/status` (cookie-admin only) for a health snapshot, and updates `POST /api/admin/scheduled` to accept either `Bearer API_SECRET` or an admin session via a new `requireBearerOrAdmin()` helper (with constant-time header comparison) in `web/src/lib/admin.ts`.
> 
> Updates tooling by ignoring `*.astro` in `.prettierignore` to avoid formatting failures without `prettier-plugin-astro`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b196e305620f355ed33f93dee9618136f3de648b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->