### PR TITLE
fix(github): evict stale release cache on 404

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -229,6 +229,62 @@ test("GitHub release mirror negative-caches upstream 404s", () => {
   `);
 });
 
+test("GitHub release mirror does not serve stale positive cache after upstream 404", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    let fetches = 0;
+    globalThis.fetch = async () => {
+      fetches++;
+      return new Response("not found", { status: 404 });
+    };
+
+    const writes = [];
+    const deletes = [];
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async (key) => {
+          if (key === "github:release:owner/repo:v1.0.0") {
+            return {
+              cached_at: Date.now() - 7 * 60 * 60 * 1000,
+              data: {
+                tag_name: "v1.0.0",
+                draft: false,
+                prerelease: false,
+                created_at: "2026-01-01T00:00:00Z",
+                immutable: false,
+                assets: [{
+                  name: "tool.tar.gz",
+                  browser_download_url: "https://github.com/owner/repo/releases/download/v1.0.0/tool.tar.gz",
+                  url: "https://api.github.com/repos/owner/repo/releases/assets/1",
+                }],
+              },
+            };
+          }
+          return null;
+        },
+        put: async (key, value, options) => writes.push({ key, value, options }),
+        delete: async (key) => deletes.push(key),
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "v1.0.0"),
+      (error) => githubStatus(error) === 404,
+    );
+
+    assert.equal(fetches, 1);
+    assert.deepEqual(deletes, ["github:release:owner/repo:v1.0.0"]);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].key, "github:release-error:owner/repo:v1.0.0");
+  `);
+});
+
 test("GitHub release mirror serves fresh negative cache without fetching", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -154,6 +154,12 @@ export async function getCachedGitHubRelease(
           : tag !== "latest" && data.immutable === true
             ? undefined
             : CACHE_TTL_SECONDS,
+      useStaleOnError: releaseStaleFallbackAllowed,
+      onFetchError: async (error) => {
+        if (githubStatus(error) === 404) {
+          await deleteCachedRelease(env, cacheKey);
+        }
+      },
     });
   } catch (error) {
     try {
@@ -235,6 +241,14 @@ async function clearCachedReleaseError(
   }
 }
 
+async function deleteCachedRelease(env: Env, cacheKey: string): Promise<void> {
+  try {
+    await env.GITHUB_CACHE.delete?.(cacheKey);
+  } catch (error) {
+    console.warn("failed to delete stale GitHub release cache:", error);
+  }
+}
+
 function releaseErrorFreshMs(status: number, error?: unknown): number | null {
   if (status === 404) {
     return NEGATIVE_RELEASE_NOT_FOUND_FRESH_MS;
@@ -249,6 +263,11 @@ function releaseErrorFreshMs(status: number, error?: unknown): number | null {
     return NEGATIVE_RELEASE_TRANSIENT_FRESH_MS;
   }
   return null;
+}
+
+function releaseStaleFallbackAllowed(error: unknown): boolean {
+  const status = githubStatus(error);
+  return isRateLimited(error) || status === null || status >= 500;
 }
 
 export async function getCachedGitHubAttestations(
@@ -279,12 +298,16 @@ async function getOrRefresh<T>({
   isFresh,
   fetcher,
   expirationTtl,
+  useStaleOnError = () => true,
+  onFetchError,
 }: {
   env: Env;
   cacheKey: string;
   isFresh: (entry: CacheEntry<T>) => boolean;
   fetcher: (token: TokenRecord | null) => Promise<T>;
   expirationTtl?: (data: T) => number | undefined;
+  useStaleOnError?: (error: unknown) => boolean;
+  onFetchError?: (error: unknown) => Promise<void>;
 }): Promise<T> {
   const cached = await env.GITHUB_CACHE.get<CacheEntry<T>>(cacheKey, "json");
   if (cached && isFresh(cached)) {
@@ -306,7 +329,8 @@ async function getOrRefresh<T>({
     if (isRateLimited(error) && token) {
       await markRateLimited(env, token.id, resetAt(error));
     }
-    if (cached) {
+    await onFetchError?.(error);
+    if (cached && useStaleOnError(error)) {
       return cached.data;
     }
     throw error;


### PR DESCRIPTION
## Summary
- stop serving stale positive GitHub release cache entries after upstream returns 404
- delete the stale positive release cache so the negative release cache can take over
- keep stale fallback for rate limits, network-like errors, and 5xx responses

## Context
This prevents cases like `yaml/yamlscript@0.2.12`, where mise-versions had stale release metadata with dead asset URLs even though GitHub no longer returned that release.

## Tests
- `node --test scripts/github-mirror.test.js`
- `npm run test:js`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release mirror cache behavior on fetch errors; wrong gating could break resilience during outages or serve bad metadata, but scope is limited to release caching with new test coverage.
> 
> **Overview**
> Fixes a case where **stale positive release metadata** could still be returned after GitHub had removed the release (e.g. dead asset URLs while upstream is 404).
> 
> **`getOrRefresh`** now accepts **`useStaleOnError`** and **`onFetchError`**. Release lookups use **`releaseStaleFallbackAllowed`**, so stale positive cache is only used on rate limits, network-like errors, or **5xx**—not on **404**. On upstream **404**, **`deleteCachedRelease`** removes the positive KV entry so the error propagates and the existing **negative release cache** can apply.
> 
> A regression test asserts that an expired positive cache plus a **404** fetch triggers cache **delete**, does not return stale data, and still writes the negative cache key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d3919fbde708258d7c918d3a5966acb6c1c837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub release caching to better handle upstream errors and manage stale cached data.

* **Tests**
  * Added test coverage for cache behavior when upstream requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->