### PR TITLE
[codex] Fix Analytics Engine user list queries

### DIFF
--- a/scripts/refresh-mau-direct.js
+++ b/scripts/refresh-mau-direct.js
@@ -197,12 +197,13 @@ async function refreshMauForDate(config, date) {
       token: config.analyticsEngineApiToken,
       dataset: config.dataset,
       sql: `
-        SELECT DISTINCT index1 AS ip_hash
+        SELECT index1 AS ip_hash
         FROM ${config.dataset}
         WHERE
           blob1 IN ('download', 'version_request')
           AND timestamp >= toDateTime('${aeStart}')
           AND timestamp <= toDateTime('${end}')
+        GROUP BY index1
       `,
     });
     for (const row of aeUsers) users.add(row.ip_hash);

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -212,12 +212,13 @@ export function createRollupFunctions(
       const aeUsers = await queryAnalyticsEngine<{ ip_hash: string }>(
         analyticsEngine!,
         `
-          SELECT DISTINCT index1 AS ip_hash
+          SELECT index1 AS ip_hash
           FROM ${table}
           WHERE
             blob1 = 'version_request'
             AND timestamp >= toDateTime('${start}')
             AND timestamp <= toDateTime('${end}')
+          GROUP BY index1
         `,
       );
       const aeStats = await queryAnalyticsEngine<{ total: number }>(
@@ -529,9 +530,10 @@ export function createRollupFunctions(
       const aeCombinedUsers = await queryAnalyticsEngine<{ ip_hash: string }>(
         analyticsEngine!,
         `
-          SELECT DISTINCT index1 AS ip_hash
+          SELECT index1 AS ip_hash
           FROM ${table}
           WHERE blob1 IN ('download', 'version_request') AND ${range}
+          GROUP BY index1
         `,
       );
       combinedDau = new Set([
@@ -809,12 +811,13 @@ export function createRollupFunctions(
         const result = await queryAnalyticsEngine<{ ip_hash: string }>(
           analyticsEngine!,
           `
-            SELECT DISTINCT index1 AS ip_hash
+            SELECT index1 AS ip_hash
             FROM ${table}
             WHERE
               blob1 IN ('download', 'version_request')
               AND timestamp >= toDateTime('${aeStart}')
               AND timestamp <= toDateTime('${end}')
+            GROUP BY index1
           `,
         );
         for (const row of result.rows) users.add(row.ip_hash);

--- a/src/analytics/trends.ts
+++ b/src/analytics/trends.ts
@@ -62,12 +62,13 @@ export function createTrendsFunctions(
           const result = await queryAnalyticsEngine<{ ip_hash: string }>(
             analyticsEngine!,
             `
-              SELECT DISTINCT index1 AS ip_hash
+              SELECT index1 AS ip_hash
               FROM ${table}
               WHERE
                 blob1 = 'version_request'
                 AND timestamp >= toDateTime('${aeStart}')
                 AND timestamp <= toDateTime('${aeEnd}')
+              GROUP BY index1
             `,
           );
           for (const row of result.rows) users.add(row.ip_hash);

--- a/src/analytics/versions.ts
+++ b/src/analytics/versions.ts
@@ -53,12 +53,13 @@ export function createVersionsFunctions(
           const result = await queryAnalyticsEngine<{ ip_hash: string }>(
             analyticsEngine!,
             `
-              SELECT DISTINCT index1 AS ip_hash
+              SELECT index1 AS ip_hash
               FROM ${table}
               WHERE
                 blob1 = 'version_request'
                 AND timestamp >= toDateTime('${aeStart}')
                 AND timestamp <= toDateTime('${aeEnd}')
+              GROUP BY index1
             `,
           );
           for (const row of result.rows) users.add(row.ip_hash);


### PR DESCRIPTION
## Summary

- Replace row-returning Analytics Engine `SELECT DISTINCT index1` queries with `SELECT index1 ... GROUP BY index1`.
- Update both Worker rollup code and the direct GHA MAU refresh script.

## Why

The newly added maintenance workflow surfaced the underlying Analytics Engine failure:

`Cloudflare API failed 422: "Input was invalid: selection used unsupported features: SELECT DISTINCT "`

Analytics Engine accepts aggregate distinct counts in existing paths, but rejects row-returning `SELECT DISTINCT`. Grouping by `index1` returns the same unique user list without that unsupported construct.

## Validation

- `aube exec prettier --write src/analytics/versions.ts src/analytics/trends.ts src/analytics/rollups.ts scripts/refresh-mau-direct.js`
- `node --check scripts/refresh-mau-direct.js`
- `aube exec tsc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how unique users are fetched from Analytics Engine; semantics should match DISTINCT but incorrect grouping would skew MAU/DAU and rollup stats.
> 
> **Overview**
> Fixes **422** failures from Cloudflare Analytics Engine on queries that returned distinct `index1` rows (`SELECT DISTINCT` is unsupported for row lists; aggregate `count(DISTINCT …)` paths are unchanged).
> 
> Every affected query now uses **`SELECT index1 … GROUP BY index1`** (aliased as `ip_hash` where needed) so MAU/DAU rollups and live metrics still build the same unique-user sets from `index1`.
> 
> Touches **`scripts/refresh-mau-direct.js`** (GHA MAU refresh) and Worker analytics in **`rollups.ts`**, **`trends.ts`**, and **`versions.ts`**—version-request users, combined download+version_request users, and cutover-aware MAU paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8594951ecd3aa05ccb1e71d1c97057a40d6d2d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->