### PR TITLE
fix(github): restrict mirror to registry repos

### DIFF
--- a/scripts/github-registry.test.js
+++ b/scripts/github-registry.test.js
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isRegisteredGitHubRepo } from "../web/src/lib/github/registry.ts";
+
+function analyticsDbReturning(row, seen = {}) {
+  return {
+    prepare(query) {
+      seen.query = query;
+      return {
+        bind(...args) {
+          seen.args = args;
+          return {
+            first: async () => row,
+          };
+        },
+      };
+    },
+  };
+}
+
+test("GitHub registry allowlist normalizes and checks registry-backed slugs", async () => {
+  const seen = {};
+  const allowed = await isRegisteredGitHubRepo(
+    analyticsDbReturning({ allowed: 1 }, seen),
+    "Cli",
+    "CLI",
+  );
+
+  assert.equal(allowed, true);
+  assert.match(seen.query, /FROM tools t/);
+  assert.deepEqual(seen.args, [
+    "cli/cli",
+    "cli/cli",
+    "aqua:cli/cli",
+    "github:cli/cli",
+    "ubi:cli/cli",
+    "aqua:cli/cli[%",
+    "github:cli/cli[%",
+    "ubi:cli/cli[%",
+  ]);
+});
+
+test("GitHub registry allowlist rejects unknown repos", async () => {
+  const allowed = await isRegisteredGitHubRepo(
+    analyticsDbReturning(null),
+    "someone",
+    "anything",
+  );
+
+  assert.equal(allowed, false);
+});

--- a/web/src/lib/github/registry.ts
+++ b/web/src/lib/github/registry.ts
@@ -1,0 +1,46 @@
+const GITHUB_BACKEND_PREFIXES = ["aqua", "github", "ubi"] as const;
+
+function normalizeRepo(owner: string, repo: string): string {
+  return `${owner}/${repo}`.toLowerCase();
+}
+
+function likeEscape(value: string): string {
+  return value.replace(/[\\%_]/g, (char) => `\\${char}`);
+}
+
+export async function isRegisteredGitHubRepo(
+  analyticsDb: D1Database,
+  owner: string,
+  repo: string,
+): Promise<boolean> {
+  const slug = normalizeRepo(owner, repo);
+  const exactBackends = GITHUB_BACKEND_PREFIXES.map(
+    (backend) => `${backend}:${slug}`,
+  );
+  const filteredBackends = GITHUB_BACKEND_PREFIXES.map(
+    (backend) => `${backend}:${likeEscape(slug)}[%`,
+  );
+
+  const row = await analyticsDb
+    .prepare(
+      `
+        SELECT 1 AS allowed
+        FROM tools t
+        WHERE lower(t.github) = ?
+           OR lower(t.name) = ?
+           OR EXISTS (
+             SELECT 1
+             FROM json_each(t.backends) b
+             WHERE lower(b.value) IN (?, ?, ?)
+                OR lower(b.value) LIKE ? ESCAPE '\\'
+                OR lower(b.value) LIKE ? ESCAPE '\\'
+                OR lower(b.value) LIKE ? ESCAPE '\\'
+           )
+        LIMIT 1
+      `,
+    )
+    .bind(slug, slug, ...exactBackends, ...filteredBackends)
+    .first<{ allowed: number }>();
+
+  return !!row;
+}

--- a/web/src/lib/github/registry.ts
+++ b/web/src/lib/github/registry.ts
@@ -27,6 +27,8 @@ export async function isRegisteredGitHubRepo(
         SELECT 1 AS allowed
         FROM tools t
         WHERE lower(t.github) = ?
+           -- Some explicit registry entries use owner/repo as the tool name.
+           -- Do not match the repo basename; that would allow unrelated owners.
            OR lower(t.name) = ?
            OR EXISTS (
              SELECT 1

--- a/web/src/pages/api/github/repo.ts
+++ b/web/src/pages/api/github/repo.ts
@@ -44,7 +44,14 @@ export const GET: APIRoute = async ({ request, locals }) => {
   if (!validRepoPart(owner) || !validRepoPart(repo)) {
     return errorResponse("Invalid owner or repo parameter", 400);
   }
-  if (!(await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo))) {
+  let registered: boolean;
+  try {
+    registered = await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo);
+  } catch (error) {
+    console.error(`GitHub registry check failed for ${owner}/${repo}:`, error);
+    return errorResponse("Failed to check GitHub repo registry", 503);
+  }
+  if (!registered) {
     return errorResponse("GitHub repo is not in the mise registry", 403);
   }
 

--- a/web/src/pages/api/github/repo.ts
+++ b/web/src/pages/api/github/repo.ts
@@ -4,6 +4,8 @@ import { Octokit } from "@octokit/rest";
 import { setupDatabase } from "../../../../../src/database";
 import { getAuthCookie } from "../../../lib/auth";
 import { jsonResponse, errorResponse } from "../../../lib/api";
+import { validRepoPart } from "../../../lib/github/mirror";
+import { isRegisteredGitHubRepo } from "../../../lib/github/registry";
 
 import { env } from "cloudflare:workers";
 // Cache freshness threshold (6 hours in milliseconds)
@@ -38,6 +40,12 @@ export const GET: APIRoute = async ({ request, locals }) => {
 
   if (!owner || !repo) {
     return errorResponse("Missing owner or repo parameter", 400);
+  }
+  if (!validRepoPart(owner) || !validRepoPart(repo)) {
+    return errorResponse("Invalid owner or repo parameter", 400);
+  }
+  if (!(await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo))) {
+    return errorResponse("GitHub repo is not in the mise registry", 403);
   }
 
   const cacheKey = `github:${owner}/${repo}`;

--- a/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
@@ -16,11 +16,18 @@ export const GET: APIRoute = async ({ params }) => {
     return errorResponse("Invalid GitHub attestation path", 400);
   }
 
+  let registered: boolean;
   try {
-    if (!(await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo))) {
-      return errorResponse("GitHub repo is not in the mise registry", 403);
-    }
+    registered = await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo);
+  } catch (error) {
+    console.error(`GitHub registry check failed for ${owner}/${repo}:`, error);
+    return errorResponse("Failed to check GitHub repo registry", 503);
+  }
+  if (!registered) {
+    return errorResponse("GitHub repo is not in the mise registry", 403);
+  }
 
+  try {
     const attestations = await getCachedGitHubAttestations(
       env,
       owner,

--- a/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
@@ -8,6 +8,7 @@ import {
   validDigest,
   validRepoPart,
 } from "../../../../../../../lib/github/mirror";
+import { isRegisteredGitHubRepo } from "../../../../../../../lib/github/registry";
 
 export const GET: APIRoute = async ({ params }) => {
   const { owner, repo, digest } = params;
@@ -16,6 +17,10 @@ export const GET: APIRoute = async ({ params }) => {
   }
 
   try {
+    if (!(await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo))) {
+      return errorResponse("GitHub repo is not in the mise registry", 403);
+    }
+
     const attestations = await getCachedGitHubAttestations(
       env,
       owner,

--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -8,6 +8,7 @@ import {
   validReleaseTag,
   validRepoPart,
 } from "../../../../../../../lib/github/mirror";
+import { isRegisteredGitHubRepo } from "../../../../../../../lib/github/registry";
 
 export const GET: APIRoute = async ({ params }) => {
   const { owner, repo, tag } = params;
@@ -16,6 +17,10 @@ export const GET: APIRoute = async ({ params }) => {
   }
 
   try {
+    if (!(await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo))) {
+      return errorResponse("GitHub repo is not in the mise registry", 403);
+    }
+
     const release = await getCachedGitHubRelease(env, owner, repo, tag);
     return jsonResponse(release, 200, releaseCacheHeaders(tag, release));
   } catch (error) {

--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -16,11 +16,18 @@ export const GET: APIRoute = async ({ params }) => {
     return errorResponse("Invalid GitHub release path", 400);
   }
 
+  let registered: boolean;
   try {
-    if (!(await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo))) {
-      return errorResponse("GitHub repo is not in the mise registry", 403);
-    }
+    registered = await isRegisteredGitHubRepo(env.ANALYTICS_DB, owner, repo);
+  } catch (error) {
+    console.error(`GitHub registry check failed for ${owner}/${repo}:`, error);
+    return errorResponse("Failed to check GitHub repo registry", 503);
+  }
+  if (!registered) {
+    return errorResponse("GitHub repo is not in the mise registry", 403);
+  }
 
+  try {
     const release = await getCachedGitHubRelease(env, owner, repo, tag);
     return jsonResponse(release, 200, releaseCacheHeaders(tag, release));
   } catch (error) {


### PR DESCRIPTION
## Summary
- add a D1-backed allowlist check for GitHub repos synced from the mise registry
- reject non-registry repos before release, attestation, or repo metadata endpoints call GitHub
- cover the allowlist SQL bindings and rejection path with tests

## Validation
- `node --test scripts/github-registry.test.js`
- `node --test scripts/*.test.js`
- `aube run test`
- `aube exec tsc`
- `git diff --check`

Note: `aube --dir web exec tsc` still fails on the existing TS6 `baseUrl` deprecation before checking this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization for public GitHub proxy endpoints; misconfigured registry data or query logic could block legitimate tools or leave edge cases, but scope is limited to allowlisting before existing mirror behavior.
> 
> **Overview**
> GitHub mirror and metadata APIs are now **restricted to repos present in the mise registry**, so arbitrary `owner/repo` requests no longer reach GitHub.
> 
> A new **`isRegisteredGitHubRepo`** helper queries **ANALYTICS_DB** (`tools` table) with normalized `owner/repo`, matching `github`, `name`, and `aqua`/`github`/`ubi` backend entries (including prefixed variants). **Repo info**, **release mirror**, and **attestation mirror** routes validate `owner`/`repo` (repo info adds `validRepoPart`), return **403** when not registered, and **503** if the registry check fails. Tests cover normalization, SQL bindings, and rejection for unknown repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507547b2da68b8f5139ba7b165835caf470f3d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API endpoints for GitHub repository information now require repositories to be registered; unregistered repos return 403.
  * Repository identifier validation applied to release and attestation endpoints; invalid identifiers return 400.
  * Registry-check failures return 503.

* **Tests**
  * Added tests verifying registry validation behavior and query-based recognition of registered repos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->