### PR TITLE
Serve version TOML files as static assets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "worker/**"
+      - "docs/*.toml"
       - "web/**"
       - "src/**"
       - "wrangler.jsonc"

--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ docs/*.gz
 # Generated files - not tracked in git
 docs/tools.json
 docs/metadata-cache.json
+web/public/data/

--- a/scripts/build-static-version-files.js
+++ b/scripts/build-static-version-files.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Generate static version files served from /data/*.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(SCRIPT_DIR, "..");
+
+export function buildStaticVersionFiles({
+  docsDir = join(REPO_ROOT, "docs"),
+  outputDir = join(REPO_ROOT, "web", "public", "data"),
+} = {}) {
+  if (!existsSync(docsDir)) {
+    throw new Error(`Docs directory not found: ${docsDir}`);
+  }
+
+  rmSync(outputDir, { recursive: true, force: true });
+  mkdirSync(outputDir, { recursive: true });
+
+  const files = readdirSync(docsDir)
+    .filter((file) => file.endsWith(".toml"))
+    .sort();
+
+  for (const file of files) {
+    const tomlContent = readFileSync(join(docsDir, file), "utf8");
+    writeFileSync(join(outputDir, file), tomlContent);
+  }
+
+  return { tools: files.length };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [docsDir, outputDir] = process.argv.slice(2);
+  const result = buildStaticVersionFiles({ docsDir, outputDir });
+  console.log(`Generated static version files for ${result.tools} tools`);
+}

--- a/scripts/build-static-version-files.js
+++ b/scripts/build-static-version-files.js
@@ -10,10 +10,11 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const SCRIPT_DIR = dirname(SCRIPT_PATH);
 const REPO_ROOT = join(SCRIPT_DIR, "..");
 
 export function buildStaticVersionFiles({
@@ -39,7 +40,7 @@ export function buildStaticVersionFiles({
   return { tools: files.length };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
   const [docsDir, outputDir] = process.argv.slice(2);
   const result = buildStaticVersionFiles({ docsDir, outputDir });
   console.log(`Generated static version files for ${result.tools} tools`);

--- a/scripts/build-static-version-files.js
+++ b/scripts/build-static-version-files.js
@@ -8,33 +8,55 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const SCRIPT_DIR = dirname(SCRIPT_PATH);
 const REPO_ROOT = join(SCRIPT_DIR, "..");
 
+function assertSafeOutputDir(docsDir, outputDir) {
+  if (!existsSync(docsDir)) {
+    throw new Error(`Docs directory not found: ${docsDir}`);
+  }
+  if (!statSync(docsDir).isDirectory()) {
+    throw new Error(`Docs path is not a directory: ${docsDir}`);
+  }
+
+  const resolvedDocsDir = resolve(docsDir);
+  const resolvedOutputDir = resolve(outputDir);
+  const docsRelativeToOutput = relative(resolvedOutputDir, resolvedDocsDir);
+  if (
+    resolvedDocsDir === resolvedOutputDir ||
+    (docsRelativeToOutput &&
+      !docsRelativeToOutput.startsWith("..") &&
+      !docsRelativeToOutput.startsWith("/"))
+  ) {
+    throw new Error("outputDir must not be the docsDir or contain docsDir");
+  }
+
+  return { docsDir: resolvedDocsDir, outputDir: resolvedOutputDir };
+}
+
 export function buildStaticVersionFiles({
   docsDir = join(REPO_ROOT, "docs"),
   outputDir = join(REPO_ROOT, "web", "public", "data"),
 } = {}) {
-  if (!existsSync(docsDir)) {
-    throw new Error(`Docs directory not found: ${docsDir}`);
-  }
+  const paths = assertSafeOutputDir(docsDir, outputDir);
 
-  rmSync(outputDir, { recursive: true, force: true });
-  mkdirSync(outputDir, { recursive: true });
+  rmSync(paths.outputDir, { recursive: true, force: true });
+  mkdirSync(paths.outputDir, { recursive: true });
 
-  const files = readdirSync(docsDir)
+  const files = readdirSync(paths.docsDir)
     .filter((file) => file.endsWith(".toml"))
     .sort();
 
   for (const file of files) {
-    const tomlContent = readFileSync(join(docsDir, file), "utf8");
-    writeFileSync(join(outputDir, file), tomlContent);
+    const tomlContent = readFileSync(join(paths.docsDir, file), "utf8");
+    writeFileSync(join(paths.outputDir, file), tomlContent);
   }
 
   return { tools: files.length };

--- a/scripts/build-static-version-files.test.js
+++ b/scripts/build-static-version-files.test.js
@@ -60,4 +60,16 @@ describe("build-static-version-files.js", () => {
     );
     assert.strictEqual(existsSync(join(outputDir, "node")), false);
   });
+
+  it("rejects destructive source and output path collisions", () => {
+    assert.throws(
+      () => buildStaticVersionFiles({ docsDir, outputDir: docsDir }),
+      /outputDir must not be the docsDir/,
+    );
+
+    assert.throws(
+      () => buildStaticVersionFiles({ docsDir, outputDir: tempDir }),
+      /outputDir must not be the docsDir/,
+    );
+  });
 });

--- a/scripts/build-static-version-files.test.js
+++ b/scripts/build-static-version-files.test.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildStaticVersionFiles } from "./build-static-version-files.js";
+
+describe("build-static-version-files.js", () => {
+  let tempDir;
+  let docsDir;
+  let outputDir;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "static-version-files-test-"));
+    docsDir = join(tempDir, "docs");
+    outputDir = join(tempDir, "public", "data");
+    mkdirSync(docsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  it("writes TOML files for each tool", () => {
+    writeFileSync(
+      join(docsDir, "node.toml"),
+      `[versions]
+"20.0.0" = { created_at = 2024-01-01T00:00:00.000Z }
+"22.0.0" = { created_at = 2024-02-01T00:00:00.000Z }
+`,
+      { flag: "wx" },
+    );
+    writeFileSync(
+      join(docsDir, "python.toml"),
+      `[versions]
+"3.12.0" = { created_at = 2024-01-01T00:00:00.000Z }
+`,
+    );
+
+    const result = buildStaticVersionFiles({ docsDir, outputDir });
+
+    assert.deepStrictEqual(result, { tools: 2 });
+    assert.match(
+      readFileSync(join(outputDir, "node.toml"), "utf8"),
+      /\[versions\]/,
+    );
+    assert.match(
+      readFileSync(join(outputDir, "python.toml"), "utf8"),
+      /\[versions\]/,
+    );
+    assert.strictEqual(existsSync(join(outputDir, "node")), false);
+  });
+});

--- a/scripts/web-build.test.js
+++ b/scripts/web-build.test.js
@@ -59,3 +59,13 @@ describe("web build CSS", () => {
     }
   });
 });
+
+describe("web build static version files", () => {
+  it("includes TOML assets under /data", () => {
+    const nodeToml = join(DIST_CLIENT_DIR, "data", "node.toml");
+
+    assert.ok(existsSync(nodeToml), "missing static /data/node.toml asset");
+
+    assert.match(readFileSync(nodeToml, "utf8"), /^\[versions\]/);
+  });
+});

--- a/web/build-pages.sh
+++ b/web/build-pages.sh
@@ -6,10 +6,6 @@ set -e
 
 cd "$(dirname "$0")"
 
-# Copy TOML version files to public/data for static serving
-mkdir -p public/data
-cp ../docs/*.toml public/data/ 2>/dev/null || true
-
 # Build the Astro app
 aube run build
 

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "node ../scripts/build-static-version-files.js && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,7 +14,16 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "web/dist/client",
-    "run_worker_first": true,
+    "run_worker_first": [
+      "/api/*",
+      "/admin*",
+      "/badge/*",
+      "/github/*",
+      "/health",
+      "/stats*",
+      "/tools/*",
+      "/webhooks/*",
+    ],
   },
   "observability": {
     "enabled": true,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,10 +14,15 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "web/dist/client",
+    // Keep dynamic routes Worker-first while allowing generated /data/*.toml
+    // assets to bypass Worker billing. Legacy root routes such as /node.toml,
+    // /python-precompiled.gz, and /tools.json intentionally fall through from
+    // asset lookup to the Worker because they share the root namespace.
     "run_worker_first": [
       "/api/*",
       "/admin*",
       "/badge/*",
+      "/badge.svg",
       "/github/*",
       "/health",
       "/stats*",


### PR DESCRIPTION
## Summary
- generate TOML version files under `web/public/data` during the standard web build
- allow static assets to serve before the Worker for non-dynamic routes, so `/data/:tool.toml` can bypass Worker request billing
- keep existing Worker-backed compatibility routes like `/tools/:tool.toml` and API/admin/stats routes Worker-first

## Notes
- latest mise reads the versions host from `/tools/:tool.toml`, so this PR only creates the new static TOML form (`/data/:tool.toml`) and does not generate extensionless legacy text files
- clients need to switch to `/data/:tool.toml` to get the cost reduction; legacy routes still work unchanged

## Verification
- `aube exec tsc --noEmit --ignoreDeprecations 6.0`
- `aube --dir web run build`
- `aube run test:js`
- `aube run test:shell`
- verified `web/dist/client/data` contains 1000 TOML files and no `/data/node` extensionless asset

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrangler asset routing changes affect which requests hit the Worker; misconfiguration could break API/admin routes or accidentally expose wrong static behavior.
> 
> **Overview**
> Version TOML files are now **generated at build time** into `web/public/data` (via a new Node script) instead of being copied in `build-pages.sh`, and that output is **gitignored**.
> 
> **Cloudflare routing** changes from “Worker first for everything” to a **path allowlist** (`/api/*`, `/admin*`, `/tools/*`, etc.) so **`/data/:tool.toml` is served as static assets** and can skip Worker invocations; legacy Worker-backed routes stay unchanged.
> 
> Deploy workflow now triggers on **`docs/*.toml`** changes, with unit and web-build tests covering generation and dist output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dfb11ace775de46a356d7619c86349a8b387284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now generates static version files under the public data directory before site build, and the site build no longer copies version files from the docs during packaging.
  * Ignore public data directory in VCS.
  * Routing rules updated to apply worker-first handling to key endpoints while streamlining static asset delivery.
  * CI deploy trigger now also runs when version files in docs change.
* **Tests**
  * Added tests to verify static version files are produced, contain version entries, and that unsafe output locations are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->