### PR TITLE
fix(github): allow python standalone attestations

### DIFF
--- a/scripts/github-registry.test.js
+++ b/scripts/github-registry.test.js
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isRegisteredGitHubRepo } from "../web/src/lib/github/registry.ts";
+import {
+  isKnownGitHubAttestationRepo,
+  isRegisteredGitHubRepo,
+} from "../web/src/lib/github/registry.ts";
 
 function analyticsDbReturning(row, seen = {}) {
   return {
@@ -48,4 +51,15 @@ test("GitHub registry allowlist rejects unknown repos", async () => {
   );
 
   assert.equal(allowed, false);
+});
+
+test("GitHub attestation allowlist includes python-build-standalone", () => {
+  assert.equal(
+    isKnownGitHubAttestationRepo("Astral-Sh", "Python-Build-Standalone"),
+    true,
+  );
+});
+
+test("GitHub attestation allowlist rejects unknown repos", () => {
+  assert.equal(isKnownGitHubAttestationRepo("crate-ci", "cargo-release"), false);
 });

--- a/web/src/lib/github/registry.ts
+++ b/web/src/lib/github/registry.ts
@@ -1,5 +1,9 @@
 const GITHUB_BACKEND_PREFIXES = ["aqua", "github", "ubi"] as const;
 
+const GITHUB_ATTESTATION_REPOS = new Set([
+  "astral-sh/python-build-standalone",
+]);
+
 function normalizeRepo(owner: string, repo: string): string {
   return `${owner}/${repo}`.toLowerCase();
 }
@@ -45,4 +49,11 @@ export async function isRegisteredGitHubRepo(
     .first<{ allowed: number }>();
 
   return !!row;
+}
+
+export function isKnownGitHubAttestationRepo(
+  owner: string,
+  repo: string,
+): boolean {
+  return GITHUB_ATTESTATION_REPOS.has(normalizeRepo(owner, repo));
 }

--- a/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
@@ -8,7 +8,10 @@ import {
   validDigest,
   validRepoPart,
 } from "../../../../../../../lib/github/mirror";
-import { isRegisteredGitHubRepo } from "../../../../../../../lib/github/registry";
+import {
+  isKnownGitHubAttestationRepo,
+  isRegisteredGitHubRepo,
+} from "../../../../../../../lib/github/registry";
 
 export const GET: APIRoute = async ({ params }) => {
   const { owner, repo, digest } = params;
@@ -23,7 +26,7 @@ export const GET: APIRoute = async ({ params }) => {
     console.error(`GitHub registry check failed for ${owner}/${repo}:`, error);
     return errorResponse("Failed to check GitHub repo registry", 503);
   }
-  if (!registered) {
+  if (!registered && !isKnownGitHubAttestationRepo(owner, repo)) {
     return errorResponse("GitHub repo is not in the mise registry", 403);
   }
 


### PR DESCRIPTION
## Summary
- allow `astral-sh/python-build-standalone` through the GitHub attestations mirror allowlist
- keep release metadata restricted to registry repos
- add regression coverage for the Python attestation repo and for not allowing `crate-ci/cargo-release`

## Testing
- `npm run test:js`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped expansion of one API’s access check with a fixed repo list; release metadata remains registry-gated.
> 
> **Overview**
> Adds a **separate static allowlist** for GitHub attestation mirroring via `isKnownGitHubAttestationRepo` in `registry.ts`, seeded with `astral-sh/python-build-standalone` (case-insensitive).
> 
> The **attestations** `GET` route now returns data when the repo is either in the mise registry **or** on that attestation allowlist; registry-only checks for release metadata are unchanged. Regression tests cover acceptance of Python Build Standalone and rejection of unrelated repos like `crate-ci/cargo-release`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a4359095edd28bc5b28863e0ea286fe62a349bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub attestation endpoints now recognize an expanded allowlist of known repositories, enabling support for additional projects beyond the main registry.

* **Tests**
  * Added test coverage for the new GitHub attestation repository allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->