### PR TITLE
fix(github): follow release API redirects

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -53,6 +53,62 @@ test("GitHub release mirror caches empty assets as a short cache miss", () => {
   `);
 });
 
+test("GitHub release mirror follows API redirects", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import { getCachedGitHubRelease } from "./web/src/lib/github/mirror.ts";
+
+    const seen = [];
+    globalThis.fetch = async (url) => {
+      seen.push(String(url));
+      if (String(url) === "https://api.github.com/repos/StackExchange/dnscontrol/releases/tags/v4.41.0") {
+        return new Response("", {
+          status: 301,
+          headers: {
+            Location: "https://api.github.com/repos/StackExchange/dnscontrol2/releases/tags/v4.41.0",
+          },
+        });
+      }
+      if (String(url) === "https://api.github.com/repos/StackExchange/dnscontrol2/releases/tags/v4.41.0") {
+        return new Response(JSON.stringify({
+          tag_name: "v4.41.0",
+          draft: false,
+          prerelease: false,
+          created_at: "2026-01-01T00:00:00Z",
+          published_at: "2026-01-01T00:00:00Z",
+          assets: [{
+            name: "dnscontrol.tar.gz",
+            browser_download_url: "https://github.com/StackExchange/dnscontrol2/releases/download/v4.41.0/dnscontrol.tar.gz",
+            url: "https://api.github.com/repos/StackExchange/dnscontrol2/releases/assets/1",
+          }],
+        }), { status: 200 });
+      }
+      return new Response("unexpected URL", { status: 500 });
+    };
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {},
+      },
+    };
+
+    const release = await getCachedGitHubRelease(
+      env,
+      "StackExchange",
+      "dnscontrol",
+      "v4.41.0",
+    );
+
+    assert.equal(release.tag_name, "v4.41.0");
+    assert.deepEqual(seen, [
+      "https://api.github.com/repos/StackExchange/dnscontrol/releases/tags/v4.41.0",
+      "https://api.github.com/repos/StackExchange/dnscontrol2/releases/tags/v4.41.0",
+    ]);
+  `);
+});
+
 test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -109,6 +109,90 @@ test("GitHub release mirror follows API redirects", () => {
   `);
 });
 
+test("GitHub release mirror rejects redirects outside the GitHub API", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    const seen = [];
+    globalThis.fetch = async (url) => {
+      seen.push(String(url));
+      return new Response("", {
+        status: 302,
+        headers: {
+          Location: "https://example.com/repos/owner/repo/releases/tags/v1.0.0",
+        },
+      });
+    };
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {},
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "v1.0.0"),
+      (error) => githubStatus(error) === 502,
+    );
+    assert.deepEqual(seen, [
+      "https://api.github.com/repos/owner/repo/releases/tags/v1.0.0",
+    ]);
+  `);
+});
+
+test("GitHub release mirror rejects redirect loops", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    const seen = [];
+    globalThis.fetch = async (url) => {
+      const current = String(url);
+      seen.push(current);
+      const redirect = Number(new URL(current).searchParams.get("redirect") ?? "0");
+      return new Response("", {
+        status: 302,
+        headers: {
+          Location:
+            redirect < 3
+              ? "https://api.github.com/repos/owner/repo/releases/tags/v1.0.0?redirect=" + (redirect + 1)
+              : "https://example.com/should-not-be-resolved",
+        },
+      });
+    };
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {},
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "v1.0.0"),
+      (error) =>
+        githubStatus(error) === 502 &&
+        error.message === "GitHub API redirect limit exceeded",
+    );
+    assert.deepEqual(seen, [
+      "https://api.github.com/repos/owner/repo/releases/tags/v1.0.0",
+      "https://api.github.com/repos/owner/repo/releases/tags/v1.0.0?redirect=1",
+      "https://api.github.com/repos/owner/repo/releases/tags/v1.0.0?redirect=2",
+      "https://api.github.com/repos/owner/repo/releases/tags/v1.0.0?redirect=3",
+    ]);
+  `);
+});
+
 test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -348,11 +348,21 @@ async function fetchGitHubJsonResponse(
   url: string,
   token: TokenRecord | null,
 ): Promise<Response> {
+  const maxRedirects = 3;
   let currentUrl = url;
-  for (let redirectCount = 0; redirectCount <= 3; redirectCount++) {
+  for (let redirectCount = 0; ; redirectCount++) {
     const headers = githubJsonHeaders(currentUrl, token);
     const response = await fetch(currentUrl, { headers, redirect: "manual" });
     if (isGitHubApiRedirect(response)) {
+      await response.body?.cancel();
+      if (redirectCount >= maxRedirects) {
+        throw new GitHubError(
+          502,
+          "GitHub API redirect limit exceeded",
+          response.headers,
+          currentUrl,
+        );
+      }
       const nextUrl = redirectedGitHubApiUrl(currentUrl, response);
       if (!nextUrl) {
         throw new GitHubError(
@@ -366,15 +376,8 @@ async function fetchGitHubJsonResponse(
       continue;
     }
 
-    return await validateGitHubJsonResponse(response, currentUrl);
+    return validateGitHubJsonResponse(response, currentUrl);
   }
-
-  throw new GitHubError(
-    502,
-    "GitHub API redirect limit exceeded",
-    new Headers(),
-    currentUrl,
-  );
 }
 
 async function validateGitHubJsonResponse(

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -340,8 +340,47 @@ async function githubJson<T>(
   url: string,
   token: TokenRecord | null,
 ): Promise<T> {
-  const headers = githubJsonHeaders(url, token);
-  const response = await fetch(url, { headers, redirect: "manual" });
+  const response = await fetchGitHubJsonResponse(url, token);
+  return readJsonResponse(response);
+}
+
+async function fetchGitHubJsonResponse(
+  url: string,
+  token: TokenRecord | null,
+): Promise<Response> {
+  let currentUrl = url;
+  for (let redirectCount = 0; redirectCount <= 3; redirectCount++) {
+    const headers = githubJsonHeaders(currentUrl, token);
+    const response = await fetch(currentUrl, { headers, redirect: "manual" });
+    if (isGitHubApiRedirect(response)) {
+      const nextUrl = redirectedGitHubApiUrl(currentUrl, response);
+      if (!nextUrl) {
+        throw new GitHubError(
+          502,
+          "GitHub API redirect location was invalid",
+          response.headers,
+          currentUrl,
+        );
+      }
+      currentUrl = nextUrl;
+      continue;
+    }
+
+    return await validateGitHubJsonResponse(response, currentUrl);
+  }
+
+  throw new GitHubError(
+    502,
+    "GitHub API redirect limit exceeded",
+    new Headers(),
+    currentUrl,
+  );
+}
+
+async function validateGitHubJsonResponse(
+  response: Response,
+  url: string,
+): Promise<Response> {
   if (response.status === 404) {
     throw new GitHubError(404, "Not found", response.headers, url);
   }
@@ -353,7 +392,31 @@ async function githubJson<T>(
       url,
     );
   }
-  return readJsonResponse(response);
+  return response;
+}
+
+function isGitHubApiRedirect(response: Response): boolean {
+  return (
+    response.status >= 300 &&
+    response.status < 400 &&
+    response.headers.has("location")
+  );
+}
+
+function redirectedGitHubApiUrl(
+  currentUrl: string,
+  response: Response,
+): string | null {
+  const location = response.headers.get("location");
+  if (!location || !isGitHubApiUrl(currentUrl)) {
+    return null;
+  }
+  try {
+    const nextUrl = new URL(location, currentUrl);
+    return nextUrl.hostname === "api.github.com" ? nextUrl.toString() : null;
+  } catch {
+    return null;
+  }
 }
 
 async function readJsonResponse<T>(response: Response): Promise<T> {


### PR DESCRIPTION
## Summary
- follow GitHub API redirects while fetching mirrored release metadata
- constrain redirects to api.github.com and cap chains at 3 hops
- add a regression test for a redirected release lookup

## Test plan
- npx prettier --write web/src/lib/github/mirror.ts scripts/github-mirror.test.js
- node --test scripts/github-mirror.test.js

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared `githubJson` fetch behavior for releases and attestations; redirect allowlisting reduces SSRF risk but mis-handled redirects could still break metadata mirroring.
> 
> **Overview**
> **GitHub JSON fetches** no longer rely on the runtime’s automatic redirect behavior. `githubJson` now uses manual redirect handling (`redirect: "manual"`) with a small loop that follows up to **3** hops only when the request started on `api.github.com` and each `Location` resolves to **`api.github.com`**; otherwise it returns **502** (invalid location, off-host redirect, or redirect limit).
> 
> Regression coverage was added for a successful API redirect chain (e.g. renamed repo), rejection of redirects to non-GitHub hosts, and exhaustion of the redirect cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77bbe770f2ff96b7b4254361dbfa3abb73532dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub release API redirect handling: follows safe GitHub API redirects, rejects redirects to external hosts, enforces a redirect limit, and correctly returns the payload from the final location.

* **Tests**
  * Added unit tests covering redirect-following, rejection of external redirects, and redirect-loop protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->