### PR TITLE
feat: add edge cache for GitHub mirror

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -44,7 +44,10 @@ export function cachedJsonResponse(
 export function errorResponse(message: string, status = 400) {
   return new Response(message, {
     status,
-    headers: CORS_HEADERS,
+    headers: {
+      ...CORS_HEADERS,
+      "Cache-Control": "private, no-store",
+    },
   });
 }
 

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -5,6 +5,9 @@ const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
 const RELEASE_FRESH_MS = 6 * 60 * 60 * 1000;
 const RELEASE_IMMUTABLE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 const NEGATIVE_ATTESTATION_FRESH_MS = 30 * 60 * 1000;
+const EDGE_SHORT_TTL_SECONDS = 10 * 60;
+const EDGE_NEGATIVE_ATTESTATION_TTL_SECONDS = 30 * 60;
+const EDGE_IMMUTABLE_TTL_SECONDS = 365 * 24 * 60 * 60;
 
 interface CacheEntry<T> {
   cached_at: number;
@@ -46,10 +49,46 @@ interface TokenRecord {
   token: string;
 }
 
-export function cacheHeaders(maxAge = 600): Record<string, string> {
+export function cacheHeaders({
+  browserMaxAge = 600,
+  edgeMaxAge = EDGE_SHORT_TTL_SECONDS,
+  immutable = false,
+}: {
+  browserMaxAge?: number;
+  edgeMaxAge?: number;
+  immutable?: boolean;
+} = {}): Record<string, string> {
+  const directives = [
+    `public`,
+    `max-age=${browserMaxAge}`,
+    `s-maxage=${edgeMaxAge}`,
+  ];
+  if (immutable) {
+    directives.push("immutable");
+  } else {
+    directives.push("stale-while-revalidate=86400");
+  }
   return {
-    "Cache-Control": `public, max-age=${maxAge}, stale-while-revalidate=86400`,
+    "Cache-Control": directives.join(", "),
   };
+}
+
+export function releaseCacheHeaders(tag: string, release: GitHubRelease) {
+  const immutable = tag !== "latest" && release.immutable === true;
+  return cacheHeaders({
+    edgeMaxAge: immutable ? EDGE_IMMUTABLE_TTL_SECONDS : EDGE_SHORT_TTL_SECONDS,
+    immutable,
+  });
+}
+
+export function attestationsCacheHeaders(response: GitHubAttestationsResponse) {
+  const positive = response.attestations.length > 0;
+  return cacheHeaders({
+    edgeMaxAge: positive
+      ? EDGE_IMMUTABLE_TTL_SECONDS
+      : EDGE_NEGATIVE_ATTESTATION_TTL_SECONDS,
+    immutable: positive,
+  });
 }
 
 export function validRepoPart(value: string | undefined): value is string {
@@ -299,7 +338,7 @@ async function githubJson<T>(
   if (token) {
     headers.Authorization = `Bearer ${token.token}`;
   }
-  const response = await fetch(url, { headers, redirect: "error" });
+  const response = await fetch(url, { headers, redirect: "manual" });
   if (response.status === 404) {
     throw new GitHubError(404, "Not found", response.headers);
   }

--- a/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { errorResponse, jsonResponse } from "../../../../../../../lib/api";
 import {
-  cacheHeaders,
+  attestationsCacheHeaders,
   getCachedGitHubAttestations,
   githubStatus,
   validDigest,
@@ -22,7 +22,11 @@ export const GET: APIRoute = async ({ params }) => {
       repo,
       digest,
     );
-    return jsonResponse(attestations, 200, cacheHeaders());
+    return jsonResponse(
+      attestations,
+      200,
+      attestationsCacheHeaders(attestations),
+    );
   } catch (error) {
     console.error(
       `GitHub attestation mirror failed for ${owner}/${repo}@${digest}:`,

--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -2,9 +2,9 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { errorResponse, jsonResponse } from "../../../../../../../lib/api";
 import {
-  cacheHeaders,
   getCachedGitHubRelease,
   githubStatus,
+  releaseCacheHeaders,
   validReleaseTag,
   validRepoPart,
 } from "../../../../../../../lib/github/mirror";
@@ -17,7 +17,7 @@ export const GET: APIRoute = async ({ params }) => {
 
   try {
     const release = await getCachedGitHubRelease(env, owner, repo, tag);
-    return jsonResponse(release, 200, cacheHeaders());
+    return jsonResponse(release, 200, releaseCacheHeaders(tag, release));
   } catch (error) {
     console.error(
       `GitHub release mirror failed for ${owner}/${repo}@${tag}:`,


### PR DESCRIPTION
## Summary
- set CDN-friendly Cache-Control headers on GitHub release and attestation mirror endpoints
- use long s-maxage plus immutable for immutable tagged releases and positive attestation responses
- keep latest releases and negative attestation responses on shorter edge TTLs
- switch GitHub fetches to redirect: manual, which Cloudflare Workers supports, while still avoiding implicit redirects
- leave error responses private/no-store so GitHub/API failures are not cached

## Verification
- cd web && npm run build
- npm run test:js

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caching policy affects how quickly clients see updated releases or new attestations; mis-tuned immutable/negative TTLs could serve stale mirror data at the CDN.
> 
> **Overview**
> Adds **CDN-friendly `Cache-Control`** on the GitHub release and attestation mirror APIs, with **`s-maxage`** and optional **`immutable`** for long-lived edge caching when responses are stable.
> 
> **Release** responses use a **short edge TTL** for `latest` and non-immutable tags; **immutable tagged releases** get a **one-year `s-maxage`** plus `immutable`. **Attestation** responses use a **long edge cache** when attestations exist, and a **shorter edge TTL** for empty (negative) results.
> 
> **Error** responses from `errorResponse` now send **`private, no-store`** so failures are not cached at the edge. Upstream GitHub `fetch` uses **`redirect: manual`** instead of `error`, matching Workers behavior while avoiding implicit redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4f455f77ed923145f2c79a4230f9f049fa3ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->