### PR TITLE
[codex] Skip install in maintenance workflow

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -33,8 +33,6 @@ jobs:
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
 
-      - run: aube ci
-
       - name: Refresh MAU directly
         run: |
           args=(--days="${INPUT_DAYS:-2}")


### PR DESCRIPTION
## Summary

- Remove the `aube ci` step from the manual maintenance workflow.

## Why

The direct MAU refresh script only uses Node built-ins, and `mise-action` already installs the configured Node runtime. A one-day maintenance retry got stuck in `aube ci` before reaching the refresh step, so the install step is unnecessary overhead and another failure point.

## Validation

- `aube exec prettier --check .github/workflows/maintenance.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a manual workflow; the refresh step is unchanged aside from skipping dependency install.
> 
> **Overview**
> The manual **maintenance** workflow’s `refresh-mau` job no longer runs **`aube ci`** before **`node scripts/refresh-mau-direct.js`**.
> 
> Checkout and **`mise-action`** remain, so the job still gets the configured Node runtime without a full monorepo install. That trims time and avoids failures in the install step when the refresh script only needs Node built-ins and Cloudflare secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96caa1b7df884b2372b6f99a0de2e6be86a47bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->