### PR TITLE
fix(analytics): avoid zero mau during rollup lag

### DIFF
--- a/src/analytics/migrations.ts
+++ b/src/analytics/migrations.ts
@@ -524,6 +524,9 @@ export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
     sql`CREATE INDEX IF NOT EXISTS idx_downloads_created_at ON downloads(created_at)`,
   );
   await db.run(
+    sql`CREATE INDEX IF NOT EXISTS idx_downloads_created_ip ON downloads(created_at, ip_hash)`,
+  );
+  await db.run(
     sql`CREATE INDEX IF NOT EXISTS idx_downloads_dedup ON downloads(tool_id, version, ip_hash, created_at)`,
   );
   await db.run(
@@ -621,6 +624,9 @@ export async function runAnalyticsMigrations(db: AnalyticsDb): Promise<void> {
   `);
   await db.run(
     sql`CREATE INDEX IF NOT EXISTS idx_version_requests_created_at ON version_requests(created_at)`,
+  );
+  await db.run(
+    sql`CREATE INDEX IF NOT EXISTS idx_version_requests_created_ip ON version_requests(created_at, ip_hash)`,
   );
   await db.run(
     sql`CREATE INDEX IF NOT EXISTS idx_version_requests_ip_hash ON version_requests(ip_hash)`,

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -333,7 +333,7 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
           `
         SELECT COUNT(DISTINCT ip_hash) as mau FROM (
           SELECT ip_hash FROM downloads WHERE created_at >= ? AND created_at <= ?
-          UNION
+          UNION ALL
           SELECT ip_hash FROM version_requests WHERE created_at >= ? AND created_at <= ?
         )
       `,
@@ -349,7 +349,7 @@ export function createRollupFunctions(db: ReturnType<typeof drizzle>) {
         .from(
           sql`(
             SELECT ip_hash FROM downloads WHERE created_at >= ${dateStart} AND created_at <= ${dateEnd}
-            UNION
+            UNION ALL
             SELECT ip_hash FROM version_requests WHERE created_at >= ${dateStart} AND created_at <= ${dateEnd}
           )`,
         )

--- a/src/analytics/stats.ts
+++ b/src/analytics/stats.ts
@@ -263,15 +263,13 @@ export function createStatsFunctions(db: ReturnType<typeof drizzle>) {
     // Get monthly active users from pre-computed rollup table
     async getMAU() {
       const today = new Date().toISOString().split("T")[0];
-      const yesterday = new Date(Date.now() - 86400000)
-        .toISOString()
-        .split("T")[0];
-
-      // Try today's value first, then yesterday's
+      // Prefer today's rollup, but fall back to the latest populated date. The
+      // scheduled MAU step can lag behind other rollups, and returning 0 hides
+      // the header badge even when recent MAU data exists.
       const result = await db
-        .select({ mau: dailyMauStats.mau })
+        .select({ mau: dailyMauStats.mau, date: dailyMauStats.date })
         .from(dailyMauStats)
-        .where(sql`${dailyMauStats.date} IN (${today}, ${yesterday})`)
+        .where(sql`${dailyMauStats.date} <= ${today}`)
         .orderBy(sql`${dailyMauStats.date} DESC`)
         .limit(1)
         .get();

--- a/web/src/pages/api/stats/mau.ts
+++ b/web/src/pages/api/stats/mau.ts
@@ -5,7 +5,6 @@ import { env } from "cloudflare:workers";
 import {
   cachedJsonResponse,
   errorResponse,
-  CACHE_CONTROL,
 } from "../../../lib/api";
 
 // GET /api/stats/mau - Get monthly active users (public)
@@ -16,7 +15,10 @@ export const GET: APIRoute = async ({ locals }) => {
 
     const mau = await analytics.getMAU();
 
-    return cachedJsonResponse({ mau }, CACHE_CONTROL.API);
+    return cachedJsonResponse(
+      { mau },
+      "public, max-age=300, stale-while-revalidate=600",
+    );
   } catch (error) {
     console.error("Get MAU error:", error);
     return errorResponse("Failed to get MAU", 500);


### PR DESCRIPTION
## Summary
- fall back to the latest populated MAU rollup instead of returning 0 when today/yesterday are missing
- reduce stale cache duration for the public MAU endpoint
- speed up MAU rollup queries with covering indexes and `UNION ALL`

## Testing
- `bunx tsc`
- `npm run build -w web`
- `npm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics read path and index additions only; MAU semantics are unchanged when rollups are current, with low blast radius beyond the public MAU badge.
> 
> **Overview**
> Fixes **MAU showing as 0** when scheduled rollups for today/yesterday are missing: `getMAU()` now returns the **most recent** `daily_mau_stats` row on or before today instead of only checking those two dates.
> 
> **Rollup performance:** adds `(created_at, ip_hash)` indexes on `downloads` and `version_requests`, and switches the MAU 30-day union subquery from `UNION` to **`UNION ALL`** (still deduped by `COUNT(DISTINCT ip_hash)`).
> 
> **Public API:** `/api/stats/mau` uses a **shorter cache** (5 min max-age, 10 min stale-while-revalidate) instead of the shared 10 min / 1 day `CACHE_CONTROL.API` profile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfcbdf327db2f80a4abf16e043c02288d784cb2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Monthly Active User (MAU) calculations to accurately reflect user engagement metrics by retrieving the most recent available data

* **Performance**
  * Optimized analytics database queries for improved response times
  * Enhanced API response caching to reduce server load and improve overall platform performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->