### PR TITLE
fix: allow erlang GitHub release repos

### DIFF
--- a/scripts/github-registry.test.js
+++ b/scripts/github-registry.test.js
@@ -53,6 +53,17 @@ test("GitHub registry allowlist rejects unknown repos", async () => {
   assert.equal(allowed, false);
 });
 
+test("GitHub registry allowlist includes Erlang release repos", async () => {
+  const db = {
+    prepare() {
+      throw new Error("database should not be queried");
+    },
+  };
+
+  assert.equal(await isRegisteredGitHubRepo(db, "Erlang", "OTP"), true);
+  assert.equal(await isRegisteredGitHubRepo(db, "Erlef", "OTP_Builds"), true);
+});
+
 test("GitHub attestation allowlist includes python-build-standalone", () => {
   assert.equal(
     isKnownGitHubAttestationRepo("Astral-Sh", "Python-Build-Standalone"),
@@ -61,5 +72,8 @@ test("GitHub attestation allowlist includes python-build-standalone", () => {
 });
 
 test("GitHub attestation allowlist rejects unknown repos", () => {
-  assert.equal(isKnownGitHubAttestationRepo("crate-ci", "cargo-release"), false);
+  assert.equal(
+    isKnownGitHubAttestationRepo("crate-ci", "cargo-release"),
+    false,
+  );
 });

--- a/web/src/lib/github/registry.ts
+++ b/web/src/lib/github/registry.ts
@@ -1,8 +1,8 @@
 const GITHUB_BACKEND_PREFIXES = ["aqua", "github", "ubi"] as const;
 
-const GITHUB_ATTESTATION_REPOS = new Set([
-  "astral-sh/python-build-standalone",
-]);
+const GITHUB_RELEASE_REPOS = new Set(["erlang/otp", "erlef/otp_builds"]);
+
+const GITHUB_ATTESTATION_REPOS = new Set(["astral-sh/python-build-standalone"]);
 
 function normalizeRepo(owner: string, repo: string): string {
   return `${owner}/${repo}`.toLowerCase();
@@ -18,6 +18,10 @@ export async function isRegisteredGitHubRepo(
   repo: string,
 ): Promise<boolean> {
   const slug = normalizeRepo(owner, repo);
+  if (GITHUB_RELEASE_REPOS.has(slug)) {
+    return true;
+  }
+
   const exactBackends = GITHUB_BACKEND_PREFIXES.map(
     (backend) => `${backend}:${slug}`,
   );


### PR DESCRIPTION
## Summary
- allow `erlang/otp` and `erlef/otp_builds` through the GitHub release mirror registry check
- add regression coverage for the static Erlang release repo allowlist

## Tests
- `mise exec -- aube ci`
- `mise exec -- aube --dir web run build`
- `mise exec -- aube run test:js`
- `mise exec -- tsc`
- `mise exec -- hk check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, explicit allowlist before existing DB logic; scope limited to two known Erlang release repos with unit test coverage.
> 
> **Overview**
> **GitHub release mirror** access no longer depends on the analytics `tools` registry for the official Erlang OTP sources.
> 
> `isRegisteredGitHubRepo` now short-circuits on a static `GITHUB_RELEASE_REPOS` set (`erlang/otp`, `erlef/otp_builds`) after normalizing owner/repo casing, so those repos pass the same gate used by repo/release API routes without a D1 query. Regression tests assert both slugs are allowed and that the database is never hit for them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 993abecad4c00ae59d7f7aa0a1f91af367baae0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->