### PR TITLE
fix(github): follow repo redirects in release mirror

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -153,6 +153,39 @@ test("GitHub release mirror rewrites canonical asset casing to the requested rep
   `);
 });
 
+test("GitHub release mirror limits redirect chains", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    let redirects = 0;
+    globalThis.fetch = async () =>
+      new Response("Moved Permanently", {
+        status: 301,
+        headers: {
+          Location: \`https://api.github.com/repositories/\${++redirects}/releases/latest\`,
+        },
+      });
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {},
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "latest"),
+      (error) => githubStatus(error) === 508,
+    );
+    assert.equal(redirects, 4);
+  `);
+});
+
 test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -53,6 +53,106 @@ test("GitHub release mirror caches empty assets as a short cache miss", () => {
   `);
 });
 
+test("GitHub release mirror follows repository redirects and rewrites asset URLs", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+    } from "./web/src/lib/github/mirror.ts";
+
+    const seen = [];
+    const writes = [];
+    globalThis.fetch = async (url) => {
+      seen.push(String(url));
+      if (String(url) === "https://api.github.com/repos/jdx/rtx/releases/latest") {
+        return new Response("Moved Permanently", {
+          status: 301,
+          headers: {
+            Location: "https://api.github.com/repositories/586920414/releases/latest",
+          },
+        });
+      }
+      if (String(url) === "https://api.github.com/repositories/586920414/releases/latest") {
+        return new Response(JSON.stringify({
+          tag_name: "v2026.6.0",
+          draft: false,
+          prerelease: false,
+          created_at: "2026-06-03T18:02:06Z",
+          published_at: "2026-06-03T18:02:06Z",
+          assets: [{
+            name: "install.sh",
+            browser_download_url: "https://github.com/jdx/mise/releases/download/v2026.6.0/install.sh",
+            url: "https://api.github.com/repos/jdx/mise/releases/assets/437498665",
+            digest: "sha256:abc123",
+          }],
+        }), { status: 200 });
+      }
+      return new Response("unexpected URL", { status: 500 });
+    };
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async (key, value) => writes.push({ key, value }),
+      },
+    };
+
+    const release = await getCachedGitHubRelease(env, "jdx", "rtx", "latest");
+
+    assert.deepEqual(seen, [
+      "https://api.github.com/repos/jdx/rtx/releases/latest",
+      "https://api.github.com/repositories/586920414/releases/latest",
+    ]);
+    assert.equal(release.assets[0].browser_download_url, "https://github.com/jdx/rtx/releases/download/v2026.6.0/install.sh");
+    assert.equal(release.assets[0].url, "https://api.github.com/repos/jdx/rtx/releases/assets/437498665");
+    assert.equal(writes[0].key, "github:release:jdx/rtx:latest");
+  `);
+});
+
+test("GitHub release mirror rewrites canonical asset casing to the requested repo", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+    } from "./web/src/lib/github/mirror.ts";
+
+    globalThis.fetch = async (url) => {
+      assert.equal(String(url), "https://api.github.com/repos/Dicklesworthstone/Destructive_command_guard/releases/tags/v0.5.6");
+      return new Response(JSON.stringify({
+        tag_name: "v0.5.6",
+        draft: false,
+        prerelease: false,
+        created_at: "2026-05-27T00:04:32Z",
+        published_at: "2026-05-27T00:30:31Z",
+        assets: [{
+          name: "dcg-aarch64-apple-darwin.tar.xz",
+          browser_download_url: "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/v0.5.6/dcg-aarch64-apple-darwin.tar.xz",
+          url: "https://api.github.com/repos/Dicklesworthstone/destructive_command_guard/releases/assets/430632958",
+        }],
+      }), { status: 200 });
+    };
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {},
+      },
+    };
+
+    const release = await getCachedGitHubRelease(
+      env,
+      "Dicklesworthstone",
+      "Destructive_command_guard",
+      "v0.5.6",
+    );
+
+    assert.equal(release.assets[0].browser_download_url, "https://github.com/Dicklesworthstone/Destructive_command_guard/releases/download/v0.5.6/dcg-aarch64-apple-darwin.tar.xz");
+    assert.equal(release.assets[0].url, "https://api.github.com/repos/Dicklesworthstone/Destructive_command_guard/releases/assets/430632958");
+  `);
+});
+
 test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -186,6 +186,37 @@ test("GitHub release mirror limits redirect chains", () => {
   `);
 });
 
+test("GitHub release mirror rejects unsafe redirects", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    globalThis.fetch = async () =>
+      new Response("Moved Permanently", {
+        status: 301,
+        headers: {
+          Location: "https://example.com/repos/owner/repo/releases/latest",
+        },
+      });
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {},
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "latest"),
+      (error) => githubStatus(error) === 502,
+    );
+  `);
+});
+
 test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -354,23 +354,31 @@ async function githubJson<T>(
   token: TokenRecord | null,
 ): Promise<T> {
   let currentUrl = url;
-  for (let redirects = 0; redirects <= MAX_GITHUB_REDIRECTS; redirects++) {
+  let redirects = 0;
+  while (true) {
     const headers = githubJsonHeaders(currentUrl, token);
     const response = await fetch(currentUrl, { headers, redirect: "manual" });
     if (isRedirect(response.status)) {
       const nextUrl = githubRedirectUrl(currentUrl, response);
-      if (nextUrl) {
-        if (redirects >= MAX_GITHUB_REDIRECTS) {
-          throw new GitHubError(
-            508,
-            "Too many GitHub redirects",
-            response.headers,
-            currentUrl,
-          );
-        }
-        currentUrl = nextUrl;
-        continue;
+      if (!nextUrl) {
+        throw new GitHubError(
+          502,
+          "Unsafe GitHub redirect",
+          response.headers,
+          currentUrl,
+        );
       }
+      if (redirects >= MAX_GITHUB_REDIRECTS) {
+        throw new GitHubError(
+          508,
+          "Too many GitHub redirects",
+          response.headers,
+          currentUrl,
+        );
+      }
+      redirects += 1;
+      currentUrl = nextUrl;
+      continue;
     }
     if (response.status === 404) {
       throw new GitHubError(404, "Not found", response.headers, currentUrl);
@@ -385,7 +393,6 @@ async function githubJson<T>(
     }
     return readJsonResponse(response);
   }
-  throw new GitHubError(508, "Too many GitHub redirects", new Headers(), url);
 }
 
 async function readJsonResponse<T>(response: Response): Promise<T> {

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -11,6 +11,7 @@ const NEGATIVE_ATTESTATION_FRESH_MS = 30 * 60 * 1000;
 const EDGE_SHORT_TTL_SECONDS = 10 * 60;
 const EDGE_NEGATIVE_ATTESTATION_TTL_SECONDS = 30 * 60;
 const EDGE_IMMUTABLE_TTL_SECONDS = 365 * 24 * 60 * 60;
+const MAX_GITHUB_REDIRECTS = 3;
 
 interface CacheEntry<T> {
   cached_at: number;
@@ -269,12 +270,24 @@ async function fetchGitHubRelease(
     prerelease: data.prerelease,
     created_at: data.created_at,
     immutable,
-    assets: assets.map((asset) => ({
-      name: asset.name,
-      browser_download_url: asset.browser_download_url,
-      url: asset.url,
-      digest: asset.digest ?? null,
-    })),
+    assets: assets.map((asset) => normalizeGitHubAsset(asset, owner, repo)),
+  };
+}
+
+function normalizeGitHubAsset(
+  asset: GitHubAsset,
+  owner: string,
+  repo: string,
+): GitHubAsset {
+  return {
+    name: asset.name,
+    browser_download_url: withRequestedGitHubRepo(
+      asset.browser_download_url,
+      owner,
+      repo,
+    ),
+    url: withRequestedGitHubRepo(asset.url, owner, repo),
+    digest: asset.digest ?? null,
   };
 }
 
@@ -340,20 +353,31 @@ async function githubJson<T>(
   url: string,
   token: TokenRecord | null,
 ): Promise<T> {
-  const headers = githubJsonHeaders(url, token);
-  const response = await fetch(url, { headers, redirect: "manual" });
-  if (response.status === 404) {
-    throw new GitHubError(404, "Not found", response.headers, url);
+  let currentUrl = url;
+  for (let redirects = 0; redirects <= MAX_GITHUB_REDIRECTS; redirects++) {
+    const headers = githubJsonHeaders(currentUrl, token);
+    const response = await fetch(currentUrl, { headers, redirect: "manual" });
+    if (isRedirect(response.status)) {
+      const nextUrl = githubRedirectUrl(currentUrl, response);
+      if (nextUrl && redirects < MAX_GITHUB_REDIRECTS) {
+        currentUrl = nextUrl;
+        continue;
+      }
+    }
+    if (response.status === 404) {
+      throw new GitHubError(404, "Not found", response.headers, currentUrl);
+    }
+    if (!response.ok) {
+      throw new GitHubError(
+        response.status,
+        await response.text(),
+        response.headers,
+        currentUrl,
+      );
+    }
+    return readJsonResponse(response);
   }
-  if (!response.ok) {
-    throw new GitHubError(
-      response.status,
-      await response.text(),
-      response.headers,
-      url,
-    );
-  }
-  return readJsonResponse(response);
+  throw new GitHubError(508, "Too many GitHub redirects", new Headers(), url);
 }
 
 async function readJsonResponse<T>(response: Response): Promise<T> {
@@ -397,6 +421,66 @@ function isGitHubApiUrl(value: string | undefined): boolean {
     return new URL(value).hostname === "api.github.com";
   } catch {
     return false;
+  }
+}
+
+function isRedirect(status: number): boolean {
+  return [301, 302, 303, 307, 308].includes(status);
+}
+
+function githubRedirectUrl(
+  currentUrl: string,
+  response: Response,
+): string | null {
+  const location = response.headers.get("location");
+  if (!location || !isGitHubApiUrl(currentUrl)) {
+    return null;
+  }
+  try {
+    const nextUrl = new URL(location, currentUrl).toString();
+    return isGitHubApiUrl(nextUrl) ? nextUrl : null;
+  } catch {
+    return null;
+  }
+}
+
+function withRequestedGitHubRepo(
+  value: string,
+  owner: string,
+  repo: string,
+): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") {
+      return value;
+    }
+    const segments = url.pathname.split("/");
+    if (
+      url.hostname === "github.com" &&
+      segments.length >= 6 &&
+      segments[3] === "releases" &&
+      segments[4] === "download"
+    ) {
+      segments[1] = owner;
+      segments[2] = repo;
+      url.pathname = segments.join("/");
+      return url.toString();
+    }
+    if (
+      url.hostname === "api.github.com" &&
+      segments.length === 7 &&
+      segments[1] === "repos" &&
+      segments[4] === "releases" &&
+      segments[5] === "assets"
+    ) {
+      segments[2] = owner;
+      segments[3] = repo;
+      url.pathname = segments.join("/");
+      return url.toString();
+    }
+    return value;
+  } catch {
+    return value;
   }
 }
 
@@ -454,7 +538,9 @@ class GitHubError extends Error {
 export const __testing = {
   GitHubError,
   githubJsonHeaders,
+  githubRedirectUrl,
   isGitHubApiUrl,
   isRateLimited,
   validGitHubAttestationBundleUrl,
+  withRequestedGitHubRepo,
 };

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -359,7 +359,15 @@ async function githubJson<T>(
     const response = await fetch(currentUrl, { headers, redirect: "manual" });
     if (isRedirect(response.status)) {
       const nextUrl = githubRedirectUrl(currentUrl, response);
-      if (nextUrl && redirects < MAX_GITHUB_REDIRECTS) {
+      if (nextUrl) {
+        if (redirects >= MAX_GITHUB_REDIRECTS) {
+          throw new GitHubError(
+            508,
+            "Too many GitHub redirects",
+            response.headers,
+            currentUrl,
+          );
+        }
         currentUrl = nextUrl;
         continue;
       }


### PR DESCRIPTION
## Summary
- follow safe GitHub API redirects in the release/attestation JSON helper so renamed or transferred repositories resolve through the mirror
- rewrite mirrored GitHub release asset URLs back to the owner/repo requested through the proxy, preserving compatibility with released `mise` clients that validate the requested slug
- reject unsafe off-API redirects and cap redirect chains with explicit 502/508 behavior
- add regression coverage for a renamed repo redirect (`jdx/rtx` -> `jdx/mise`), canonical asset casing (`Destructive_command_guard`), redirect-chain limits, and unsafe redirects

## How This Fixes It
`mise` uses the `mise-versions` GitHub release endpoint as a cache for public GitHub release metadata, but released clients validate the returned asset URLs before using them. That validation expects release asset URLs to match the backend slug the user requested, such as `github:jdx/rtx` or `github:Dicklesworthstone/Destructive_command_guard`.

GitHub can legitimately return a different owner/repo spelling in two cases:

- repository owner/name casing is canonicalized in release asset URLs
- renamed or transferred repositories redirect from the requested slug to the canonical repository, such as `jdx/rtx` redirecting to `jdx/mise`

If the proxy simply returns GitHub's canonical asset URLs, current `mise` clients warn that `mise-versions returned invalid GitHub release asset URLs` and fall back to the live GitHub API. For renamed/transferred repositories, the client also cannot safely decide on its own that a different owner/repo is valid unless the API contract includes trusted canonical-repository metadata.

This PR keeps the compatibility boundary in the proxy:

1. `githubJson` manually follows redirects only while the current URL and the `Location` URL are on `api.github.com`.
2. Redirect chains are limited to `MAX_GITHUB_REDIRECTS`; over-limit chains fail with 508.
3. Redirect responses without a safe GitHub API target fail with 502 instead of being followed or misreported.
4. After GitHub returns the release JSON, the proxy rewrites only the owner/repo path segments in known GitHub release asset URL shapes back to the slug the caller requested.
5. The cache key remains the requested slug, so existing clients continue to validate and use the mirror response without changing their API expectations.

The companion `mise` client PR, https://github.com/jdx/mise/pull/10240, handles the case-only part for future clients by making owner/repo validation case-insensitive while keeping host, path, and tag checks strict. It intentionally does not make the client accept arbitrary different repositories for rename/transfer cases; those stay proxy-side unless a future API contract adds trusted canonical-repository metadata.

## Testing
- `node --test scripts/github-mirror.test.js`
- `npm run build -w web`
- `npm run test:js`
- `npx tsc --noEmit`
- `npx prettier --check web/src/lib/github/mirror.ts scripts/github-mirror.test.js`
- live local mirror smoke test for `jdx/rtx` redirect rewriting

## Notes
- `npx eslint web/src/lib/github/mirror.ts` could not run locally because ESLint 10 requires an `eslint.config.*` file and this repo does not currently provide one.
- `npm audit --omit=dev --audit-level=high` reports existing dependency advisories (`devalue`, `ws` via Cloudflare tooling); no dependency changes are included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced GitHub release mirroring with bounded redirect handling to prevent infinite loops.
  * Release asset URLs now properly normalize to match the requested repository context.
  * Added safety checks to reject redirects to external destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->