### PR TITLE
Default Cache-Control to private, no-store via middleware

### DIFF
--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,15 @@
+import { defineMiddleware } from "astro:middleware";
+
+// Cacheability is a property of the response, not the URL path. Each route
+// is responsible for setting an explicit Cache-Control header. If a route
+// forgets, default to `private, no-store` so the failure mode is "not cached"
+// (cost/perf hit) rather than "cached" (data leak). Combined with the
+// mise-versions edge cache rule's `respect_origin` mode, this means routes
+// must opt-in to caching by setting a public Cache-Control header.
+export const onRequest = defineMiddleware(async (_context, next) => {
+  const response = await next();
+  if (!response.headers.has("Cache-Control")) {
+    response.headers.set("Cache-Control", "private, no-store");
+  }
+  return response;
+});


### PR DESCRIPTION
## Summary

Adds an Astro middleware that sets `Cache-Control: private, no-store` on any response that didn't set Cache-Control itself. This was originally part of #175 but missed the squash because the PR's head SHA was webhook-delayed at merge time.

Combined with the [endevco/cloudflare-infra#3](https://github.com/endevco/cloudflare-infra/pull/3) cache rule (`respect_origin`), it makes caching opt-in per route: forgetting to set Cache-Control on a new admin/auth/private endpoint fails closed (not cached) instead of inheriting an aggressive edge cache.

## Why

The cloudflare-infra PR enables a broad `cache = true` rule on `mise-versions.jdx.dev`. Routes that already set `Cache-Control: public, max-age=...` (TOML files, `/api/tools`, `/api/downloads`, `/api/stats`, `/api/og`, marketing HTML) get cached — that's the cost win. Routes that don't set anything would inherit Cloudflare's default cache behavior, which is unsafe for admin/auth content.

This middleware ensures every response leaves the worker with an explicit `Cache-Control` directive. Routes that already set one are unchanged. Routes that don't get `private, no-store` — explicit "don't cache" that both Cloudflare's edge and downstream browsers/proxies will honor.

## What changes

- New file: `web/src/middleware.ts` (15 lines)
- All other routes are unaffected — the middleware only sets the header when one isn't already present

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx prettier --check` — clean
- [ ] After deploy: `curl -I https://mise-versions.jdx.dev/admin` → `Cache-Control: private, no-store`
- [ ] After deploy: `curl -I https://mise-versions.jdx.dev/node.toml` → `Cache-Control: public, max-age=600` (unchanged from current)
- [ ] After deploy: `curl -I https://mise-versions.jdx.dev/api/admin/check` → `Cache-Control: private, no-store`
- [ ] Then merge [endevco/cloudflare-infra#3](https://github.com/endevco/cloudflare-infra/pull/3) to enable the edge cache rule

## Related

- #175 — original PR (squash didn't include this commit due to webhook lag)
- [endevco/cloudflare-infra#3](https://github.com/endevco/cloudflare-infra/pull/3) — depends on this landing first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Applies to every response in the Astro app and can change caching/performance characteristics for any route that previously omitted `Cache-Control`, though it fails closed to reduce accidental caching of private data.
> 
> **Overview**
> Adds an Astro `onRequest` middleware that ensures every response includes an explicit `Cache-Control` header.
> 
> If a route doesn’t set one, the middleware defaults it to `private, no-store`, making caching opt-in per route while leaving existing explicit cache headers unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 321757ebe7ff1614dfc6f50f1a31ae4e763328b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->