### PR TITLE
fix(github): negative cache release failures

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -193,6 +193,83 @@ test("GitHub release mirror rejects redirect loops", () => {
   `);
 });
 
+test("GitHub release mirror negative-caches upstream 404s", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    const writes = [];
+    let fetches = 0;
+    globalThis.fetch = async () => {
+      fetches++;
+      return new Response("not found", { status: 404 });
+    };
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async (key, value, options) => writes.push({ key, value, options }),
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "v404.0.0"),
+      (error) => githubStatus(error) === 404,
+    );
+
+    assert.equal(fetches, 1);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].key, "github:release-error:owner/repo:v404.0.0");
+    assert.deepEqual(writes[0].options, { expirationTtl: 1800 });
+    assert.equal(JSON.parse(writes[0].value).data.status, 404);
+  `);
+});
+
+test("GitHub release mirror serves fresh negative cache without fetching", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    let fetches = 0;
+    globalThis.fetch = async () => {
+      fetches++;
+      return new Response("unexpected fetch", { status: 500 });
+    };
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async (key) => {
+          if (key === "github:release-error:owner/repo:v404.0.0") {
+            return {
+              cached_at: Date.now(),
+              data: { status: 404, message: "Not found" },
+            };
+          }
+          return null;
+        },
+        put: async () => {
+          throw new Error("negative cache hit should not write");
+        },
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "v404.0.0"),
+      (error) => githubStatus(error) === 404,
+    );
+
+    assert.equal(fetches, 0);
+  `);
+});
+
 test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -359,27 +359,31 @@ test("GitHub release mirror does not negative-cache rate-limited 403s", () => {
       githubStatus,
     } from "./web/src/lib/github/mirror.ts";
 
-    const writes = [];
-    globalThis.fetch = async () =>
-      new Response("rate limited", {
-        status: 403,
-        headers: { "x-ratelimit-reset": "1780092823" },
-      });
+    async function writesForHeaders(headers) {
+      const writes = [];
+      globalThis.fetch = async () =>
+        new Response("rate limited", { status: 403, headers });
 
-    const env = {
-      DB: {},
-      GITHUB_CACHE: {
-        get: async () => null,
-        put: async (key, value, options) => writes.push({ key, value, options }),
-      },
-    };
+      const env = {
+        DB: {},
+        GITHUB_CACHE: {
+          get: async () => null,
+          put: async (key, value, options) => writes.push({ key, value, options }),
+        },
+      };
 
-    await assert.rejects(
-      () => getCachedGitHubRelease(env, "owner", "repo", "v403.0.0"),
-      (error) => githubStatus(error) === 403,
+      await assert.rejects(
+        () => getCachedGitHubRelease(env, "owner", "repo", "v403.0.0"),
+        (error) => githubStatus(error) === 403,
+      );
+      return writes;
+    }
+
+    assert.equal(
+      (await writesForHeaders({ "x-ratelimit-reset": "1780092823" })).length,
+      0,
     );
-
-    assert.equal(writes.length, 0);
+    assert.equal((await writesForHeaders({ "retry-after": "60" })).length, 0);
   `);
 });
 
@@ -492,11 +496,27 @@ test("GitHub rate limiting only applies to GitHub API responses", () => {
     import assert from "node:assert/strict";
     import { __testing } from "./web/src/lib/github/mirror.ts";
 
-    const headers = new Headers({ "x-ratelimit-reset": "1780092823" });
+    const resetHeaders = new Headers({ "x-ratelimit-reset": "1780092823" });
+    const retryAfterHeaders = new Headers({ "retry-after": "60" });
+    const retryAfterDateHeaders = new Headers({
+      "retry-after": "Sat, 06 Jun 2026 23:00:00 GMT",
+    });
     const githubError = new __testing.GitHubError(
       403,
       "rate limited",
-      headers,
+      resetHeaders,
+      "https://api.github.com/repos/cli/cli/releases/latest",
+    );
+    const secondaryLimitError = new __testing.GitHubError(
+      403,
+      "secondary rate limit",
+      retryAfterHeaders,
+      "https://api.github.com/repos/cli/cli/releases/latest",
+    );
+    const secondaryLimitDateError = new __testing.GitHubError(
+      403,
+      "secondary rate limit",
+      retryAfterDateHeaders,
       "https://api.github.com/repos/cli/cli/releases/latest",
     );
     const azureError = new __testing.GitHubError(
@@ -513,7 +533,14 @@ test("GitHub rate limiting only applies to GitHub API responses", () => {
     );
 
     assert.equal(__testing.isRateLimited(githubError), true);
+    assert.equal(__testing.isRateLimited(secondaryLimitError), true);
+    assert.equal(__testing.isRateLimited(secondaryLimitDateError), true);
     assert.equal(__testing.isRateLimited(azureError), false);
     assert.equal(__testing.isRateLimited(githubForbidden), false);
+    assert.equal(__testing.resetAt(githubError), "2026-05-29T22:13:43.000Z");
+    assert.equal(
+      __testing.resetAt(secondaryLimitDateError),
+      "2026-06-06T23:00:00.000Z",
+    );
   `);
 });

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -270,6 +270,146 @@ test("GitHub release mirror serves fresh negative cache without fetching", () =>
   `);
 });
 
+test("GitHub release mirror ignores stale negative cache and fetches", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+    } from "./web/src/lib/github/mirror.ts";
+
+    let fetches = 0;
+    globalThis.fetch = async () => {
+      fetches++;
+      return new Response(JSON.stringify({
+        tag_name: "v1.0.0",
+        draft: false,
+        prerelease: false,
+        created_at: "2026-01-01T00:00:00Z",
+        published_at: "2026-01-01T00:00:00Z",
+        assets: [{
+          name: "tool.tar.gz",
+          browser_download_url: "https://github.com/owner/repo/releases/download/v1.0.0/tool.tar.gz",
+          url: "https://api.github.com/repos/owner/repo/releases/assets/1",
+        }],
+      }), { status: 200 });
+    };
+
+    const deletes = [];
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async (key) => {
+          if (key === "github:release-error:owner/repo:v1.0.0") {
+            return {
+              cached_at: Date.now() - 31 * 60 * 1000,
+              data: { status: 404, message: "Not found" },
+            };
+          }
+          return null;
+        },
+        put: async () => {},
+        delete: async (key) => deletes.push(key),
+      },
+    };
+
+    const release = await getCachedGitHubRelease(env, "owner", "repo", "v1.0.0");
+
+    assert.equal(fetches, 1);
+    assert.equal(release.tag_name, "v1.0.0");
+    assert.deepEqual(deletes, ["github:release-error:owner/repo:v1.0.0"]);
+  `);
+});
+
+test("GitHub release mirror uses status-specific negative cache TTLs", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    async function ttlForStatus(status) {
+      const writes = [];
+      globalThis.fetch = async () => new Response("failure", { status });
+      const env = {
+        DB: {},
+        GITHUB_CACHE: {
+          get: async () => null,
+          put: async (key, value, options) => writes.push({ key, value, options }),
+        },
+      };
+      await assert.rejects(
+        () => getCachedGitHubRelease(env, "owner", "repo", "v" + status),
+        (error) => githubStatus(error) === status,
+      );
+      return writes[0].options.expirationTtl;
+    }
+
+    assert.equal(await ttlForStatus(500), 60);
+    assert.equal(await ttlForStatus(401), 300);
+    assert.equal(await ttlForStatus(403), 300);
+  `);
+});
+
+test("GitHub release mirror does not negative-cache rate-limited 403s", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    const writes = [];
+    globalThis.fetch = async () =>
+      new Response("rate limited", {
+        status: 403,
+        headers: { "x-ratelimit-reset": "1780092823" },
+      });
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async (key, value, options) => writes.push({ key, value, options }),
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "v403.0.0"),
+      (error) => githubStatus(error) === 403,
+    );
+
+    assert.equal(writes.length, 0);
+  `);
+});
+
+test("GitHub release mirror preserves upstream error when negative-cache write fails", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    globalThis.fetch = async () => new Response("not found", { status: 404 });
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async () => {
+          throw new Error("KV write failed");
+        },
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "v404.0.0"),
+      (error) => githubStatus(error) === 404,
+    );
+  `);
+});
+
 test("GitHub attestations hydrate signed blob bundle URLs without GitHub tokens", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";
@@ -365,8 +505,15 @@ test("GitHub rate limiting only applies to GitHub API responses", () => {
       new Headers(),
       "https://tmaproduction.blob.core.windows.net/attestations/1/bundle.json?sig=test",
     );
+    const githubForbidden = new __testing.GitHubError(
+      403,
+      "forbidden",
+      new Headers(),
+      "https://api.github.com/repos/cli/cli/releases/latest",
+    );
 
     assert.equal(__testing.isRateLimited(githubError), true);
     assert.equal(__testing.isRateLimited(azureError), false);
+    assert.equal(__testing.isRateLimited(githubForbidden), false);
   `);
 });

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -7,6 +7,9 @@ const RELEASE_FRESH_MS = 6 * 60 * 60 * 1000;
 const EMPTY_RELEASE_FRESH_MS = 30 * 60 * 1000;
 const EMPTY_RELEASE_CACHE_TTL_SECONDS = 30 * 60;
 const RELEASE_IMMUTABLE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+const NEGATIVE_RELEASE_NOT_FOUND_FRESH_MS = 30 * 60 * 1000;
+const NEGATIVE_RELEASE_AUTH_FRESH_MS = 5 * 60 * 1000;
+const NEGATIVE_RELEASE_TRANSIENT_FRESH_MS = 60 * 1000;
 const NEGATIVE_ATTESTATION_FRESH_MS = 30 * 60 * 1000;
 const EDGE_SHORT_TTL_SECONDS = 10 * 60;
 const EDGE_NEGATIVE_ATTESTATION_TTL_SECONDS = 30 * 60;
@@ -36,6 +39,11 @@ export interface GitHubRelease {
 interface GitHubAttestation {
   bundle?: unknown;
   bundle_url?: string;
+}
+
+interface CachedGitHubError {
+  status: number;
+  message: string;
 }
 
 export interface GitHubAttestationsResponse {
@@ -121,23 +129,36 @@ export async function getCachedGitHubRelease(
   repo: string,
   tag: string,
 ): Promise<GitHubRelease> {
-  const release = await getOrRefresh({
-    env,
-    cacheKey: `github:release:${owner}/${repo}:${tag}`,
-    isFresh: (entry) =>
-      (tag !== "latest" && entry.data.immutable === true) ||
-      Date.now() - entry.cached_at <
-        (entry.data.assets.length === 0
-          ? EMPTY_RELEASE_FRESH_MS
-          : RELEASE_FRESH_MS),
-    fetcher: (token) => fetchGitHubRelease(owner, repo, tag, token),
-    expirationTtl: (data) =>
-      data.assets.length === 0
-        ? EMPTY_RELEASE_CACHE_TTL_SECONDS
-        : tag !== "latest" && data.immutable === true
-          ? undefined
-          : CACHE_TTL_SECONDS,
-  });
+  const cacheKey = `github:release:${owner}/${repo}:${tag}`;
+  const negativeCacheKey = `github:release-error:${owner}/${repo}:${tag}`;
+  const cachedError = await cachedReleaseError(env, negativeCacheKey);
+  if (cachedError) {
+    throw cachedError;
+  }
+
+  let release: GitHubRelease;
+  try {
+    release = await getOrRefresh({
+      env,
+      cacheKey,
+      isFresh: (entry) =>
+        (tag !== "latest" && entry.data.immutable === true) ||
+        Date.now() - entry.cached_at <
+          (entry.data.assets.length === 0
+            ? EMPTY_RELEASE_FRESH_MS
+            : RELEASE_FRESH_MS),
+      fetcher: (token) => fetchGitHubRelease(owner, repo, tag, token),
+      expirationTtl: (data) =>
+        data.assets.length === 0
+          ? EMPTY_RELEASE_CACHE_TTL_SECONDS
+          : tag !== "latest" && data.immutable === true
+            ? undefined
+            : CACHE_TTL_SECONDS,
+    });
+  } catch (error) {
+    await cacheReleaseError(env, negativeCacheKey, error);
+    throw error;
+  }
   if (release.assets.length === 0) {
     throw new GitHubError(
       404,
@@ -146,6 +167,66 @@ export async function getCachedGitHubRelease(
     );
   }
   return release;
+}
+
+async function cachedReleaseError(
+  env: Env,
+  cacheKey: string,
+): Promise<GitHubError | null> {
+  const cached = await env.GITHUB_CACHE.get<CacheEntry<CachedGitHubError>>(
+    cacheKey,
+    "json",
+  );
+  if (!cached) {
+    return null;
+  }
+  const freshMs = releaseErrorFreshMs(cached.data.status);
+  if (!freshMs || Date.now() - cached.cached_at >= freshMs) {
+    return null;
+  }
+  return new GitHubError(
+    cached.data.status,
+    cached.data.message,
+    new Headers(),
+  );
+}
+
+async function cacheReleaseError(
+  env: Env,
+  cacheKey: string,
+  error: unknown,
+): Promise<void> {
+  if (!(error instanceof GitHubError)) {
+    return;
+  }
+  const freshMs = releaseErrorFreshMs(error.status);
+  if (!freshMs) {
+    return;
+  }
+  await env.GITHUB_CACHE.put(
+    cacheKey,
+    JSON.stringify({
+      cached_at: Date.now(),
+      data: {
+        status: error.status,
+        message: error.message,
+      },
+    }),
+    { expirationTtl: Math.ceil(freshMs / 1000) },
+  );
+}
+
+function releaseErrorFreshMs(status: number): number | null {
+  if (status === 404) {
+    return NEGATIVE_RELEASE_NOT_FOUND_FRESH_MS;
+  }
+  if (status === 401 || status === 403) {
+    return NEGATIVE_RELEASE_AUTH_FRESH_MS;
+  }
+  if (status >= 500 && status < 600) {
+    return NEGATIVE_RELEASE_TRANSIENT_FRESH_MS;
+  }
+  return null;
 }
 
 export async function getCachedGitHubAttestations(

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -592,7 +592,9 @@ function isRateLimited(error: unknown): boolean {
     error instanceof GitHubError &&
     isGitHubApiUrl(error.url) &&
     (error.status === 429 ||
-      (error.status === 403 && error.headers.has("x-ratelimit-reset")))
+      (error.status === 403 &&
+        (error.headers.has("x-ratelimit-reset") ||
+          error.headers.has("retry-after"))))
   );
 }
 
@@ -601,12 +603,23 @@ function resetAt(error: unknown): string | undefined {
     return undefined;
   }
   const reset = error.headers.get("x-ratelimit-reset");
-  if (!reset) {
+  if (reset) {
+    const epochSeconds = Number(reset);
+    return Number.isFinite(epochSeconds)
+      ? new Date(epochSeconds * 1000).toISOString()
+      : undefined;
+  }
+  const retryAfter = error.headers.get("retry-after");
+  if (!retryAfter) {
     return undefined;
   }
-  const epochSeconds = Number(reset);
-  return Number.isFinite(epochSeconds)
-    ? new Date(epochSeconds * 1000).toISOString()
+  const retryAfterSeconds = Number(retryAfter);
+  if (Number.isFinite(retryAfterSeconds)) {
+    return new Date(Date.now() + retryAfterSeconds * 1000).toISOString();
+  }
+  const retryAfterDate = new Date(retryAfter);
+  return Number.isFinite(retryAfterDate.getTime())
+    ? retryAfterDate.toISOString()
     : undefined;
 }
 
@@ -626,5 +639,6 @@ export const __testing = {
   githubJsonHeaders,
   isGitHubApiUrl,
   isRateLimited,
+  resetAt,
   validGitHubAttestationBundleUrl,
 };

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -156,7 +156,14 @@ export async function getCachedGitHubRelease(
             : CACHE_TTL_SECONDS,
     });
   } catch (error) {
-    await cacheReleaseError(env, negativeCacheKey, error);
+    try {
+      await cacheReleaseError(env, negativeCacheKey, error);
+    } catch (cacheError) {
+      console.warn(
+        "failed to persist GitHub release negative cache:",
+        cacheError,
+      );
+    }
     throw error;
   }
   if (release.assets.length === 0) {
@@ -166,6 +173,7 @@ export async function getCachedGitHubRelease(
       new Headers(),
     );
   }
+  await clearCachedReleaseError(env, negativeCacheKey);
   return release;
 }
 
@@ -199,7 +207,7 @@ async function cacheReleaseError(
   if (!(error instanceof GitHubError)) {
     return;
   }
-  const freshMs = releaseErrorFreshMs(error.status);
+  const freshMs = releaseErrorFreshMs(error.status, error);
   if (!freshMs) {
     return;
   }
@@ -216,9 +224,23 @@ async function cacheReleaseError(
   );
 }
 
-function releaseErrorFreshMs(status: number): number | null {
+async function clearCachedReleaseError(
+  env: Env,
+  cacheKey: string,
+): Promise<void> {
+  try {
+    await env.GITHUB_CACHE.delete?.(cacheKey);
+  } catch (error) {
+    console.warn("failed to clear GitHub release negative cache:", error);
+  }
+}
+
+function releaseErrorFreshMs(status: number, error?: unknown): number | null {
   if (status === 404) {
     return NEGATIVE_RELEASE_NOT_FOUND_FRESH_MS;
+  }
+  if (error && isRateLimited(error)) {
+    return null;
   }
   if (status === 401 || status === 403) {
     return NEGATIVE_RELEASE_AUTH_FRESH_MS;
@@ -569,7 +591,8 @@ function isRateLimited(error: unknown): boolean {
   return (
     error instanceof GitHubError &&
     isGitHubApiUrl(error.url) &&
-    (error.status === 403 || error.status === 429)
+    (error.status === 429 ||
+      (error.status === 403 && error.headers.has("x-ratelimit-reset")))
   );
 }
 


### PR DESCRIPTION
## Summary
- add a short negative cache for GitHub release mirror failures
- cache 404s for 30 minutes, auth failures for 5 minutes, and 5xx failures for 1 minute
- avoid another upstream GitHub fetch while a negative cache entry is fresh

## Why
Repeated bad repo/tag lookups can generate a lot of worker noise and upstream traffic. Positive and empty release responses were already cached, but upstream failures were retried by every cold request.

## Test plan
- npx prettier --write web/src/lib/github/mirror.ts scripts/github-mirror.test.js
- node --test scripts/github-mirror.test.js
- npm run test:js

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release mirror caching and error/rate-limit classification for all release API traffic; misclassification could cache auth errors or skip caching when needed, but behavior is covered by new tests.
> 
> **Overview**
> Adds **negative caching** for failed GitHub release lookups in `getCachedGitHubRelease`, using KV keys `github:release-error:…` so repeat requests for the same bad owner/repo/tag skip upstream fetches while the entry is fresh.
> 
> TTLs vary by status: **404** for 30 minutes, **401/403** for 5 minutes, **5xx** for 1 minute. **Rate-limited** GitHub API errors (403/429 with `x-ratelimit-reset` or `retry-after`) are **not** negative-cached. Stale negative entries are ignored and refetched; successful releases clear the negative entry. KV write/delete failures are logged but the original error is still returned.
> 
> **Rate-limit handling** is tightened: plain 403 without those headers is no longer treated as rate limiting. `resetAt` also parses `retry-after` as seconds or an HTTP date. New unit tests cover negative-cache hits, TTLs, stale entries, rate-limit exclusions, and KV failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c7be314c13fa912a8babd11c705ab1203ddbc51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved negative-caching for failed GitHub release lookups: error entries now vary TTL by status, stale entries are ignored/deleted, true rate-limited responses are not cached, reset time handling for rate limits is more robust, and negative entries are cleared after successful fetches.

* **Tests**
  * Added comprehensive unit tests covering negative-cache behavior, TTL differences by status, stale-entry handling and deletion, non-caching of rate-limited responses, and failure/write-edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->