### PR TITLE
Use D1 unique index for download dedup; drop DOWNLOAD_DEDUPE roundtrip

### DIFF
--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -294,6 +294,29 @@ const analyticsMigrations: AnalyticsMigration[] = [
       `);
     },
   },
+  {
+    id: 5,
+    name: "downloads_day_unique_index",
+    async up(db) {
+      const cols = await db.all<{ name: string }>(
+        sql`PRAGMA table_info(downloads)`,
+      );
+      const hasDay = (cols as { name: string }[]).some((c) => c.name === "day");
+      if (!hasDay) {
+        await db.run(sql`ALTER TABLE downloads ADD COLUMN day INTEGER`);
+      }
+      // Mirrors the version_requests dedup index: old rows keep day=NULL,
+      // new tracking writes set day and are deduped via INSERT OR IGNORE.
+      // Matches the prior KV dedup key (tool, version, ip_hash, day) — backend
+      // and platform are intentionally excluded so the same user downloading
+      // for multiple platforms in a day still counts as one download, the
+      // same behavior as the KV dedup it replaces.
+      await db.run(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_downloads_unique_tool_version_ip_day
+        ON downloads(tool_id, version, ip_hash, day)
+      `);
+    },
+  },
 ];
 
 async function runAnalyticsDataMigrations(db: AnalyticsDb): Promise<void> {
@@ -435,6 +458,7 @@ export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
         platform_id INTEGER,
         ip_hash TEXT NOT NULL,
         created_at INTEGER NOT NULL,
+        day INTEGER,
         FOREIGN KEY (tool_id) REFERENCES tools(id),
         FOREIGN KEY (backend_id) REFERENCES backends(id),
         FOREIGN KEY (platform_id) REFERENCES platforms(id)

--- a/src/analytics/schema.ts
+++ b/src/analytics/schema.ts
@@ -20,7 +20,9 @@ export const platforms = sqliteTable("platforms", {
   arch: text("arch"),
 });
 
-// Downloads table with foreign keys and integer timestamp
+// Downloads table with foreign keys and integer timestamp.
+// `day` is the UTC day-bucket (created_at / 86400) and pairs with the
+// UNIQUE(tool_id, version, ip_hash, day) index to dedupe via INSERT OR IGNORE.
 export const downloads = sqliteTable("downloads", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   tool_id: integer("tool_id").notNull(),
@@ -29,6 +31,7 @@ export const downloads = sqliteTable("downloads", {
   platform_id: integer("platform_id"),
   ip_hash: text("ip_hash").notNull(),
   created_at: integer("created_at").notNull(), // Unix timestamp
+  day: integer("day"),
 });
 
 // Daily aggregated data for historical stats (data older than 90 days)

--- a/src/analytics/tracking.ts
+++ b/src/analytics/tracking.ts
@@ -1,7 +1,7 @@
 // Tracking functions for downloads and version requests
 import type { drizzle } from "drizzle-orm/d1";
 import { sql, eq, and } from "drizzle-orm";
-import { tools, backends, platforms, downloads } from "./schema.js";
+import { tools, backends, platforms } from "./schema.js";
 import { keyPart } from "../../web/src/lib/kv-cache.js";
 
 // Caches for ID lookups (shared within the tracking module)
@@ -209,7 +209,9 @@ export function createTrackingFunctions(
       return { deduplicated: changes === 0 };
     },
 
-    // Track a download with daily deduplication per IP/tool/version
+    // Track a download with daily deduplication per IP/tool/version.
+    // Relies on the UNIQUE(tool_id, version, ip_hash, day) index on downloads;
+    // INSERT OR IGNORE returns changes=0 when the row already exists for today.
     async trackDownload(
       tool: string,
       version: string,
@@ -222,18 +224,17 @@ export function createTrackingFunctions(
       const backendId = await getOrCreateBackendId(full);
       const platformId = await getOrCreatePlatformId(os, arch);
       const now = Math.floor(Date.now() / 1000);
+      const day = Math.floor(now / 86400);
 
-      // Insert new record
-      await db.insert(downloads).values({
-        tool_id: toolId,
-        backend_id: backendId,
-        version,
-        platform_id: platformId,
-        ip_hash: ipHash,
-        created_at: now,
-      });
+      const result = (await db.run(sql`
+        INSERT OR IGNORE INTO downloads
+          (tool_id, backend_id, version, platform_id, ip_hash, created_at, day)
+        VALUES
+          (${toolId}, ${backendId}, ${version}, ${platformId}, ${ipHash}, ${now}, ${day})
+      `)) as { meta?: { changes?: number } };
 
-      return { deduplicated: false };
+      const changes = result.meta?.changes ?? 0;
+      return { deduplicated: changes === 0 };
     },
   };
 }

--- a/web/src/pages/api/track.ts
+++ b/web/src/pages/api/track.ts
@@ -3,18 +3,6 @@ import { drizzle } from "drizzle-orm/d1";
 import { setupAnalytics } from "../../../../src/analytics";
 import { hashIP, getClientIP } from "../../lib/hash";
 import { env } from "cloudflare:workers";
-import { keyPart } from "../../lib/kv-cache";
-
-const DOWNLOAD_DEDUPE_TTL_SECONDS = 2 * 24 * 60 * 60;
-
-function downloadDedupeKey(
-  tool: string,
-  version: string,
-  ipHash: string,
-): string {
-  const day = Math.floor(Date.now() / 86400000);
-  return `download-dedupe:${day}:${keyPart(tool)}:${keyPart(version)}:${ipHash}`;
-}
 
 export const POST: APIRoute = async ({ request }) => {
   return trackDownloadRequest({ request });
@@ -71,25 +59,6 @@ export async function trackDownloadRequest({
     const db = drizzle(env.ANALYTICS_DB);
     const analytics = setupAnalytics(db, {
       trackingCache: env.DOWNLOAD_DEDUPE,
-    });
-    const dedupeKey = downloadDedupeKey(tool, body.version, ipHash);
-
-    const seen = await env.DOWNLOAD_DEDUPE.get(dedupeKey);
-    if (seen) {
-      return new Response(
-        JSON.stringify({
-          success: true,
-          deduplicated: true,
-        }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    }
-
-    await env.DOWNLOAD_DEDUPE.put(dedupeKey, "1", {
-      expirationTtl: DOWNLOAD_DEDUPE_TTL_SECONDS,
     });
 
     const result = await analytics.trackDownload(


### PR DESCRIPTION
## Summary

Mirrors the version_requests change in #175 for the downloads tracking path. Adds a `UNIQUE(tool_id, version, ip_hash, day)` index on `downloads` and replaces the KV get/put dedup wrapper in `/api/track` with a single `INSERT OR IGNORE` in `trackDownload`.

## Why

Post-#175, the `DOWNLOAD_DEDUPE` namespace still does ~8K writes/hour + ~57K reads/hour from this download tracking path. That's the bulk of the remaining KV ops cost. Same pattern that #175 fixed for `version_requests`, applied here.

**Projected savings:** ~$30/mo KV writes + ~$15/mo KV reads, plus ~2 subrequests per tracked download.

## Behavior parity

The new unique index keys on `(tool_id, version, ip_hash, day)` — same fields the prior KV dedup keyed on (`download-dedupe:${day}:${tool}:${version}:${ipHash}`). Backend and platform are intentionally excluded so a single user downloading for multiple platforms in a day still counts as one tracked download — identical behavior to before.

## Migration

Migration #5 (`downloads_day_unique_index`) runs on next deploy:

1. `ALTER TABLE downloads ADD COLUMN day INTEGER` (guarded by `PRAGMA table_info`)
2. `CREATE UNIQUE INDEX IF NOT EXISTS idx_downloads_unique_tool_version_ip_day ON downloads(tool_id, version, ip_hash, day)`

Old rows keep `day=NULL`. SQLite treats NULLs as distinct in unique indexes, so the index only enforces uniqueness on rows tracked after the cutover. No bulk dedup of historical data needed.

## What's left in DOWNLOAD_DEDUPE

After this lands, `DOWNLOAD_DEDUPE` still gets used by:
- `getCachedVersionRows` / `putCachedVersionRows` — TOML version-row response cache
- `getCachedText` / `putCachedText` — full TOML text cache

Those are legitimate caches (not dedup), so they stay. They're also where most of the remaining ~57K reads/hour come from — but those KV reads are cheaper than the D1 reads they save.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx prettier --check` — clean
- [x] `bun run test:js` — 38/39 (one pre-existing web build CSS asset failure)
- [ ] After deploy: watch DOWNLOAD_DEDUPE write rate drop within ~1h
- [ ] Verify `POST /api/track` still returns `{success: true, deduplicated: true|false}` correctly for repeated tool/version/IP combos

## Related

- #175 — same pattern applied to version_requests (merged)
- #176 — Cache-Control middleware (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes download tracking deduplication from KV-based get/put to a database-enforced unique index plus `INSERT OR IGNORE`, which impacts analytics write behavior and requires a schema migration on existing installs.
> 
> **Overview**
> **Download tracking now deduplicates in D1 instead of KV.** A new migration adds a nullable `day` column to `downloads` and creates `UNIQUE(tool_id, version, ip_hash, day)` so daily duplicates are ignored at insert time.
> 
> `trackDownload` is updated to compute `day` and use a single `INSERT OR IGNORE` (returning `deduplicated` based on `changes`), and the `/api/track` handler drops the KV dedupe key read/write wrapper while preserving the same response shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ac29e087d72c9d70d4a63b6d76404b5b406e08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->