### PR TITLE
fix(github): allow @ in release tag validation

### DIFF
--- a/scripts/github-mirror-validation.test.js
+++ b/scripts/github-mirror-validation.test.js
@@ -5,7 +5,7 @@ import test from "node:test";
 function runValidationTest(source) {
   const result = spawnSync(
     process.execPath,
-    ["--import", "tsx", "--input-type=module"],
+    ["--import", "tsx", "--input-type=module", "-"],
     {
       cwd: new URL("..", import.meta.url),
       input: source,

--- a/scripts/github-mirror-validation.test.js
+++ b/scripts/github-mirror-validation.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+function runValidationTest(source) {
+  const result = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module"],
+    {
+      cwd: new URL("..", import.meta.url),
+      input: source,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`.trim());
+}
+
+test("validReleaseTag accepts npm-style aqua release tags", () => {
+  runValidationTest(`
+    import assert from "node:assert/strict";
+    import { validReleaseTag } from "./web/src/lib/github/mirror.ts";
+
+    assert.equal(validReleaseTag("@biomejs/biome@2.4.16"), true);
+    assert.equal(validReleaseTag("@moonrepo/cli@1.0.0"), true);
+    assert.equal(validReleaseTag("@yarnpkg/cli/4.0.0"), true);
+  `);
+});
+
+test("validReleaseTag accepts common GitHub release tags", () => {
+  runValidationTest(`
+    import assert from "node:assert/strict";
+    import { validReleaseTag } from "./web/src/lib/github/mirror.ts";
+
+    assert.equal(validReleaseTag("v1.0.0"), true);
+    assert.equal(validReleaseTag("latest"), true);
+    assert.equal(validReleaseTag("release/2026"), true);
+  `);
+});
+
+test("validReleaseTag rejects empty and unsafe values", () => {
+  runValidationTest(`
+    import assert from "node:assert/strict";
+    import { validReleaseTag } from "./web/src/lib/github/mirror.ts";
+
+    assert.equal(validReleaseTag(undefined), false);
+    assert.equal(validReleaseTag(""), false);
+    assert.equal(validReleaseTag("tag with spaces"), false);
+    assert.equal(validReleaseTag("tag?query=1"), false);
+  `);
+});

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -112,7 +112,7 @@ export function validRepoPart(value: string | undefined): value is string {
 }
 
 export function validReleaseTag(value: string | undefined): value is string {
-  return !!value && /^[A-Za-z0-9_.\/:+-]+$/.test(value);
+  return !!value && /^[A-Za-z0-9_.\/:@+-]+$/.test(value);
 }
 
 export function validDigest(value: string | undefined): value is string {


### PR DESCRIPTION
## Problem

Registry-backed aqua tools such as **biome** use npm-style GitHub release tags defined in the aqua registry via `version_prefix`, e.g. `@biomejs/biome@2.4.16`. These tags are valid on GitHub and are what mise's aqua backend requests when installing a version.

Since [jdx/mise#10341](https://github.com/jdx/mise/pull/10341), mise routes GitHub release metadata for registry tools through mise-versions first. For biome this produces a spurious warning on every install:

```
mise WARN  mise-versions endpoint=github_release repo=biomejs/biome tag=@biomejs/biome@2.4.16 outcome=failed status=400 fallback=true error="HTTP status client error (400 Bad Request): Invalid GitHub release path"
```

The install still succeeds because mise falls back to the GitHub API directly, but the versions-host cache is never used and users see noisy warnings.

**Root cause:** `validReleaseTag` in `web/src/lib/github/mirror.ts` only allowed `[A-Za-z0-9_.\/:+-]`. The `@` character is not in that set, so the API handler rejects the request with 400 before attempting to mirror the release.

The same issue affects other aqua packages with npm-style prefixes, including `@moonrepo/cli@…` and `@yarnpkg/cli/…`.

## Fix

Allow `@` in `validReleaseTag`. Add unit tests covering biome-style tags and existing common tag formats.

## Test plan

- [x] `aube run test:js` (includes new `scripts/github-mirror-validation.test.js`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release tag validation now supports `@` character for scoped package names.

* **Tests**
  * Added comprehensive test suite for release tag validation, covering npm-style scoped packages, common GitHub release formats, and malformed input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->