### PR TITLE
fix: decode GitHub attestation bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "drizzle-orm": "^0.45.0",
         "semver": "^7.7.4",
         "smol-toml": "^1.5.2",
+        "snappyjs": "^0.7.0",
         "workers-og": "^0.0.27"
       },
       "devDependencies": {
@@ -7474,6 +7475,12 @@
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
       }
+    },
+    "node_modules/snappyjs": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.7.0.tgz",
+      "integrity": "sha512-u5iEEXkMe2EInQio6Wv9LWHOQYRDbD2O9hzS27GpT/lwfIQhTCnHCTqedqHIHe9ZcvQo+9au6vngQayipz1NYw==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.7.6",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "drizzle-orm": "^0.45.0",
     "semver": "^7.7.4",
     "smol-toml": "^1.5.2",
+    "snappyjs": "^0.7.0",
     "workers-og": "^0.0.27"
   }
 }

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -60,8 +60,13 @@ test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens"
       __testing,
       getCachedGitHubAttestations,
     } from "./web/src/lib/github/mirror.ts";
+    import { compress } from "snappyjs";
 
     const bundleUrl = "https://tmaproduction.blob.core.windows.net/attestations/1/bundle.json?sig=test";
+    const bundle = { mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json" };
+    const compressedBundle = compress(
+      new TextEncoder().encode(JSON.stringify(bundle)),
+    );
     const token = { id: 1, token: "secret-github-token" };
     assert.equal(__testing.validGitHubAttestationBundleUrl(bundleUrl), true);
     assert.equal(__testing.validGitHubAttestationBundleUrl("https://example.com/bundle.json"), false);
@@ -88,7 +93,10 @@ test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens"
         }), { status: 200 });
       }
       if (String(url) === bundleUrl) {
-        return new Response(JSON.stringify({ mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json" }), { status: 200 });
+        return new Response(compressedBundle, {
+          status: 200,
+          headers: { "Content-Type": "application/x-snappy" },
+        });
       }
       return new Response("unexpected URL", { status: 500 });
     };
@@ -108,9 +116,7 @@ test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens"
       "sha256:02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0",
     );
 
-    assert.deepEqual(response.attestations[0].bundle, {
-      mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
-    });
+    assert.deepEqual(response.attestations[0].bundle, bundle);
     assert.deepEqual(seen, [
       {
         url: "https://api.github.com/repos/cli/cli/attestations/sha256%3A02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0?per_page=30",

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -30,3 +30,7 @@ interface Env {
 declare namespace App {
   interface Locals extends Runtime {}
 }
+
+declare module "snappyjs" {
+  export function uncompress(input: Uint8Array): Uint8Array;
+}

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -1,4 +1,5 @@
 import { drizzle } from "drizzle-orm/d1";
+import { uncompress } from "snappyjs";
 import { setupDatabase } from "../../../../src/database";
 
 const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -351,6 +352,16 @@ async function githubJson<T>(
       response.headers,
       url,
     );
+  }
+  return readJsonResponse(response);
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T> {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  if (contentType.split(";")[0].trim() === "application/x-snappy") {
+    const bytes = await response.arrayBuffer();
+    const json = new TextDecoder().decode(uncompress(new Uint8Array(bytes)));
+    return JSON.parse(json);
   }
   return response.json();
 }


### PR DESCRIPTION
## Summary
- decode GitHub attestation bundle URLs served by Azure as `application/x-snappy` before JSON parsing
- keep GitHub API JSON handling unchanged
- update the mirror attestation test to use a Snappy-compressed bundle response

## Validation
- `npm run test:js`
- `npx prettier --check web/src/lib/github/mirror.ts scripts/github-mirror.test.js web/env.d.ts package.json package-lock.json`
- `npm run build -w web`
- local live attestation repro now hydrates 2 bundles successfully

Note: `cd web && npx tsc --noEmit --ignoreDeprecations 6.0` still fails on existing unrelated repo-wide `unknown` JSON/Cloudflare `Env` typing errors.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches attestation bundle hydration used for supply-chain metadata; scope is limited to content-type handling with a regression test.
> 
> **Overview**
> GitHub attestation **bundle URLs** hosted on Azure often return bodies with `Content-Type: application/x-snappy`, not plain JSON. The mirror’s shared `githubJson` path now routes successful responses through **`readJsonResponse`**, which Snappy-decompresses those bodies before `JSON.parse` while leaving normal `application/json` responses on `response.json()`.
> 
> This adds the **`snappyjs`** dependency plus a minimal module typing in `web/env.d.ts`, and updates the attestation mirror test to serve a compressed bundle like production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951e7dabc21c461661a2571ea4ede598bfaa519d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->