### PR TITLE
fix: handle GitHub mirror cache misses

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -49,6 +49,7 @@ test("GitHub release mirror caches empty assets as a short cache miss", () => {
     assert.equal(writes.length, 1);
     assert.equal(writes[0].key, "github:release:owner/repo:latest");
     assert.deepEqual(writes[0].options, { expirationTtl: 1800 });
+    assert.equal(JSON.parse(writes[0].value).data.immutable, false);
   `);
 });
 
@@ -61,10 +62,19 @@ test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens"
     } from "./web/src/lib/github/mirror.ts";
 
     const bundleUrl = "https://tmaproduction.blob.core.windows.net/attestations/1/bundle.json?sig=test";
+    const token = { id: 1, token: "secret-github-token" };
     assert.equal(__testing.validGitHubAttestationBundleUrl(bundleUrl), true);
     assert.equal(__testing.validGitHubAttestationBundleUrl("https://example.com/bundle.json"), false);
     assert.equal(__testing.isGitHubApiUrl("https://api.github.com/repos/cli/cli"), true);
     assert.equal(__testing.isGitHubApiUrl(bundleUrl), false);
+    assert.equal(
+      __testing.githubJsonHeaders("https://api.github.com/repos/cli/cli", token).Authorization,
+      "Bearer secret-github-token",
+    );
+    assert.equal(
+      __testing.githubJsonHeaders(bundleUrl, token).Authorization,
+      undefined,
+    );
 
     const seen = [];
     globalThis.fetch = async (url, init) => {

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -63,8 +63,8 @@ test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens"
     const bundleUrl = "https://tmaproduction.blob.core.windows.net/attestations/1/bundle.json?sig=test";
     assert.equal(__testing.validGitHubAttestationBundleUrl(bundleUrl), true);
     assert.equal(__testing.validGitHubAttestationBundleUrl("https://example.com/bundle.json"), false);
-    assert.equal(__testing.shouldSendGitHubToken("https://api.github.com/repos/cli/cli"), true);
-    assert.equal(__testing.shouldSendGitHubToken(bundleUrl), false);
+    assert.equal(__testing.isGitHubApiUrl("https://api.github.com/repos/cli/cli"), true);
+    assert.equal(__testing.isGitHubApiUrl(bundleUrl), false);
 
     const seen = [];
     globalThis.fetch = async (url, init) => {
@@ -111,5 +111,29 @@ test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens"
         authorization: undefined,
       },
     ]);
+  `);
+});
+
+test("GitHub rate limiting only applies to GitHub API responses", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import { __testing } from "./web/src/lib/github/mirror.ts";
+
+    const headers = new Headers({ "x-ratelimit-reset": "1780092823" });
+    const githubError = new __testing.GitHubError(
+      403,
+      "rate limited",
+      headers,
+      "https://api.github.com/repos/cli/cli/releases/latest",
+    );
+    const azureError = new __testing.GitHubError(
+      403,
+      "expired SAS token",
+      new Headers(),
+      "https://tmaproduction.blob.core.windows.net/attestations/1/bundle.json?sig=test",
+    );
+
+    assert.equal(__testing.isRateLimited(githubError), true);
+    assert.equal(__testing.isRateLimited(azureError), false);
   `);
 });

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -15,7 +15,7 @@ function runMirrorTest(source) {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`.trim());
 }
 
-test("GitHub release mirror treats empty assets as a cache miss", () => {
+test("GitHub release mirror caches empty assets as a short cache miss", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";
     import {
@@ -23,6 +23,7 @@ test("GitHub release mirror treats empty assets as a cache miss", () => {
       githubStatus,
     } from "./web/src/lib/github/mirror.ts";
 
+    const writes = [];
     globalThis.fetch = async () =>
       new Response(JSON.stringify({
         tag_name: "v1.0.0",
@@ -37,9 +38,7 @@ test("GitHub release mirror treats empty assets as a cache miss", () => {
       DB: {},
       GITHUB_CACHE: {
         get: async () => null,
-        put: async () => {
-          throw new Error("empty releases should not be cached");
-        },
+        put: async (key, value, options) => writes.push({ key, value, options }),
       },
     };
 
@@ -47,10 +46,13 @@ test("GitHub release mirror treats empty assets as a cache miss", () => {
       () => getCachedGitHubRelease(env, "owner", "repo", "latest"),
       (error) => githubStatus(error) === 404,
     );
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].key, "github:release:owner/repo:latest");
+    assert.deepEqual(writes[0].options, { expirationTtl: 1800 });
   `);
 });
 
-test("GitHub attestations hydrate signed blob bundle URLs", () => {
+test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";
     import {
@@ -61,10 +63,15 @@ test("GitHub attestations hydrate signed blob bundle URLs", () => {
     const bundleUrl = "https://tmaproduction.blob.core.windows.net/attestations/1/bundle.json?sig=test";
     assert.equal(__testing.validGitHubAttestationBundleUrl(bundleUrl), true);
     assert.equal(__testing.validGitHubAttestationBundleUrl("https://example.com/bundle.json"), false);
+    assert.equal(__testing.shouldSendGitHubToken("https://api.github.com/repos/cli/cli"), true);
+    assert.equal(__testing.shouldSendGitHubToken(bundleUrl), false);
 
     const seen = [];
-    globalThis.fetch = async (url) => {
-      seen.push(String(url));
+    globalThis.fetch = async (url, init) => {
+      seen.push({
+        url: String(url),
+        authorization: init?.headers?.Authorization,
+      });
       if (String(url).startsWith("https://api.github.com/repos/cli/cli/attestations/")) {
         return new Response(JSON.stringify({
           attestations: [{ bundle: null, bundle_url: bundleUrl }],
@@ -95,8 +102,14 @@ test("GitHub attestations hydrate signed blob bundle URLs", () => {
       mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
     });
     assert.deepEqual(seen, [
-      "https://api.github.com/repos/cli/cli/attestations/sha256%3A02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0?per_page=30",
-      bundleUrl,
+      {
+        url: "https://api.github.com/repos/cli/cli/attestations/sha256%3A02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0?per_page=30",
+        authorization: undefined,
+      },
+      {
+        url: bundleUrl,
+        authorization: undefined,
+      },
     ]);
   `);
 });

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+function runMirrorTest(source) {
+  const result = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module"],
+    {
+      cwd: new URL("..", import.meta.url),
+      input: source,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`.trim());
+}
+
+test("GitHub release mirror treats empty assets as a cache miss", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({
+        tag_name: "v1.0.0",
+        draft: false,
+        prerelease: false,
+        created_at: "2026-01-01T00:00:00Z",
+        published_at: "2026-01-01T00:00:00Z",
+        assets: [],
+      }), { status: 200 });
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {
+          throw new Error("empty releases should not be cached");
+        },
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "latest"),
+      (error) => githubStatus(error) === 404,
+    );
+  `);
+});
+
+test("GitHub attestations hydrate signed blob bundle URLs", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      __testing,
+      getCachedGitHubAttestations,
+    } from "./web/src/lib/github/mirror.ts";
+
+    const bundleUrl = "https://tmaproduction.blob.core.windows.net/attestations/1/bundle.json?sig=test";
+    assert.equal(__testing.validGitHubAttestationBundleUrl(bundleUrl), true);
+    assert.equal(__testing.validGitHubAttestationBundleUrl("https://example.com/bundle.json"), false);
+
+    const seen = [];
+    globalThis.fetch = async (url) => {
+      seen.push(String(url));
+      if (String(url).startsWith("https://api.github.com/repos/cli/cli/attestations/")) {
+        return new Response(JSON.stringify({
+          attestations: [{ bundle: null, bundle_url: bundleUrl }],
+        }), { status: 200 });
+      }
+      if (String(url) === bundleUrl) {
+        return new Response(JSON.stringify({ mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json" }), { status: 200 });
+      }
+      return new Response("unexpected URL", { status: 500 });
+    };
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {},
+      },
+    };
+
+    const response = await getCachedGitHubAttestations(
+      env,
+      "cli",
+      "cli",
+      "sha256:02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0",
+    );
+
+    assert.deepEqual(response.attestations[0].bundle, {
+      mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+    });
+    assert.deepEqual(seen, [
+      "https://api.github.com/repos/cli/cli/attestations/sha256%3A02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0?per_page=30",
+      bundleUrl,
+    ]);
+  `);
+});

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -247,7 +247,7 @@ async function fetchGitHubRelease(
   const assets = data.assets ?? [];
   if (assets.length === 0) {
     throw new GitHubError(
-      502,
+      404,
       "GitHub release response did not include assets",
       new Headers(),
     );
@@ -313,7 +313,7 @@ async function hydrateBundle(
       new Headers(),
     );
   }
-  if (!validGitHubApiUrl(attestation.bundle_url)) {
+  if (!validGitHubAttestationBundleUrl(attestation.bundle_url)) {
     throw new GitHubError(
       502,
       "Invalid GitHub attestation bundle URL",
@@ -362,14 +362,22 @@ function assertValidRepo(owner: string, repo: string) {
   }
 }
 
-function validGitHubApiUrl(value: string): boolean {
+function validGitHubAttestationBundleUrl(value: string): boolean {
   try {
     const url = new URL(value);
-    return url.protocol === "https:" && url.hostname === "api.github.com";
+    return (
+      url.protocol === "https:" &&
+      (url.hostname === "api.github.com" ||
+        url.hostname.endsWith(".blob.core.windows.net"))
+    );
   } catch {
     return false;
   }
 }
+
+export const __testing = {
+  validGitHubAttestationBundleUrl,
+};
 
 function isRateLimited(error: unknown): boolean {
   return (

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -3,6 +3,8 @@ import { setupDatabase } from "../../../../src/database";
 
 const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
 const RELEASE_FRESH_MS = 6 * 60 * 60 * 1000;
+const EMPTY_RELEASE_FRESH_MS = 30 * 60 * 1000;
+const EMPTY_RELEASE_CACHE_TTL_SECONDS = 30 * 60;
 const RELEASE_IMMUTABLE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 const NEGATIVE_ATTESTATION_FRESH_MS = 30 * 60 * 1000;
 const EDGE_SHORT_TTL_SECONDS = 10 * 60;
@@ -118,18 +120,31 @@ export async function getCachedGitHubRelease(
   repo: string,
   tag: string,
 ): Promise<GitHubRelease> {
-  return getOrRefresh({
+  const release = await getOrRefresh({
     env,
     cacheKey: `github:release:${owner}/${repo}:${tag}`,
     isFresh: (entry) =>
       (tag !== "latest" && entry.data.immutable === true) ||
-      Date.now() - entry.cached_at < RELEASE_FRESH_MS,
+      Date.now() - entry.cached_at <
+        (entry.data.assets.length === 0
+          ? EMPTY_RELEASE_FRESH_MS
+          : RELEASE_FRESH_MS),
     fetcher: (token) => fetchGitHubRelease(owner, repo, tag, token),
     expirationTtl: (data) =>
-      tag !== "latest" && data.immutable === true
-        ? undefined
-        : CACHE_TTL_SECONDS,
+      data.assets.length === 0
+        ? EMPTY_RELEASE_CACHE_TTL_SECONDS
+        : tag !== "latest" && data.immutable === true
+          ? undefined
+          : CACHE_TTL_SECONDS,
   });
+  if (release.assets.length === 0) {
+    throw new GitHubError(
+      404,
+      "GitHub release response did not include assets",
+      new Headers(),
+    );
+  }
+  return release;
 }
 
 export async function getCachedGitHubAttestations(
@@ -245,13 +260,6 @@ async function fetchGitHubRelease(
     Number.isFinite(publishedAt) &&
     Date.now() - publishedAt > RELEASE_IMMUTABLE_AFTER_MS;
   const assets = data.assets ?? [];
-  if (assets.length === 0) {
-    throw new GitHubError(
-      404,
-      "GitHub release response did not include assets",
-      new Headers(),
-    );
-  }
 
   return {
     tag_name: data.tag_name,
@@ -335,7 +343,7 @@ async function githubJson<T>(
     "User-Agent": "mise-versions (https://github.com/jdx/mise-versions)",
     "X-GitHub-Api-Version": "2022-11-28",
   };
-  if (token) {
+  if (token && shouldSendGitHubToken(url)) {
     headers.Authorization = `Bearer ${token.token}`;
   }
   const response = await fetch(url, { headers, redirect: "manual" });
@@ -375,7 +383,16 @@ function validGitHubAttestationBundleUrl(value: string): boolean {
   }
 }
 
+function shouldSendGitHubToken(value: string): boolean {
+  try {
+    return new URL(value).hostname === "api.github.com";
+  } catch {
+    return false;
+  }
+}
+
 export const __testing = {
+  shouldSendGitHubToken,
   validGitHubAttestationBundleUrl,
 };
 

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -253,13 +253,14 @@ async function fetchGitHubRelease(
   const publishedAt = data.published_at
     ? new Date(data.published_at).getTime()
     : NaN;
+  const assets = data.assets ?? [];
   const immutable =
+    assets.length > 0 &&
     tag !== "latest" &&
     !data.draft &&
     !data.prerelease &&
     Number.isFinite(publishedAt) &&
     Date.now() - publishedAt > RELEASE_IMMUTABLE_AFTER_MS;
-  const assets = data.assets ?? [];
 
   return {
     tag_name: data.tag_name,
@@ -338,17 +339,7 @@ async function githubJson<T>(
   url: string,
   token: TokenRecord | null,
 ): Promise<T> {
-  const isGitHub = isGitHubApiUrl(url);
-  const headers: Record<string, string> = {
-    "User-Agent": "mise-versions (https://github.com/jdx/mise-versions)",
-  };
-  if (isGitHub) {
-    headers.Accept = "application/vnd.github+json";
-    headers["X-GitHub-Api-Version"] = "2022-11-28";
-  }
-  if (token && isGitHub) {
-    headers.Authorization = `Bearer ${token.token}`;
-  }
+  const headers = githubJsonHeaders(url, token);
   const response = await fetch(url, { headers, redirect: "manual" });
   if (response.status === 404) {
     throw new GitHubError(404, "Not found", response.headers, url);
@@ -398,6 +389,24 @@ function isGitHubApiUrl(value: string | undefined): boolean {
   }
 }
 
+function githubJsonHeaders(
+  url: string,
+  token: TokenRecord | null,
+): Record<string, string> {
+  const isGitHub = isGitHubApiUrl(url);
+  const headers: Record<string, string> = {
+    "User-Agent": "mise-versions (https://github.com/jdx/mise-versions)",
+  };
+  if (isGitHub) {
+    headers.Accept = "application/vnd.github+json";
+    headers["X-GitHub-Api-Version"] = "2022-11-28";
+  }
+  if (token && isGitHub) {
+    headers.Authorization = `Bearer ${token.token}`;
+  }
+  return headers;
+}
+
 function isRateLimited(error: unknown): boolean {
   return (
     error instanceof GitHubError &&
@@ -433,6 +442,7 @@ class GitHubError extends Error {
 
 export const __testing = {
   GitHubError,
+  githubJsonHeaders,
   isGitHubApiUrl,
   isRateLimited,
   validGitHubAttestationBundleUrl,

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -338,23 +338,27 @@ async function githubJson<T>(
   url: string,
   token: TokenRecord | null,
 ): Promise<T> {
+  const isGitHub = isGitHubApiUrl(url);
   const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
     "User-Agent": "mise-versions (https://github.com/jdx/mise-versions)",
-    "X-GitHub-Api-Version": "2022-11-28",
   };
-  if (token && shouldSendGitHubToken(url)) {
+  if (isGitHub) {
+    headers.Accept = "application/vnd.github+json";
+    headers["X-GitHub-Api-Version"] = "2022-11-28";
+  }
+  if (token && isGitHub) {
     headers.Authorization = `Bearer ${token.token}`;
   }
   const response = await fetch(url, { headers, redirect: "manual" });
   if (response.status === 404) {
-    throw new GitHubError(404, "Not found", response.headers);
+    throw new GitHubError(404, "Not found", response.headers, url);
   }
   if (!response.ok) {
     throw new GitHubError(
       response.status,
       await response.text(),
       response.headers,
+      url,
     );
   }
   return response.json();
@@ -383,7 +387,10 @@ function validGitHubAttestationBundleUrl(value: string): boolean {
   }
 }
 
-function shouldSendGitHubToken(value: string): boolean {
+function isGitHubApiUrl(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
   try {
     return new URL(value).hostname === "api.github.com";
   } catch {
@@ -391,14 +398,10 @@ function shouldSendGitHubToken(value: string): boolean {
   }
 }
 
-export const __testing = {
-  shouldSendGitHubToken,
-  validGitHubAttestationBundleUrl,
-};
-
 function isRateLimited(error: unknown): boolean {
   return (
     error instanceof GitHubError &&
+    isGitHubApiUrl(error.url) &&
     (error.status === 403 || error.status === 429)
   );
 }
@@ -422,7 +425,15 @@ class GitHubError extends Error {
     readonly status: number,
     message: string,
     readonly headers: Headers,
+    readonly url?: string,
   ) {
     super(message);
   }
 }
+
+export const __testing = {
+  GitHubError,
+  isGitHubApiUrl,
+  isRateLimited,
+  validGitHubAttestationBundleUrl,
+};


### PR DESCRIPTION
## Summary
- return a 404-style mirror miss when GitHub releases exist but have no downloadable assets, allowing mise clients to fall back quietly instead of surfacing 502 retry warnings
- hydrate GitHub artifact attestation bundles from the signed blob URLs GitHub returns when the inline `bundle` field is null
- add regression coverage for both mirror failure modes

## Cloudflare impact
On 2026-05-29 UTC, Cloudflare edge analytics for `mise-versions.jdx.dev/api/github/repos/%` showed:
- 617,969 total requests
- 110,324 HTTP 502s (17.85%)
- release mirror: 88,759 / 488,120 were 502s (18.18%)
- attestation mirror: 21,606 / 130,057 were 502s (16.61%)

Top release 502s included `kubernetes/kubernetes`, `hashicorp/terraform`, `apache/maven`, and `npm/cli`, all of which currently hit the zero-assets release path.

## Testing
- `npm run build -w web`
- `npm run test:js`
- `npx prettier --check web/src/lib/github/mirror.ts scripts/github-mirror.test.js`
- `npx tsc --noEmit --ignoreDeprecations 6.0`

Notes: `npx tsc --noEmit` without `--ignoreDeprecations 6.0` fails on the existing TS 6 `baseUrl` deprecation. `cd web && npx tsc --noEmit --ignoreDeprecations 6.0` still reports existing Env/fetch typing issues unrelated to this change.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public mirror HTTP semantics (502→404 for empty releases) and expands outbound fetch targets to signed Azure blob URLs, though both are bounded by existing API error mapping and URL allowlisting.
> 
> **Overview**
> Fixes GitHub mirror behavior so **releases with no assets** and **attestations with external bundle URLs** stop surfacing as **502** errors.
> 
> **Release mirror:** Empty-asset releases are cached with a **30-minute** TTL and freshness window, then surfaced as a **404** miss (instead of failing during fetch with 502). Immutable release caching only applies when assets exist.
> 
> **Attestation mirror:** When GitHub returns `bundle_url` on Azure blob storage instead of an inline `bundle`, the mirror fetches that URL after allowlisting `*.blob.core.windows.net`. GitHub API headers and bearer tokens are applied **only** to `api.github.com` requests; rate-limit handling is scoped the same way via an optional `url` on `GitHubError`.
> 
> Adds **`scripts/github-mirror.test.js`** regression tests (spawned via `tsx`) for empty-release caching, bundle hydration, and rate-limit scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066ff9451bc81a7778ae74c981b7a634b0c4fa82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->