### PR TITLE
fix(github): shorten mutable release cache freshness

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -285,6 +285,59 @@ test("GitHub release mirror does not serve stale positive cache after upstream 4
   `);
 });
 
+test("GitHub release mirror revalidates mutable positive cache after edge freshness window", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      getCachedGitHubRelease,
+      githubStatus,
+    } from "./web/src/lib/github/mirror.ts";
+
+    let fetches = 0;
+    globalThis.fetch = async () => {
+      fetches++;
+      return new Response("not found", { status: 404 });
+    };
+
+    const deletes = [];
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async (key) => {
+          if (key === "github:release:owner/repo:latest") {
+            return {
+              cached_at: Date.now() - 11 * 60 * 1000,
+              data: {
+                tag_name: "v1.0.0",
+                draft: false,
+                prerelease: false,
+                created_at: "2026-01-01T00:00:00Z",
+                immutable: false,
+                assets: [{
+                  name: "tool.tar.gz",
+                  browser_download_url: "https://github.com/owner/repo/releases/download/v1.0.0/tool.tar.gz",
+                  url: "https://api.github.com/repos/owner/repo/releases/assets/1",
+                }],
+              },
+            };
+          }
+          return null;
+        },
+        put: async () => {},
+        delete: async (key) => deletes.push(key),
+      },
+    };
+
+    await assert.rejects(
+      () => getCachedGitHubRelease(env, "owner", "repo", "latest"),
+      (error) => githubStatus(error) === 404,
+    );
+
+    assert.equal(fetches, 1);
+    assert.deepEqual(deletes, ["github:release:owner/repo:latest"]);
+  `);
+});
+
 test("GitHub release mirror serves fresh negative cache without fetching", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -3,7 +3,6 @@ import { uncompress } from "snappyjs";
 import { setupDatabase } from "../../../../src/database";
 
 const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
-const RELEASE_FRESH_MS = 6 * 60 * 60 * 1000;
 const EMPTY_RELEASE_FRESH_MS = 30 * 60 * 1000;
 const EMPTY_RELEASE_CACHE_TTL_SECONDS = 30 * 60;
 const RELEASE_IMMUTABLE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
@@ -12,6 +11,7 @@ const NEGATIVE_RELEASE_AUTH_FRESH_MS = 5 * 60 * 1000;
 const NEGATIVE_RELEASE_TRANSIENT_FRESH_MS = 60 * 1000;
 const NEGATIVE_ATTESTATION_FRESH_MS = 30 * 60 * 1000;
 const EDGE_SHORT_TTL_SECONDS = 10 * 60;
+const MUTABLE_RELEASE_FRESH_MS = EDGE_SHORT_TTL_SECONDS * 1000;
 const EDGE_NEGATIVE_ATTESTATION_TTL_SECONDS = 30 * 60;
 const EDGE_IMMUTABLE_TTL_SECONDS = 365 * 24 * 60 * 60;
 
@@ -143,10 +143,7 @@ export async function getCachedGitHubRelease(
       cacheKey,
       isFresh: (entry) =>
         (tag !== "latest" && entry.data.immutable === true) ||
-        Date.now() - entry.cached_at <
-          (entry.data.assets.length === 0
-            ? EMPTY_RELEASE_FRESH_MS
-            : RELEASE_FRESH_MS),
+        Date.now() - entry.cached_at < releaseFreshMs(entry.data),
       fetcher: (token) => fetchGitHubRelease(owner, repo, tag, token),
       expirationTtl: (data) =>
         data.assets.length === 0
@@ -263,6 +260,12 @@ function releaseErrorFreshMs(status: number, error?: unknown): number | null {
     return NEGATIVE_RELEASE_TRANSIENT_FRESH_MS;
   }
   return null;
+}
+
+function releaseFreshMs(release: GitHubRelease): number {
+  return release.assets.length === 0
+    ? EMPTY_RELEASE_FRESH_MS
+    : MUTABLE_RELEASE_FRESH_MS;
 }
 
 function releaseStaleFallbackAllowed(error: unknown): boolean {


### PR DESCRIPTION
## Summary
- revalidate mutable GitHub release cache entries after the edge freshness window instead of 6 hours
- keep empty release misses short-lived and immutable versioned releases long-lived
- add a regression test proving stale mutable release metadata revalidates and can be evicted on upstream 404

## Context
After #226, stale positive release entries are evicted on upstream 404, but the eviction cannot run while an existing positive cache entry is still considered fresh. This shortens the freshness window for mutable releases so cases like `yaml/yamlscript@0.2.12` converge in minutes instead of hours.

## Tests
- `node --test scripts/github-mirror.test.js`
- `npm run test:js`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Caching TTL change only in the GitHub mirror layer; increases GitHub API traffic for mutable releases but improves correctness when releases disappear upstream.
> 
> **Overview**
> **Mutable GitHub release cache entries** (releases with assets that are not treated as immutable) now count as fresh for **10 minutes** instead of **6 hours**, matching the edge `s-maxage` window. Empty-asset releases still use the 30-minute empty freshness window, and versioned immutable releases are unchanged.
> 
> Freshness is centralized in `releaseFreshMs()` so `getOrRefresh` can re-fetch sooner; when upstream returns **404**, stale positive entries can be deleted instead of being served for hours.
> 
> A regression test asserts that a `latest` cache entry older than 11 minutes triggers a fetch, propagates the 404, and deletes the positive cache key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b652b0d97fb382ff00434362a2aa281f7dcb8c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub release information now refreshes more frequently, with cache revalidation occurring every 10 minutes instead of 6 hours, ensuring users have access to the latest release data.

* **Tests**
  * Added test coverage for cache revalidation behavior during the edge freshness window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->