### PR TITLE
fix(ci): deploy static data after version updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
 
 env:
@@ -60,11 +61,17 @@ jobs:
           API_SECRET: ${{ secrets.TOKEN_MANAGER_SECRET }}
           FULL_SYNC: ${{ inputs.full_sync || 'false' }}
       - name: Push committed versions
+        id: push_versions
         run: |
           git fetch origin main
           if [ "$(git rev-list --count origin/main..HEAD)" -gt 0 ]; then
             git pull --autostash --rebase origin main
             git push
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No local commits to push"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Deploy refreshed static version files
+        if: steps.push_versions.outputs.pushed == 'true'
+        run: gh workflow run deploy.yml --ref main


### PR DESCRIPTION
## Summary
- keep `/data/*.toml` served as static assets for low-cost mise client reads
- have the update workflow explicitly dispatch the deploy workflow after it pushes version commits
- skip the deploy dispatch when an update run has no commits to push

## Root Cause
The update workflow refreshes committed `docs/*.toml` and D1, but its push is made from GitHub Actions. That push does not reliably trigger the `deploy` workflow that rebuilds the static `/data` asset bundle. As a result, dynamic routes could be fresh while `/data/aube.toml` remained stale.

## Validation
- `aube --dir web run build`
- `aube run test`
- `aube exec prettier --check .github/workflows/update.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change: extra deploy trigger and workflow permissions, with no application runtime logic touched in this diff.
> 
> **Overview**
> The **update** workflow now records whether the version push step actually pushed commits, and only then kicks off **deploy**.
> 
> It grants **`actions: write`** so `gh workflow run deploy.yml` can run after a successful push. The push step exposes a **`pushed`** output (`true`/`false`) so deploy is not run when there was nothing new to push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5f2aec15c3e7077241275a99fa4c881aa973d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->