### PR TITLE
[codex] Add focused MAU refresh admin action

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,51 @@
+name: maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Maintenance task to run"
+        required: true
+        type: choice
+        options:
+          - refresh-mau
+      date:
+        description: "Base date in UTC (YYYY-MM-DD); defaults to today"
+        required: false
+        type: string
+      days:
+        description: "Number of days to refresh, counting backward from date"
+        required: false
+        default: "2"
+        type: string
+
+concurrency:
+  group: maintenance-${{ github.event.inputs.task }}
+  cancel-in-progress: false
+
+jobs:
+  refresh-mau:
+    if: github.event.inputs.task == 'refresh-mau'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+
+      - run: aube ci
+
+      - name: Refresh MAU directly
+        run: |
+          args=(--days="${{ github.event.inputs.days || '2' }}")
+          if [ -n "${{ github.event.inputs.date }}" ]; then
+            args+=(--date="${{ github.event.inputs.date }}")
+          fi
+          node scripts/refresh-mau-direct.js "${args[@]}"
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ANALYTICS_ENGINE_ACCOUNT_ID: ${{ secrets.ANALYTICS_ENGINE_ACCOUNT_ID }}
+          ANALYTICS_ENGINE_API_TOKEN: ${{ secrets.ANALYTICS_ENGINE_API_TOKEN }}
+          ANALYTICS_ENGINE_DATASET: mise_analytics_events
+          ANALYTICS_ENGINE_CUTOVER_DATE: "2026-06-12"

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -37,12 +37,14 @@ jobs:
 
       - name: Refresh MAU directly
         run: |
-          args=(--days="${{ github.event.inputs.days || '2' }}")
-          if [ -n "${{ github.event.inputs.date }}" ]; then
-            args+=(--date="${{ github.event.inputs.date }}")
+          args=(--days="${INPUT_DAYS:-2}")
+          if [ -n "$INPUT_DATE" ]; then
+            args+=(--date="$INPUT_DATE")
           fi
           node scripts/refresh-mau-direct.js "${args[@]}"
         env:
+          INPUT_DAYS: ${{ github.event.inputs.days }}
+          INPUT_DATE: ${{ github.event.inputs.date }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           ANALYTICS_ENGINE_ACCOUNT_ID: ${{ secrets.ANALYTICS_ENGINE_ACCOUNT_ID }}

--- a/scripts/refresh-mau-direct.js
+++ b/scripts/refresh-mau-direct.js
@@ -134,6 +134,28 @@ async function queryD1({ accountId, token, databaseId, sql, params = [] }) {
   return rows;
 }
 
+async function legacyD1Mau(config, date, startTs, endTs) {
+  console.log(`Falling back to legacy D1 MAU query for ${date}`);
+  const rows = await queryD1({
+    accountId: config.cloudflareAccountId,
+    token: config.cloudflareApiToken,
+    databaseId: config.analyticsDbId,
+    sql: `
+      SELECT COUNT(DISTINCT ip_hash) as mau FROM (
+        SELECT ip_hash FROM downloads WHERE created_at >= ? AND created_at <= ?
+        UNION ALL
+        SELECT ip_hash FROM version_requests WHERE created_at >= ? AND created_at <= ?
+      )
+    `,
+    params: [startTs, endTs, startTs, endTs],
+  });
+  const mau = Number(rows[0]?.mau ?? 0);
+  if (!Number.isFinite(mau)) {
+    throw new Error(`Unexpected legacy D1 MAU result: ${JSON.stringify(rows)}`);
+  }
+  return mau;
+}
+
 async function refreshMauForDate(config, date) {
   const cutoverDate = config.cutoverDate;
   const cutoverTs = timestamp(`${cutoverDate}T00:00:00`.replace("T", " "));
@@ -186,7 +208,12 @@ async function refreshMauForDate(config, date) {
     for (const row of aeUsers) users.add(row.ip_hash);
   }
 
-  if (users.size <= 0) {
+  let mau = users.size;
+  if (mau <= 0) {
+    mau = await legacyD1Mau(config, date, startTs, endTs);
+  }
+
+  if (mau <= 0) {
     throw new Error(`Refusing to write zero MAU for ${date}`);
   }
 
@@ -198,11 +225,11 @@ async function refreshMauForDate(config, date) {
       INSERT OR REPLACE INTO daily_mau_stats (date, mau)
       VALUES (?, ?)
     `,
-    params: [date, users.size],
+    params: [date, mau],
   });
 
-  console.log(`Refreshed ${date}: ${users.size} MAU`);
-  return { date, mau: users.size };
+  console.log(`Refreshed ${date}: ${mau} MAU`);
+  return { date, mau };
 }
 
 async function main() {

--- a/scripts/refresh-mau-direct.js
+++ b/scripts/refresh-mau-direct.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Refresh daily_mau_stats directly from GitHub Actions.
+ *
+ * This intentionally avoids the Worker/admin endpoint so Cloudflare API errors
+ * are visible in GHA logs. It queries Analytics Engine for distinct users, then
+ * upserts the result with the D1 REST API.
+ */
+
+const DEFAULT_ANALYTICS_DB_ID = "21a8b89a-c2cc-4a8a-9805-b4bcfcd4f6c8";
+const DEFAULT_DATASET = "mise_analytics_events";
+const DEFAULT_CUTOVER_DATE = "2026-06-12";
+
+function usage() {
+  console.error(`Usage: node scripts/refresh-mau-direct.js [--date=YYYY-MM-DD] [--days=N]
+
+Environment:
+  CLOUDFLARE_ACCOUNT_ID       Cloudflare account id
+  CLOUDFLARE_API_TOKEN        Cloudflare API token with D1 edit access
+  ANALYTICS_ENGINE_ACCOUNT_ID Optional; defaults to CLOUDFLARE_ACCOUNT_ID
+  ANALYTICS_ENGINE_API_TOKEN  Optional; defaults to CLOUDFLARE_API_TOKEN
+  ANALYTICS_ENGINE_DATASET    Optional; defaults to ${DEFAULT_DATASET}
+  ANALYTICS_ENGINE_CUTOVER_DATE Optional; defaults to ${DEFAULT_CUTOVER_DATE}
+  ANALYTICS_DB_ID             Optional; defaults to production ANALYTICS_DB id
+`);
+}
+
+function parseArgs(argv) {
+  const args = { date: null, days: 2 };
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    }
+    if (arg.startsWith("--date=")) {
+      args.date = arg.slice("--date=".length);
+    } else if (arg.startsWith("--days=")) {
+      args.days = Number(arg.slice("--days=".length));
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (args.date && !/^\d{4}-\d{2}-\d{2}$/.test(args.date)) {
+    throw new Error(`Invalid --date: ${args.date}`);
+  }
+  if (!Number.isInteger(args.days) || args.days < 1 || args.days > 31) {
+    throw new Error("--days must be an integer from 1 to 31");
+  }
+  return args;
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function dateStrAgo(baseDate, daysAgo) {
+  const d = new Date(`${baseDate}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().split("T")[0];
+}
+
+function dateRange(date) {
+  return {
+    start: `${date} 00:00:00`,
+    end: `${date} 23:59:59`,
+  };
+}
+
+function timestamp(dateTime) {
+  return Math.floor(new Date(`${dateTime}Z`).getTime() / 1000);
+}
+
+async function cfFetch(url, token, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+  const text = await response.text();
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = text;
+  }
+  if (!response.ok || data?.success === false) {
+    throw new Error(
+      `Cloudflare API failed ${response.status}: ${JSON.stringify(data)}`,
+    );
+  }
+  return data;
+}
+
+async function queryAnalyticsEngine({ accountId, token, dataset, sql }) {
+  console.log(`Analytics Engine SQL:\n${sql.trim()}\n`);
+  const data = await cfFetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/analytics_engine/sql`,
+    token,
+    {
+      method: "POST",
+      body: `${sql}\nFORMAT JSON`,
+    },
+  );
+  if (!Array.isArray(data.data)) {
+    throw new Error(
+      `Unexpected Analytics Engine response: ${JSON.stringify(data)}`,
+    );
+  }
+  console.log(`Analytics Engine returned ${data.data.length} row(s)`);
+  return data.data;
+}
+
+async function queryD1({ accountId, token, databaseId, sql, params = [] }) {
+  console.log(`D1 SQL:\n${sql.trim()}\nparams: ${JSON.stringify(params)}\n`);
+  const data = await cfFetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`,
+    token,
+    {
+      method: "POST",
+      body: JSON.stringify({ sql, params }),
+    },
+  );
+  const first = Array.isArray(data.result) ? data.result[0] : data.result;
+  if (!first?.success) {
+    throw new Error(`D1 query failed: ${JSON.stringify(data)}`);
+  }
+  const rows = first.results ?? [];
+  console.log(`D1 returned ${rows.length} row(s)`);
+  return rows;
+}
+
+async function refreshMauForDate(config, date) {
+  const cutoverDate = config.cutoverDate;
+  const cutoverTs = timestamp(`${cutoverDate}T00:00:00`.replace("T", " "));
+  const { end } = dateRange(date);
+  const startDate = new Date(`${date}T23:59:59Z`);
+  startDate.setUTCDate(startDate.getUTCDate() - 30);
+  const start = startDate.toISOString().replace("T", " ").slice(0, 19);
+  const startTs = Math.floor(startDate.getTime() / 1000);
+  const endTs = timestamp(end);
+
+  console.log(`Refreshing MAU for ${date} (${start} to ${end})`);
+
+  const users = new Set();
+  if (startTs < cutoverTs) {
+    const d1End = Math.min(cutoverTs, endTs + 1);
+    const d1Users = await queryD1({
+      accountId: config.cloudflareAccountId,
+      token: config.cloudflareApiToken,
+      databaseId: config.analyticsDbId,
+      sql: `
+        SELECT DISTINCT ip_hash FROM (
+          SELECT ip_hash FROM downloads WHERE created_at >= ? AND created_at < ?
+          UNION
+          SELECT ip_hash FROM version_requests WHERE created_at >= ? AND created_at < ?
+        )
+      `,
+      params: [startTs, d1End, startTs, d1End],
+    });
+    for (const row of d1Users) users.add(row.ip_hash);
+  }
+
+  if (endTs >= cutoverTs) {
+    const aeStart = new Date(Math.max(startTs, cutoverTs) * 1000)
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
+    const aeUsers = await queryAnalyticsEngine({
+      accountId: config.analyticsEngineAccountId,
+      token: config.analyticsEngineApiToken,
+      dataset: config.dataset,
+      sql: `
+        SELECT DISTINCT index1 AS ip_hash
+        FROM ${config.dataset}
+        WHERE
+          blob1 IN ('download', 'version_request')
+          AND timestamp >= toDateTime('${aeStart}')
+          AND timestamp <= toDateTime('${end}')
+      `,
+    });
+    for (const row of aeUsers) users.add(row.ip_hash);
+  }
+
+  if (users.size <= 0) {
+    throw new Error(`Refusing to write zero MAU for ${date}`);
+  }
+
+  await queryD1({
+    accountId: config.cloudflareAccountId,
+    token: config.cloudflareApiToken,
+    databaseId: config.analyticsDbId,
+    sql: `
+      INSERT OR REPLACE INTO daily_mau_stats (date, mau)
+      VALUES (?, ?)
+    `,
+    params: [date, users.size],
+  });
+
+  console.log(`Refreshed ${date}: ${users.size} MAU`);
+  return { date, mau: users.size };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const cloudflareAccountId = requiredEnv("CLOUDFLARE_ACCOUNT_ID");
+  const cloudflareApiToken = requiredEnv("CLOUDFLARE_API_TOKEN");
+  const config = {
+    cloudflareAccountId,
+    cloudflareApiToken,
+    analyticsEngineAccountId:
+      process.env.ANALYTICS_ENGINE_ACCOUNT_ID || cloudflareAccountId,
+    analyticsEngineApiToken:
+      process.env.ANALYTICS_ENGINE_API_TOKEN || cloudflareApiToken,
+    analyticsDbId: process.env.ANALYTICS_DB_ID || DEFAULT_ANALYTICS_DB_ID,
+    dataset: process.env.ANALYTICS_ENGINE_DATASET || DEFAULT_DATASET,
+    cutoverDate:
+      process.env.ANALYTICS_ENGINE_CUTOVER_DATE || DEFAULT_CUTOVER_DATE,
+  };
+
+  const baseDate = args.date || new Date().toISOString().split("T")[0];
+  const dates = Array.from({ length: args.days }, (_, i) =>
+    dateStrAgo(baseDate, i),
+  );
+  console.log(`Refreshing MAU for: ${dates.join(", ")}`);
+
+  const results = [];
+  for (const date of dates) {
+    results.push(await refreshMauForDate(config, date));
+  }
+  console.log(JSON.stringify({ success: true, results }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -50,6 +50,16 @@ if (!auth || !isAdmin(auth.username)) {
             </svg>
             <span id="run-scheduled-text">Run Scheduled Tasks</span>
           </button>
+          <button
+            id="refresh-mau-btn"
+            class="px-3 py-1.5 bg-cyan-400/10 hover:bg-cyan-400/20 border border-cyan-400/40 rounded-lg text-sm text-cyan-300 hover:text-white transition-colors flex items-center gap-1"
+            title="Refresh only today's and yesterday's MAU rollups"
+          >
+            <svg id="refresh-mau-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v6h6M20 20v-6h-6M5.64 18.36A9 9 0 0018.36 5.64M18.36 5.64H14M18.36 5.64V10M5.64 18.36H10M5.64 18.36V14" />
+            </svg>
+            <span id="refresh-mau-text">Refresh MAU</span>
+          </button>
         </div>
       </div>
       <div id="run-scheduled-output" class="hidden border-t border-dark-600 px-4 py-3">
@@ -885,6 +895,44 @@ if (!auth || !isAdmin(auth.username)) {
     }
   }
 
+  async function refreshMau() {
+    const btn = document.getElementById('refresh-mau-btn') as HTMLButtonElement;
+    const text = document.getElementById('refresh-mau-text');
+    const icon = document.getElementById('refresh-mau-icon');
+    const out = document.getElementById('run-scheduled-output');
+    const pre = document.getElementById('run-scheduled-output-pre');
+    if (!btn || !text || !icon || !out || !pre) return;
+    if (!confirm("Refresh today's and yesterday's MAU rollups now?")) {
+      return;
+    }
+    btn.disabled = true;
+    text.textContent = 'Refreshing...';
+    icon.classList.add('animate-spin');
+    out.classList.add('hidden');
+    try {
+      const started = Date.now();
+      const res = await fetch('/api/admin/refresh-mau', { method: 'POST' });
+      const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+      const body = await res.text();
+      let formatted = body;
+      try {
+        formatted = JSON.stringify(JSON.parse(body), null, 2);
+      } catch {
+        // not JSON
+      }
+      pre.textContent = `HTTP ${res.status} in ${elapsed}s\n\n${formatted}`;
+      out.classList.remove('hidden');
+      await loadMaintenanceStatus();
+    } catch (e) {
+      pre.textContent = `Error: ${e}`;
+      out.classList.remove('hidden');
+    } finally {
+      btn.disabled = false;
+      text.textContent = 'Refresh MAU';
+      icon.classList.remove('animate-spin');
+    }
+  }
+
   // Initialize
   // Load data
   loadAdminData();
@@ -906,4 +954,5 @@ if (!auth || !isAdmin(auth.username)) {
   document.getElementById('table-counts-expand-btn')?.addEventListener('click', toggleTableCountsExpanded);
   document.getElementById('refresh-btn')?.addEventListener('click', refreshAll);
   document.getElementById('run-scheduled-btn')?.addEventListener('click', runScheduled);
+  document.getElementById('refresh-mau-btn')?.addEventListener('click', refreshMau);
 </script>

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -856,6 +856,13 @@ if (!auth || !isAdmin(auth.username)) {
     }
   }
 
+  function setMaintenanceButtonsDisabled(disabled: boolean) {
+    const runBtn = document.getElementById('run-scheduled-btn') as HTMLButtonElement | null;
+    const mauBtn = document.getElementById('refresh-mau-btn') as HTMLButtonElement | null;
+    if (runBtn) runBtn.disabled = disabled;
+    if (mauBtn) mauBtn.disabled = disabled;
+  }
+
   async function runScheduled() {
     const btn = document.getElementById('run-scheduled-btn') as HTMLButtonElement;
     const text = document.getElementById('run-scheduled-text');
@@ -866,7 +873,7 @@ if (!auth || !isAdmin(auth.username)) {
     if (!confirm('Run the daily maintenance pipeline now? This may take 30+ seconds.')) {
       return;
     }
-    btn.disabled = true;
+    setMaintenanceButtonsDisabled(true);
     text.textContent = 'Running...';
     icon.classList.add('animate-spin');
     out.classList.add('hidden');
@@ -889,7 +896,7 @@ if (!auth || !isAdmin(auth.username)) {
       pre.textContent = `Error: ${e}`;
       out.classList.remove('hidden');
     } finally {
-      btn.disabled = false;
+      setMaintenanceButtonsDisabled(false);
       text.textContent = 'Run Scheduled Tasks';
       icon.classList.remove('animate-spin');
     }
@@ -905,7 +912,7 @@ if (!auth || !isAdmin(auth.username)) {
     if (!confirm("Refresh today's and yesterday's MAU rollups now?")) {
       return;
     }
-    btn.disabled = true;
+    setMaintenanceButtonsDisabled(true);
     text.textContent = 'Refreshing...';
     icon.classList.add('animate-spin');
     out.classList.add('hidden');
@@ -927,7 +934,7 @@ if (!auth || !isAdmin(auth.username)) {
       pre.textContent = `Error: ${e}`;
       out.classList.remove('hidden');
     } finally {
-      btn.disabled = false;
+      setMaintenanceButtonsDisabled(false);
       text.textContent = 'Refresh MAU';
       icon.classList.remove('animate-spin');
     }

--- a/web/src/pages/api/admin/refresh-mau.ts
+++ b/web/src/pages/api/admin/refresh-mau.ts
@@ -30,14 +30,24 @@ export const POST: APIRoute = async ({ request }) => {
     });
 
     const targets = [dateStrAgo(0), dateStrAgo(1)];
-    const results = [];
+    const results: Array<{
+      date: string;
+      ok: boolean;
+      refreshed?: boolean;
+      error?: string;
+    }> = [];
     for (const date of targets) {
       try {
         const refreshed = await analytics.populateDailyMauStats(
           date,
           env.ANALYTICS_DB,
         );
-        results.push({ date, ok: true, refreshed });
+        results.push({
+          date,
+          ok: refreshed === true,
+          refreshed,
+          ...(refreshed === true ? {} : { error: "No MAU row was refreshed" }),
+        });
       } catch (error) {
         results.push({
           date,

--- a/web/src/pages/api/admin/refresh-mau.ts
+++ b/web/src/pages/api/admin/refresh-mau.ts
@@ -1,0 +1,60 @@
+import type { APIRoute } from "astro";
+import { drizzle } from "drizzle-orm/d1";
+import { env } from "cloudflare:workers";
+import { setupAnalytics } from "../../../../../src/analytics";
+import { jsonResponse, errorResponse } from "../../../lib/api";
+import { requireBearerOrAdmin } from "../../../lib/admin";
+
+function dateStrAgo(daysAgo: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().split("T")[0];
+}
+
+// POST /api/admin/refresh-mau - Refresh just the user-visible MAU rollups.
+// This is intentionally much narrower than /api/admin/scheduled so admins can
+// repair the stats page without running every daily maintenance task.
+export const POST: APIRoute = async ({ request }) => {
+  const auth = await requireBearerOrAdmin(request, env.API_SECRET);
+  if (auth instanceof Response) return auth;
+
+  try {
+    const db = drizzle(env.ANALYTICS_DB);
+    const analytics = setupAnalytics(db, {
+      analyticsEngine: {
+        accountId: env.ANALYTICS_ENGINE_ACCOUNT_ID,
+        apiToken: env.ANALYTICS_ENGINE_API_TOKEN,
+        dataset: env.ANALYTICS_ENGINE_DATASET,
+        cutoverDate: env.ANALYTICS_ENGINE_CUTOVER_DATE,
+      },
+    });
+
+    const targets = [dateStrAgo(0), dateStrAgo(1)];
+    const results = [];
+    for (const date of targets) {
+      try {
+        const refreshed = await analytics.populateDailyMauStats(
+          date,
+          env.ANALYTICS_DB,
+        );
+        results.push({ date, ok: true, refreshed });
+      } catch (error) {
+        results.push({
+          date,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const failed = results.filter((r) => !r.ok);
+    return jsonResponse({
+      success: failed.length === 0,
+      results,
+      failed_count: failed.length,
+    });
+  } catch (error) {
+    console.error("Refresh MAU error:", error);
+    return errorResponse("Failed to refresh MAU", 500);
+  }
+};


### PR DESCRIPTION
## Summary

- Add `POST /api/admin/refresh-mau` to refresh only today and yesterday's MAU rollups.
- Add a separate **Refresh MAU** button in the admin Maintenance card.
- Add a manual `maintenance` GitHub Actions workflow that refreshes MAU directly via Cloudflare APIs instead of going through the Worker.
- Add `scripts/refresh-mau-direct.js`, which queries Analytics Engine SQL, includes the pre-cutover D1 user range when needed, and upserts `daily_mau_stats` through the D1 REST API.

## Why

The existing **Run Scheduled Tasks** button runs the full maintenance pipeline inside one admin request. Under D1 pressure, that can queue behind expensive rollup and summary work and make the admin request look like the site locked up.

The new GHA path gives us a better operator control plane: SQL statements, Cloudflare API responses, and D1/Analytics Engine errors are visible directly in Actions logs, and the job is not tied to a browser tab or a user-facing Worker request.

## Validation

- `aube --dir web run build`
- `node --check scripts/refresh-mau-direct.js`
- `node scripts/refresh-mau-direct.js --help`
- `aube exec prettier --check .github/workflows/maintenance.yml scripts/refresh-mau-direct.js`

Note: `aube --dir web exec tsc` currently stops on an existing TypeScript 6 `baseUrl` deprecation in `web/tsconfig.json` before checking this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production analytics rollups and D1 writes with Cloudflare API tokens in GHA; scope is limited to MAU repair and admin-gated endpoints.
> 
> **Overview**
> Adds a **narrow MAU repair path** so operators can refresh `daily_mau_stats` for today and yesterday without running the full daily maintenance pipeline.
> 
> **Admin API & UI:** New `POST /api/admin/refresh-mau` (same auth as other admin routes) calls `populateDailyMauStats` for the last two UTC dates. The Maintenance card gets a **Refresh MAU** button that shares the scheduled-task output panel; both maintenance buttons disable together while either job runs.
> 
> **GitHub Actions:** New `workflow_dispatch` **maintenance** workflow (`refresh-mau` task) runs `scripts/refresh-mau-direct.js` with optional `date` / `days` inputs, using repo secrets for Cloudflare D1 and Analytics Engine. The script queries distinct users (D1 pre-cutover + Analytics Engine post-cutover), refuses zero MAU writes, and upserts `daily_mau_stats` via the D1 REST API so failures show in Actions logs instead of a long-lived Worker request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e440e87ff30c4d98cf2b8d2005404f942680f6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->