### PR TITLE
Bound MAU work per cron run; share pipeline with admin button

### DIFF
--- a/src/maintenance-pipeline.ts
+++ b/src/maintenance-pipeline.ts
@@ -76,13 +76,16 @@ export async function runMaintenancePipeline(
         await analytics.populateDailyMauStats(date, env.ANALYTICS_DB);
         ok++;
       } catch (e) {
-        failures.push(`${date}: ${(e as Error).message ?? e}`);
+        failures.push(`${date}: ${errMsg(e)}`);
         console.error(`populateDailyMauStats failed for ${date}:`, e);
       }
     }
-    return failures.length
-      ? `refreshed ${ok}/${targets.length} (failures: ${failures.join("; ")})`
-      : `refreshed ${ok}/${targets.length} (${targets.join(", ")})`;
+    if (failures.length) {
+      throw new Error(
+        `refreshed ${ok}/${targets.length} (failures: ${failures.join("; ")})`,
+      );
+    }
+    return `refreshed ${ok}/${targets.length} (${targets.join(", ")})`;
   });
 
   await runStep(steps, "download-summaries", async () => {
@@ -103,6 +106,11 @@ export async function runMaintenancePipeline(
   return { steps };
 }
 
+function errMsg(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
 async function runStep(
   out: StepResult[],
   name: string,
@@ -113,9 +121,8 @@ async function runStep(
     console.log(`[${name}] ok: ${detail}`);
     out.push({ name, ok: true, detail });
   } catch (e) {
-    const msg = (e as Error).message ?? String(e);
     console.error(`[${name}] failed:`, e);
-    out.push({ name, ok: false, error: msg });
+    out.push({ name, ok: false, error: errMsg(e) });
   }
 }
 
@@ -129,19 +136,22 @@ async function runDailyBackfill(
   await runStep(out, name, async () => {
     let ok = 0;
     const failures: string[] = [];
-    for (let i = days - 1; i >= 0; i--) {
+    // Process recent days first so today/yesterday land before any per-
+    // invocation limit kicks in. Older days are best-effort backfill.
+    for (let i = 0; i < days; i++) {
       const dateStr = dateStrAgo(now, i);
       try {
         await fn(dateStr);
         ok++;
       } catch (e) {
-        failures.push(`${dateStr}: ${(e as Error).message ?? e}`);
+        failures.push(`${dateStr}: ${errMsg(e)}`);
         console.error(`${name} failed for ${dateStr}:`, e);
       }
     }
-    return failures.length
-      ? `${ok}/${days} days (${failures.length} failures)`
-      : `${ok}/${days} days`;
+    if (failures.length) {
+      throw new Error(`${ok}/${days} days (${failures.length} failures)`);
+    }
+    return `${ok}/${days} days`;
   });
 }
 

--- a/src/maintenance-pipeline.ts
+++ b/src/maintenance-pipeline.ts
@@ -1,0 +1,184 @@
+// Shared maintenance pipeline run by both the daily cron (src/worker.ts)
+// and the admin "Run Scheduled Tasks" button (api/admin/scheduled.ts).
+//
+// Each step is isolated with per-step error capture so a single failure
+// (e.g. D1 overload during MAU computation) does not cascade. The MAU step
+// is intentionally bounded — a full 31-day recompute issues 31 × ~5M-row
+// UNION queries which overwhelm D1; we only refresh today + yesterday plus
+// a handful of oldest missing days, so the historical gap heals over
+// successive runs without overloading the database.
+
+import { drizzle } from "drizzle-orm/d1";
+import { sql } from "drizzle-orm";
+import { runMigrations } from "./migrations.js";
+import { runAnalyticsMigrations, setupAnalytics } from "./analytics/index.js";
+
+const ROLLUP_BACKFILL_DAYS = 31;
+const MAU_BACKFILL_GAP_LIMIT = 3;
+
+interface PipelineEnv {
+  DB: D1Database;
+  ANALYTICS_DB: D1Database;
+}
+
+export interface StepResult {
+  name: string;
+  ok: boolean;
+  detail?: unknown;
+  error?: string;
+}
+
+export interface PipelineResult {
+  steps: StepResult[];
+}
+
+export async function runMaintenancePipeline(
+  env: PipelineEnv,
+): Promise<PipelineResult> {
+  const db = drizzle(env.DB);
+  await runMigrations(db);
+
+  const analyticsDb = drizzle(env.ANALYTICS_DB);
+  await runAnalyticsMigrations(analyticsDb);
+
+  const analytics = setupAnalytics(analyticsDb);
+  const now = new Date();
+  const steps: StepResult[] = [];
+
+  await runStep(steps, "aggregate", async () => {
+    const r = await analytics.aggregateOldData();
+    return `${r.aggregated} groups aggregated, ${r.deleted} rows deleted`;
+  });
+
+  await runDailyBackfill(steps, "rollup", now, ROLLUP_BACKFILL_DAYS, (d) =>
+    analytics.populateRollupTables(d, env.ANALYTICS_DB),
+  );
+
+  await runDailyBackfill(
+    steps,
+    "version-stats",
+    now,
+    ROLLUP_BACKFILL_DAYS,
+    (d) => analytics.populateVersionStatsRollup(d, env.ANALYTICS_DB),
+  );
+
+  await runStep(steps, "mau", async () => {
+    const targets = await pickMauTargets(
+      analyticsDb,
+      now,
+      ROLLUP_BACKFILL_DAYS,
+      MAU_BACKFILL_GAP_LIMIT,
+    );
+    let ok = 0;
+    const failures: string[] = [];
+    for (const date of targets) {
+      try {
+        await analytics.populateDailyMauStats(date, env.ANALYTICS_DB);
+        ok++;
+      } catch (e) {
+        failures.push(`${date}: ${(e as Error).message ?? e}`);
+        console.error(`populateDailyMauStats failed for ${date}:`, e);
+      }
+    }
+    return failures.length
+      ? `refreshed ${ok}/${targets.length} (failures: ${failures.join("; ")})`
+      : `refreshed ${ok}/${targets.length} (${targets.join(", ")})`;
+  });
+
+  await runStep(steps, "download-summaries", async () => {
+    const s = await analytics.populateToolDownloadSummaries(env.ANALYTICS_DB);
+    return `${s.toolSummaries} tools, ${s.platformSummaries} platforms, ${s.versionSummaries} versions`;
+  });
+
+  await runStep(steps, "backend-summaries", async () => {
+    const s = await analytics.populateBackendToolSummaries(env.ANALYTICS_DB);
+    return `${s.backendSummaries} rows`;
+  });
+
+  await runStep(steps, "trending-summaries", async () => {
+    const s = await analytics.populateTrendingToolSummaries(env.ANALYTICS_DB);
+    return `${s.trendingSummaries} tools`;
+  });
+
+  return { steps };
+}
+
+async function runStep(
+  out: StepResult[],
+  name: string,
+  fn: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    const detail = await fn();
+    console.log(`[${name}] ok: ${detail}`);
+    out.push({ name, ok: true, detail });
+  } catch (e) {
+    const msg = (e as Error).message ?? String(e);
+    console.error(`[${name}] failed:`, e);
+    out.push({ name, ok: false, error: msg });
+  }
+}
+
+async function runDailyBackfill(
+  out: StepResult[],
+  name: string,
+  now: Date,
+  days: number,
+  fn: (dateStr: string) => Promise<unknown>,
+): Promise<void> {
+  await runStep(out, name, async () => {
+    let ok = 0;
+    const failures: string[] = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const dateStr = dateStrAgo(now, i);
+      try {
+        await fn(dateStr);
+        ok++;
+      } catch (e) {
+        failures.push(`${dateStr}: ${(e as Error).message ?? e}`);
+        console.error(`${name} failed for ${dateStr}:`, e);
+      }
+    }
+    return failures.length
+      ? `${ok}/${days} days (${failures.length} failures)`
+      : `${ok}/${days} days`;
+  });
+}
+
+function dateStrAgo(now: Date, daysAgo: number): string {
+  const d = new Date(now);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().split("T")[0];
+}
+
+// Pick the dates we need to (re)compute MAU for: today + yesterday always
+// (user-visible), then the oldest missing days in the lookback window. We
+// cap the total work to keep D1 below its overload threshold.
+async function pickMauTargets(
+  analyticsDb: ReturnType<typeof drizzle>,
+  now: Date,
+  lookbackDays: number,
+  gapBackfillLimit: number,
+): Promise<string[]> {
+  const today = dateStrAgo(now, 0);
+  const yesterday = dateStrAgo(now, 1);
+  const oldest = dateStrAgo(now, lookbackDays - 1);
+
+  const present = await analyticsDb.all<{ date: string }>(sql`
+    SELECT date
+    FROM daily_mau_stats
+    WHERE date >= ${oldest} AND date <= ${today}
+  `);
+  const have = new Set(present.map((r) => r.date));
+
+  const targets = new Set<string>([today, yesterday]);
+  let added = 0;
+  for (let i = lookbackDays - 1; i >= 2 && added < gapBackfillLimit; i--) {
+    const date = dateStrAgo(now, i);
+    if (!have.has(date) && !targets.has(date)) {
+      targets.add(date);
+      added++;
+    }
+  }
+  return [...targets].sort();
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,9 +1,7 @@
 // Custom worker wrapper that adds scheduled event handling to Astro's worker
 // This allows us to use Cloudflare cron triggers for daily rollup tasks
 
-import { drizzle } from "drizzle-orm/d1";
-import { runMigrations } from "./migrations.js";
-import { runAnalyticsMigrations, setupAnalytics } from "./analytics/index.js";
+import { runMaintenancePipeline } from "./maintenance-pipeline.js";
 // @ts-expect-error - generated Astro worker bundle has no type declarations
 import astroWorker from "../web/dist/server/entry.mjs";
 
@@ -27,95 +25,10 @@ export async function scheduled(
   _ctx: ExecutionContext,
 ): Promise<void> {
   console.log("Running scheduled tasks via cron trigger...");
-
-  // Migrations are pre-requisites for everything else, so they run outside
-  // the per-step isolation below. If they fail, fail loud.
-  const db = drizzle(env.DB);
-  await runMigrations(db);
-
-  const analyticsDb = drizzle(env.ANALYTICS_DB);
-  await runAnalyticsMigrations(analyticsDb);
-
-  const analytics = setupAnalytics(analyticsDb);
-
-  const now = new Date();
-
-  // Run each section in isolation. aggregateOldData scans the full downloads
-  // table and has been blowing past D1 subrequest limits, which previously
-  // also took out the rollup steps that ran after it.
-  await runStep("aggregate", async () => {
-    const r = await analytics.aggregateOldData();
-    console.log(
-      `Aggregation: ${r.aggregated} groups aggregated, ${r.deleted} rows deleted`,
-    );
-  });
-
-  // Backfill the last 31 days of rollup + MAU tables. This makes the cron
-  // self-healing: any day previously missed (e.g. while aggregateOldData was
-  // throwing) gets refilled on the next successful run.
-  await runDailyBackfill("rollup", now, "Rollup tables", (dateStr) =>
-    analytics.populateRollupTables(dateStr, env.ANALYTICS_DB),
+  const result = await runMaintenancePipeline(env);
+  const failed = result.steps.filter((s) => !s.ok).map((s) => s.name);
+  console.log(
+    `Scheduled tasks finished: ${result.steps.length - failed.length}/${result.steps.length} steps ok` +
+      (failed.length ? ` (failed: ${failed.join(", ")})` : ""),
   );
-  await runDailyBackfill("version-stats", now, "Version stats", (dateStr) =>
-    analytics.populateVersionStatsRollup(dateStr, env.ANALYTICS_DB),
-  );
-  await runDailyBackfill("mau", now, "MAU stats", (dateStr) =>
-    analytics.populateDailyMauStats(dateStr, env.ANALYTICS_DB),
-  );
-
-  await runStep("download-summaries", async () => {
-    const s = await analytics.populateToolDownloadSummaries(env.ANALYTICS_DB);
-    console.log(
-      `Download summaries: ${s.toolSummaries} tools, ${s.platformSummaries} platforms, ${s.versionSummaries} versions`,
-    );
-  });
-
-  await runStep("backend-summaries", async () => {
-    const s = await analytics.populateBackendToolSummaries(env.ANALYTICS_DB);
-    console.log(`Backend summaries: ${s.backendSummaries} rows`);
-  });
-
-  await runStep("trending-summaries", async () => {
-    const s = await analytics.populateTrendingToolSummaries(env.ANALYTICS_DB);
-    console.log(`Trending summaries: ${s.trendingSummaries} tools`);
-  });
-
-  console.log("Scheduled tasks finished");
-}
-
-const BACKFILL_DAYS = 31;
-
-function dateStrAgo(now: Date, daysAgo: number): string {
-  const d = new Date(now);
-  d.setUTCDate(d.getUTCDate() - daysAgo);
-  return d.toISOString().split("T")[0];
-}
-
-async function runStep(name: string, fn: () => Promise<void>): Promise<void> {
-  try {
-    await fn();
-  } catch (e) {
-    console.error(`Scheduled step '${name}' failed:`, e);
-  }
-}
-
-async function runDailyBackfill(
-  name: string,
-  now: Date,
-  label: string,
-  fn: (dateStr: string) => Promise<unknown>,
-): Promise<void> {
-  await runStep(name, async () => {
-    let ok = 0;
-    for (let i = BACKFILL_DAYS - 1; i >= 0; i--) {
-      const dateStr = dateStrAgo(now, i);
-      try {
-        await fn(dateStr);
-        ok++;
-      } catch (e) {
-        console.error(`${name} failed for ${dateStr}:`, e);
-      }
-    }
-    console.log(`${label} refreshed for ${ok}/${BACKFILL_DAYS} days`);
-  });
 }

--- a/web/src/pages/api/admin/scheduled.ts
+++ b/web/src/pages/api/admin/scheduled.ts
@@ -1,153 +1,27 @@
 import type { APIRoute } from "astro";
-import { drizzle } from "drizzle-orm/d1";
-import { runMigrations } from "../../../../../src/migrations";
 import { env } from "cloudflare:workers";
-import {
-  runAnalyticsMigrations,
-  setupAnalytics,
-} from "../../../../../src/analytics";
+import { runMaintenancePipeline } from "../../../../../src/maintenance-pipeline";
 import { jsonResponse, errorResponse } from "../../../lib/api";
 import { requireBearerOrAdmin } from "../../../lib/admin";
 
 // POST /api/admin/scheduled - Run the same maintenance pipeline as the daily
 // cron. Accepts either Bearer API_SECRET (for external callers) or an admin
 // session cookie (for the admin UI button).
-export const POST: APIRoute = async ({ request, locals }) => {
+export const POST: APIRoute = async ({ request }) => {
+  const auth = await requireBearerOrAdmin(request, env.API_SECRET);
+  if (auth instanceof Response) return auth;
+
   try {
-    const auth = await requireBearerOrAdmin(request, env.API_SECRET);
-    if (auth instanceof Response) return auth;
-
     console.log("Running scheduled tasks...");
-
-    // Run migrations first
-    const db = drizzle(env.DB);
-    await runMigrations(db);
-
-    const analyticsDb = drizzle(env.ANALYTICS_DB);
-    await runAnalyticsMigrations(analyticsDb);
-
-    const analytics = setupAnalytics(analyticsDb);
-
-    // 1. Aggregate old data (data older than 90 days)
-    const aggregateResult = await analytics.aggregateOldData();
-    console.log(
-      `Aggregation complete: ${aggregateResult.aggregated} groups aggregated, ${aggregateResult.deleted} rows deleted`,
-    );
-
-    // 2. Populate rollup tables for yesterday (and today so far)
-    const now = new Date();
-    const yesterday = new Date(now);
-    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
-    const yesterdayStr = yesterday.toISOString().split("T")[0];
-    const todayStr = now.toISOString().split("T")[0];
-
-    // Populate yesterday's full data
-    const yesterdayResult = await analytics.populateRollupTables(
-      yesterdayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Rollup tables populated for ${yesterdayStr}: ${yesterdayResult.toolStats} tools, ${yesterdayResult.backendStats} backends`,
-    );
-
-    // Also update today's partial data
-    const todayResult = await analytics.populateRollupTables(
-      todayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Rollup tables updated for ${todayStr}: ${todayResult.toolStats} tools, ${todayResult.backendStats} backends`,
-    );
-
-    // 3. Populate version stats rollup for DAU/MAU
-    const yesterdayVersionStats = await analytics.populateVersionStatsRollup(
-      yesterdayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Version stats rollup for ${yesterdayStr}: ${yesterdayVersionStats ? "updated" : "no data"}`,
-    );
-
-    const todayVersionStats = await analytics.populateVersionStatsRollup(
-      todayStr,
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Version stats rollup for ${todayStr}: ${todayVersionStats ? "updated" : "no data"}`,
-    );
-
-    // 4. Populate daily MAU stats (trailing 30-day MAU for each date)
-    // Recalculate the last 31 days to correct any stale/inflated values
-    let mauDaysUpdated = 0;
-    for (let i = 30; i >= 0; i--) {
-      const d = new Date(now);
-      d.setUTCDate(d.getUTCDate() - i);
-      const dateStr = d.toISOString().split("T")[0];
-      const result = await analytics.populateDailyMauStats(
-        dateStr,
-        env.ANALYTICS_DB,
-      );
-      if (result) mauDaysUpdated++;
-    }
-    console.log(`MAU stats recalculated for ${mauDaysUpdated} of 31 days`);
-
-    // 5. Refresh summary tables used by hot UI read paths
-    const summaries = await analytics.populateToolDownloadSummaries(
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Download summaries refreshed: ${summaries.toolSummaries} tools, ${summaries.platformSummaries} platform rows, ${summaries.versionSummaries} version rows`,
-    );
-
-    const backendSummaries = await analytics.populateBackendToolSummaries(
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Backend summaries refreshed: ${backendSummaries.backendSummaries} backend rows`,
-    );
-
-    const trendingSummaries = await analytics.populateTrendingToolSummaries(
-      env.ANALYTICS_DB,
-    );
-    console.log(
-      `Trending summaries refreshed: ${trendingSummaries.trendingSummaries} tools`,
-    );
-
+    const result = await runMaintenancePipeline(env);
+    const failed = result.steps.filter((s) => !s.ok);
     return jsonResponse({
-      success: true,
-      aggregation: {
-        aggregated: aggregateResult.aggregated,
-        deleted: aggregateResult.deleted,
-      },
-      rollups: {
-        yesterday: {
-          date: yesterdayStr,
-          toolStats: yesterdayResult.toolStats,
-          backendStats: yesterdayResult.backendStats,
-          toolBackendStats: yesterdayResult.toolBackendStats,
-          combinedStats: yesterdayResult.combinedStats,
-        },
-        today: {
-          date: todayStr,
-          toolStats: todayResult.toolStats,
-          backendStats: todayResult.backendStats,
-          toolBackendStats: todayResult.toolBackendStats,
-          combinedStats: todayResult.combinedStats,
-        },
-      },
-      versionStats: {
-        yesterday: yesterdayVersionStats,
-        today: todayVersionStats,
-      },
-      mauStats: {
-        daysUpdated: mauDaysUpdated,
-      },
-      summaries,
-      backendSummaries,
-      trendingSummaries,
+      success: failed.length === 0,
+      steps: result.steps,
+      failed_count: failed.length,
     });
   } catch (error) {
     console.error("Scheduled task error:", error);
-    return errorResponse(`Failed to run scheduled tasks: ${error}`, 500);
+    return errorResponse("Failed to run scheduled tasks", 500);
   }
 };


### PR DESCRIPTION
## Summary
The first admin **Run Scheduled Tasks** click after #170 deployed errored with:
> **HTTP 500 in 113.2s** — `D1_ERROR: D1 DB is overloaded. Requests queued for too long.`

Cause: the 31-day MAU recompute issues 31 × ~5M-row UNION queries in a single Worker invocation, which D1 throttles. Aggregate + same-day rollup/version-stats had landed (confirmed: `daily_tool_stats` got fresh 05-05/05-06, `downloads_daily` grew from 7.3k → 29k), but the MAU step + summary tables never ran.

## Changes
- **`src/maintenance-pipeline.ts`** *(new)* — single `runMaintenancePipeline()` that both cron handler and admin endpoint call. Per-step `runStep()` captures errors locally so a single step's failure no longer cascades or returns 500.
- **MAU step** — stop recomputing the full 31-day window every run. Always refresh today + yesterday (user-visible), then fill up to 3 oldest missing days. Total ≤ 5 MAU queries per invocation, well below D1's overload threshold. The current 6-day gap (2026-05-01..06) heals over ~2 cron runs.
- **`src/worker.ts`** — thin wrapper that calls the pipeline and logs a one-line summary.
- **`api/admin/scheduled.ts`** — thin wrapper. Returns 200 with `{ steps: [{name, ok, detail, error}, …], failed_count }` so the UI can show which steps succeeded even when one fails. No more 500s on partial success.

## Why a smaller MAU window is sustainable
Historical `daily_mau_stats` rows are stable — once correctly computed for date X, the value doesn't change retroactively. So in steady state we only need to refresh today + yesterday. The gap-filler exists only to heal the existing hole; it caps itself at 3 days/run so the budget stays bounded.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `npm run build -w web` succeeds
- [x] `node --test scripts/*.test.js` 39/39 pass
- [x] `wrangler deploy --dry-run` bundle includes `runMaintenancePipeline` and `pickMauTargets`
- [ ] Post-deploy: click Run Scheduled Tasks; confirm 200 response and step-by-step results
- [ ] After ~2 successful runs: confirm `daily_mau_stats` has rows for 2026-05-01..06
- [ ] `/stats` page MAU line extends to today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the scheduled maintenance/analytics refresh path and changes MAU recomputation behavior to reduce D1 load; mistakes could leave analytics tables partially stale even though the run reports success per-step.
> 
> **Overview**
> Introduces a shared `runMaintenancePipeline()` used by both the cron `scheduled` handler and the admin `POST /api/admin/scheduled`, with per-step isolation that records `{name, ok, detail/error}` instead of aborting the whole run.
> 
> Bounds MAU work per invocation: always recomputes today/yesterday, then backfills only a small number of oldest missing days in the lookback window, while keeping rollup/version-stats backfills at 31 days.
> 
> Simplifies outputs: the worker logs a single success/failure summary, and the admin endpoint now returns step-level results (and no longer returns detailed rollup/migration fields), with a generic 500 message on unexpected exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8357146dae4fadfb3523d57d5886266babf64d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->