### PR TITLE
fix(api): decode percent-encoded GitHub release tags before validation

### DIFF
--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -11,7 +11,18 @@ import {
 import { isRegisteredGitHubRepo } from "../../../../../../../lib/github/registry";
 
 export const GET: APIRoute = async ({ params }) => {
-  const { owner, repo, tag } = params;
+  const { owner, repo } = params;
+  // Cloudflare/Astro preserves percent-encoded characters (notably %2F) in
+  // catch-all path params rather than decoding them, so tags such as
+  // `@biomejs/biome@2.5.0` arrive here as `%40biomejs%2Fbiome%402.5.0` and would
+  // otherwise be rejected by `validReleaseTag`.
+  let tag: string | undefined;
+  try {
+    tag =
+      typeof params.tag === "string" ? decodeURIComponent(params.tag) : undefined;
+  } catch {
+    return errorResponse("Invalid GitHub release path", 400);
+  }
   if (!validRepoPart(owner) || !validRepoPart(repo) || !validReleaseTag(tag)) {
     return errorResponse("Invalid GitHub release path", 400);
   }


### PR DESCRIPTION
## Summary

Mise clients percent-encode each path segment per RFC 3986 when calling `mise-versions.jdx.dev`. For release tags that contain `/` or `@` (npm-style aqua tags like `@biomejs/biome@2.5.0`), Cloudflare/Astro preserves the encoded chars in the catch-all `[...tag]` param rather than decoding them — so the endpoint sees `%40biomejs%2Fbiome%402.5.0` and `validReleaseTag` rejects it.

This fix decodes the catch-all `tag` param before validation. Malformed percent sequences raise `URIError`, which is caught and returned as 400, matching the existing failure mode.

## Repro

```bash
curl -sS -o /dev/null -w '%{http_code}\n' \
  'https://mise-versions.jdx.dev/api/github/repos/biomejs/biome/releases/%40biomejs%2Fbiome%402.5.0'
# 400 "Invalid GitHub release path"

# Raw chars (no encoding) work today:
curl -sS -o /dev/null -w '%{http_code}\n' --path-as-is \
  'https://mise-versions.jdx.dev/api/github/repos/biomejs/biome/releases/@biomejs/biome@2.5.0'
# 200
```

## Real-world impact

In mise (`src/versions_host.rs:295` `github_release`), every URL segment is passed through `urlencoding::encode`. For biome on mise `2026.6.12`:

```
mise WARN  mise-versions endpoint=github_release repo=biomejs/biome
  tag=@biomejs/biome@2.5.0 outcome=failed status=400 fallback=true
  error="HTTP status client error (400 Bad Request): Invalid GitHub release path"
```

The fallback to direct GitHub API kicks in so it isn't fatal, but every `mise lock` / install for tools with scoped tags pays an extra failed request and emits a noisy warning. Existing test `validReleaseTag accepts npm-style aqua release tags` already proves the validator accepts these tags once decoded.

## Test plan

- [x] Manual: `curl` against deployed instance (current behavior 400)
- [ ] After deploy: same curl returns 200
- [ ] Existing `github-mirror-validation.test.js` continues to pass

Happy to add a unit test for the endpoint handler if you'd like — wasn't sure of the preferred mocking shape since existing endpoint coverage in `scripts/api-track.test.js` reimplements the handler locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub release API to properly handle special characters and percent-encoded characters in release tag URLs, preventing incorrect release lookups.
  * Added validation with improved error handling for malformed release paths, returning a clear error response when decoding fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->