### PR TITLE
fix(sync): include registry-only tools in metadata sync

### DIFF
--- a/scripts/sync-to-d1.js
+++ b/scripts/sync-to-d1.js
@@ -313,16 +313,18 @@ function appendRegistryOnlyTools(
   existingToolNames = new Set(),
   excludedPrefixes = EXCLUDED_PREFIXES,
 ) {
-  const seen = new Set(tools.map((tool) => tool.name));
+  const existingNames = new Set(tools.map((tool) => tool.name));
   for (const name of existingToolNames) {
-    seen.add(name);
+    existingNames.add(name);
   }
+  const appendedNames = new Set();
   let added = 0;
 
   for (const registryTool of registryTools) {
     if (excludedToolName(registryTool.name, excludedPrefixes)) continue;
     const names = [registryTool.name, ...(registryTool.aliases || [])];
-    if (names.some((name) => seen.has(name))) continue;
+    if (names.some((name) => existingNames.has(name))) continue;
+    if (appendedNames.has(registryTool.name)) continue;
     tools.push(
       buildToolMetadata(
         registryTool.name,
@@ -336,9 +338,7 @@ function appendRegistryOnlyTools(
         manualOverrides[registryTool.name],
       ),
     );
-    for (const name of names) {
-      seen.add(name);
-    }
+    appendedNames.add(registryTool.name);
     added++;
   }
 

--- a/scripts/sync-to-d1.js
+++ b/scripts/sync-to-d1.js
@@ -13,13 +13,15 @@
  */
 
 import { readFileSync, readdirSync, existsSync } from "fs";
-import { join, basename } from "path";
+import { join, basename, resolve } from "path";
+import { fileURLToPath } from "url";
 import { parse } from "smol-toml";
 import { execSync } from "child_process";
 import { fetchWithRetry } from "./lib/fetch-with-retry.js";
 
 const DOCS_DIR = join(process.cwd(), "docs");
 const MANUAL_OVERRIDES_FILE = join(DOCS_DIR, "manual-overrides.json");
+const EXCLUDED_PREFIXES = ["python-precompiled"];
 
 // Fallback for tools that do not expose explicit prerelease metadata in TOML.
 // Prefer `prerelease = true` from mise where present; this catches older and
@@ -82,6 +84,7 @@ function registryInfoFromEntries(entries) {
     if (!entry.short) continue;
     const info = {
       name: entry.short,
+      aliases: Array.isArray(entry.aliases) ? entry.aliases : [],
       backends: entry.backends || [],
       description: entry.description || null,
       security: entry.security || [],
@@ -299,12 +302,27 @@ function buildToolMetadata(name, metadata, registryInfo, overrides) {
   return tool;
 }
 
-function appendRegistryOnlyTools(tools, registryTools, manualOverrides) {
+function excludedToolName(name, excludedPrefixes = EXCLUDED_PREFIXES) {
+  return excludedPrefixes.some((prefix) => name.startsWith(prefix));
+}
+
+function appendRegistryOnlyTools(
+  tools,
+  registryTools,
+  manualOverrides,
+  existingToolNames = new Set(),
+  excludedPrefixes = EXCLUDED_PREFIXES,
+) {
   const seen = new Set(tools.map((tool) => tool.name));
+  for (const name of existingToolNames) {
+    seen.add(name);
+  }
   let added = 0;
 
   for (const registryTool of registryTools) {
-    if (seen.has(registryTool.name)) continue;
+    if (excludedToolName(registryTool.name, excludedPrefixes)) continue;
+    const names = [registryTool.name, ...(registryTool.aliases || [])];
+    if (names.some((name) => seen.has(name))) continue;
     tools.push(
       buildToolMetadata(
         registryTool.name,
@@ -318,7 +336,9 @@ function appendRegistryOnlyTools(tools, registryTools, manualOverrides) {
         manualOverrides[registryTool.name],
       ),
     );
-    seen.add(registryTool.name);
+    for (const name of names) {
+      seen.add(name);
+    }
     added++;
   }
 
@@ -366,12 +386,12 @@ async function main() {
   }
 
   // Find all .toml files in docs/, excluding internal tools
-  const EXCLUDED_PREFIXES = ["python-precompiled"];
   const files = readdirSync(DOCS_DIR).filter((f) => {
     if (!f.endsWith(".toml")) return false;
     const toolName = basename(f, ".toml");
-    return !EXCLUDED_PREFIXES.some((prefix) => toolName.startsWith(prefix));
+    return !excludedToolName(toolName);
   });
+  const tomlToolNames = new Set(files.map((f) => basename(f, ".toml")));
   console.log(`Found ${files.length} TOML files`);
 
   const tools = [];
@@ -402,6 +422,7 @@ async function main() {
     tools,
     registryInfo.tools,
     manualOverrides,
+    tomlToolNames,
   );
 
   // Sort tools alphabetically
@@ -460,13 +481,17 @@ async function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
   main();
 }
 
 export {
   appendRegistryOnlyTools,
   buildToolMetadata,
+  excludedToolName,
   registryInfoFromEntries,
   summarizeTools,
 };

--- a/scripts/sync-to-d1.js
+++ b/scripts/sync-to-d1.js
@@ -63,6 +63,45 @@ function runMiseRegistry(args) {
   });
 }
 
+function emptyRegistryInfo() {
+  return { lookup: new Map(), tools: [] };
+}
+
+function registryInfoFromEntries(entries) {
+  const lookup = new Map();
+  const tools = [];
+
+  // First pass: index every `short`. The previous per-tool
+  // `mise tool <name> --json` call resolved aliases automatically,
+  // so we second-pass each entry's `aliases` to preserve that
+  // behavior for any TOML file whose name is an alias rather than a
+  // short. Shorts win over aliases (so an explicitly-named tool
+  // never has its metadata clobbered by another tool that happens
+  // to alias the same string).
+  for (const entry of entries) {
+    if (!entry.short) continue;
+    const info = {
+      name: entry.short,
+      backends: entry.backends || [],
+      description: entry.description || null,
+      security: entry.security || [],
+    };
+    lookup.set(entry.short, info);
+    tools.push(info);
+  }
+  for (const entry of entries) {
+    if (!entry.short || !Array.isArray(entry.aliases)) continue;
+    const info = lookup.get(entry.short);
+    if (!info) continue;
+    for (const alias of entry.aliases) {
+      if (!alias || lookup.has(alias)) continue;
+      lookup.set(alias, info);
+    }
+  }
+
+  return { lookup, tools };
+}
+
 function getRegistryInfo() {
   let output;
   try {
@@ -82,41 +121,15 @@ function getRegistryInfo() {
       console.error(
         `Warning: Failed to get mise registry: ${fallbackErr.message}`,
       );
-      return new Map();
+      return emptyRegistryInfo();
     }
   }
 
   try {
-    const entries = JSON.parse(output);
-    const infoMap = new Map();
-    // First pass: index every `short`. The previous per-tool
-    // `mise tool <name> --json` call resolved aliases automatically,
-    // so we second-pass each entry's `aliases` to preserve that
-    // behavior for any TOML file whose name is an alias rather than a
-    // short. Shorts win over aliases (so an explicitly-named tool
-    // never has its metadata clobbered by another tool that happens
-    // to alias the same string).
-    for (const entry of entries) {
-      if (!entry.short) continue;
-      infoMap.set(entry.short, {
-        backends: entry.backends || [],
-        description: entry.description || null,
-        security: entry.security || [],
-      });
-    }
-    for (const entry of entries) {
-      if (!entry.short || !Array.isArray(entry.aliases)) continue;
-      const info = infoMap.get(entry.short);
-      if (!info) continue;
-      for (const alias of entry.aliases) {
-        if (!alias || infoMap.has(alias)) continue;
-        infoMap.set(alias, info);
-      }
-    }
-    return infoMap;
+    return registryInfoFromEntries(JSON.parse(output));
   } catch (e) {
     console.error(`Warning: Failed to parse mise registry: ${e.message}`);
-    return new Map();
+    return emptyRegistryInfo();
   }
 }
 
@@ -221,6 +234,108 @@ function processTomlFile(filePath) {
   }
 }
 
+function buildToolMetadata(name, metadata, registryInfo, overrides) {
+  const tool = {
+    name,
+    ...metadata,
+  };
+  const info = registryInfo || {
+    backends: [],
+    description: null,
+    security: [],
+  };
+
+  if (info.description) {
+    tool.description = info.description;
+  }
+
+  if (info.security && info.security.length > 0) {
+    tool.security = info.security;
+  }
+
+  const backends = info.backends || [];
+  tool.backends = backends;
+  if (backends.length > 0) {
+    const packageUrls = buildPackageUrls(backends);
+    if (packageUrls) {
+      tool.package_urls = packageUrls;
+    }
+
+    const aquaLink = buildAquaLink(backends);
+    if (aquaLink) {
+      tool.aqua_link = aquaLink;
+    }
+
+    for (const backend of backends) {
+      const slug = extractGithubSlug(backend);
+      if (slug) {
+        tool.github = slug;
+        tool.repo_url = buildRepoUrl(slug);
+        break;
+      }
+    }
+  }
+  if (!tool.github && name.includes("/")) {
+    tool.github = name;
+    tool.repo_url = buildRepoUrl(name);
+  }
+
+  if (overrides) {
+    if (overrides.github) {
+      tool.github = overrides.github;
+      tool.repo_url = buildRepoUrl(overrides.github);
+    }
+    if (overrides.description) {
+      tool.description = overrides.description;
+    }
+    if (overrides.homepage) {
+      tool.homepage = overrides.homepage;
+    }
+    if (overrides.license) {
+      tool.license = overrides.license;
+    }
+  }
+
+  return tool;
+}
+
+function appendRegistryOnlyTools(tools, registryTools, manualOverrides) {
+  const seen = new Set(tools.map((tool) => tool.name));
+  let added = 0;
+
+  for (const registryTool of registryTools) {
+    if (seen.has(registryTool.name)) continue;
+    tools.push(
+      buildToolMetadata(
+        registryTool.name,
+        {
+          latest_version: null,
+          latest_stable_version: null,
+          version_count: 0,
+          last_updated: null,
+        },
+        registryTool,
+        manualOverrides[registryTool.name],
+      ),
+    );
+    seen.add(registryTool.name);
+    added++;
+  }
+
+  return added;
+}
+
+function summarizeTools(tools) {
+  return {
+    withGithub: tools.filter((tool) => tool.github).length,
+    withDesc: tools.filter((tool) => tool.description).length,
+    withBackends: tools.filter((tool) => tool.backends?.length > 0).length,
+    withPackageUrls: tools.filter(
+      (tool) => tool.package_urls && Object.keys(tool.package_urls).length > 0,
+    ).length,
+  };
+}
+
 async function main() {
   const apiUrl = process.env.SYNC_API_URL;
   const apiSecret = process.env.API_SECRET;
@@ -239,8 +354,9 @@ async function main() {
 
   // Load backends + descriptions for every tool in one mise call.
   console.log("Loading registry info from mise...");
-  const registryMap = getRegistryInfo();
-  console.log(`Loaded registry info for ${registryMap.size} tools`);
+  const registryInfo = getRegistryInfo();
+  const registryMap = registryInfo.lookup;
+  console.log(`Loaded registry info for ${registryInfo.tools.length} tools`);
 
   // Load manual overrides
   const manualOverrides = loadManualOverrides();
@@ -259,10 +375,6 @@ async function main() {
   console.log(`Found ${files.length} TOML files`);
 
   const tools = [];
-  let withGithub = 0;
-  let withDesc = 0;
-  let withBackends = 0;
-  let withPackageUrls = 0;
 
   for (const file of files) {
     const toolName = basename(file, ".toml");
@@ -270,81 +382,14 @@ async function main() {
     const metadata = processTomlFile(filePath);
 
     if (metadata) {
-      const tool = {
-        name: toolName,
-        ...metadata,
-      };
-
-      const registryInfo = registryMap.get(toolName) || {
-        backends: [],
-        description: null,
-        security: [],
-      };
-
-      if (registryInfo.description) {
-        tool.description = registryInfo.description;
-        withDesc++;
-      }
-
-      if (registryInfo.security && registryInfo.security.length > 0) {
-        tool.security = registryInfo.security;
-      }
-
-      // Backends always set (default empty). github/repo_url/package urls
-      // derive from the backend list.
-      const backends = registryInfo.backends;
-      tool.backends = backends;
-      if (backends.length > 0) {
-        withBackends++;
-
-        const packageUrls = buildPackageUrls(backends);
-        if (packageUrls) {
-          tool.package_urls = packageUrls;
-          withPackageUrls++;
-        }
-
-        const aquaLink = buildAquaLink(backends);
-        if (aquaLink) {
-          tool.aqua_link = aquaLink;
-        }
-
-        for (const backend of backends) {
-          const slug = extractGithubSlug(backend);
-          if (slug) {
-            tool.github = slug;
-            tool.repo_url = buildRepoUrl(slug);
-            withGithub++;
-            break;
-          }
-        }
-      }
-      if (!tool.github && toolName.includes("/")) {
-        tool.github = toolName;
-        tool.repo_url = buildRepoUrl(toolName);
-        withGithub++;
-      }
-
-      // Apply manual overrides (highest priority)
-      const overrides = manualOverrides[toolName];
-      if (overrides) {
-        if (overrides.github) {
-          tool.github = overrides.github;
-          tool.repo_url = buildRepoUrl(overrides.github);
-          if (!tool.github) withGithub++;
-        }
-        if (overrides.description) {
-          if (!tool.description) withDesc++;
-          tool.description = overrides.description;
-        }
-        if (overrides.homepage) {
-          tool.homepage = overrides.homepage;
-        }
-        if (overrides.license) {
-          tool.license = overrides.license;
-        }
-      }
-
-      tools.push(tool);
+      tools.push(
+        buildToolMetadata(
+          toolName,
+          metadata,
+          registryMap.get(toolName),
+          manualOverrides[toolName],
+        ),
+      );
     }
 
     if (tools.length % 100 === 0) {
@@ -353,14 +398,22 @@ async function main() {
   }
   console.log(`\rProcessed ${tools.length} tools`);
 
+  const registryOnlyTools = appendRegistryOnlyTools(
+    tools,
+    registryInfo.tools,
+    manualOverrides,
+  );
+
   // Sort tools alphabetically
   tools.sort((a, b) => a.name.localeCompare(b.name));
 
+  const summary = summarizeTools(tools);
   console.log(`Built manifest with ${tools.length} tools:`);
-  console.log(`  - ${withGithub} with GitHub`);
-  console.log(`  - ${withDesc} with description`);
-  console.log(`  - ${withBackends} with backends`);
-  console.log(`  - ${withPackageUrls} with package URLs`);
+  console.log(`  - ${registryOnlyTools} registry-only`);
+  console.log(`  - ${summary.withGithub} with GitHub`);
+  console.log(`  - ${summary.withDesc} with description`);
+  console.log(`  - ${summary.withBackends} with backends`);
+  console.log(`  - ${summary.withPackageUrls} with package URLs`);
 
   // POST to sync endpoint
   const syncUrl = `${apiUrl}/api/admin/tools/sync`;
@@ -407,4 +460,13 @@ async function main() {
   }
 }
 
-main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export {
+  appendRegistryOnlyTools,
+  buildToolMetadata,
+  registryInfoFromEntries,
+  summarizeTools,
+};

--- a/scripts/sync-to-d1.test.js
+++ b/scripts/sync-to-d1.test.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  appendRegistryOnlyTools,
+  buildToolMetadata,
+  registryInfoFromEntries,
+  summarizeTools,
+} from "./sync-to-d1.js";
+
+describe("sync-to-d1.js", () => {
+  it("indexes registry shorts and aliases while preserving primary tools", () => {
+    const registry = registryInfoFromEntries([
+      {
+        short: "aws-cli",
+        aliases: ["aws", "awscli"],
+        backends: ["aqua:aws/aws-cli"],
+        description: "AWS CLI",
+        security: ["checksum"],
+      },
+    ]);
+
+    assert.equal(registry.tools.length, 1);
+    assert.equal(registry.tools[0].name, "aws-cli");
+    assert.equal(registry.lookup.get("aws"), registry.lookup.get("aws-cli"));
+    assert.equal(registry.lookup.get("awscli"), registry.lookup.get("aws-cli"));
+  });
+
+  it("builds registry-only rows with GitHub allowlist metadata", () => {
+    const tool = buildToolMetadata(
+      "snyk",
+      {
+        latest_version: null,
+        latest_stable_version: null,
+        version_count: 0,
+        last_updated: null,
+      },
+      {
+        name: "snyk",
+        backends: ["aqua:snyk/cli", "github:snyk/cli"],
+        description: "Snyk CLI",
+        security: [],
+      },
+    );
+
+    assert.deepEqual(tool, {
+      name: "snyk",
+      latest_version: null,
+      latest_stable_version: null,
+      version_count: 0,
+      last_updated: null,
+      description: "Snyk CLI",
+      backends: ["aqua:snyk/cli", "github:snyk/cli"],
+      aqua_link:
+        "https://github.com/aquaproj/aqua-registry/blob/main/pkgs/snyk/cli/registry.yaml",
+      github: "snyk/cli",
+      repo_url: "https://github.com/snyk/cli",
+    });
+  });
+
+  it("appends registry-only tools without replacing TOML-backed rows", () => {
+    const tools = [
+      {
+        name: "act",
+        latest_version: "0.2.80",
+        latest_stable_version: "0.2.80",
+        version_count: 10,
+        backends: ["aqua:nektos/act"],
+      },
+    ];
+    const added = appendRegistryOnlyTools(
+      tools,
+      [
+        {
+          name: "act",
+          backends: ["aqua:nektos/act"],
+          description: "Run GitHub Actions locally",
+          security: [],
+        },
+        {
+          name: "dasel",
+          backends: ["aqua:TomWright/dasel"],
+          description: "Data selector",
+          security: [],
+        },
+      ],
+      {},
+    );
+
+    assert.equal(added, 1);
+    assert.equal(tools.length, 2);
+    assert.equal(tools[0].version_count, 10);
+    assert.deepEqual(tools[1], {
+      name: "dasel",
+      latest_version: null,
+      latest_stable_version: null,
+      version_count: 0,
+      last_updated: null,
+      description: "Data selector",
+      backends: ["aqua:TomWright/dasel"],
+      aqua_link:
+        "https://github.com/aquaproj/aqua-registry/blob/main/pkgs/TomWright/dasel/registry.yaml",
+      github: "TomWright/dasel",
+      repo_url: "https://github.com/TomWright/dasel",
+    });
+  });
+
+  it("summarizes final manifest fields after registry-only rows are added", () => {
+    const summary = summarizeTools([
+      {
+        name: "node",
+        description: "Node.js",
+        github: "nodejs/node",
+        backends: ["core:node"],
+      },
+      {
+        name: "cargo-tool",
+        backends: ["cargo:cargo-tool"],
+        package_urls: { cargo: "https://crates.io/crates/cargo-tool" },
+      },
+    ]);
+
+    assert.deepEqual(summary, {
+      withGithub: 1,
+      withDesc: 1,
+      withBackends: 2,
+      withPackageUrls: 1,
+    });
+  });
+});

--- a/scripts/sync-to-d1.test.js
+++ b/scripts/sync-to-d1.test.js
@@ -1,14 +1,33 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { describe, it } from "node:test";
 import {
   appendRegistryOnlyTools,
   buildToolMetadata,
+  excludedToolName,
   registryInfoFromEntries,
   summarizeTools,
 } from "./sync-to-d1.js";
 
+const REPO_ROOT = new URL("..", import.meta.url).pathname;
+
 describe("sync-to-d1.js", () => {
+  it("runs main when invoked by relative script path", () => {
+    const result = spawnSync(process.execPath, ["scripts/sync-to-d1.js"], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        API_SECRET: "",
+        SYNC_API_URL: "",
+      },
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /SYNC_API_URL/);
+  });
+
   it("indexes registry shorts and aliases while preserving primary tools", () => {
     const registry = registryInfoFromEntries([
       {
@@ -22,6 +41,7 @@ describe("sync-to-d1.js", () => {
 
     assert.equal(registry.tools.length, 1);
     assert.equal(registry.tools[0].name, "aws-cli");
+    assert.deepEqual(registry.tools[0].aliases, ["aws", "awscli"]);
     assert.equal(registry.lookup.get("aws"), registry.lookup.get("aws-cli"));
     assert.equal(registry.lookup.get("awscli"), registry.lookup.get("aws-cli"));
   });
@@ -103,6 +123,67 @@ describe("sync-to-d1.js", () => {
       github: "TomWright/dasel",
       repo_url: "https://github.com/TomWright/dasel",
     });
+  });
+
+  it("does not add registry-only rows for existing TOMLs or aliases", () => {
+    const tools = [];
+    const added = appendRegistryOnlyTools(
+      tools,
+      [
+        {
+          name: "aws-cli",
+          aliases: ["aws", "awscli"],
+          backends: ["aqua:aws/aws-cli"],
+          description: "AWS CLI",
+          security: [],
+        },
+        {
+          name: "broken-tool",
+          aliases: [],
+          backends: ["github:example/broken-tool"],
+          description: "Has a TOML, but it failed processing",
+          security: [],
+        },
+        {
+          name: "snyk",
+          aliases: [],
+          backends: ["aqua:snyk/cli"],
+          description: "Snyk CLI",
+          security: [],
+        },
+      ],
+      {},
+      new Set(["aws", "broken-tool"]),
+    );
+
+    assert.equal(added, 1);
+    assert.deepEqual(
+      tools.map((tool) => tool.name),
+      ["snyk"],
+    );
+  });
+
+  it("keeps excluded prefixes out of registry-only rows", () => {
+    assert.equal(excludedToolName("python-precompiled-linux-arm64"), true);
+    assert.equal(excludedToolName("python"), false);
+
+    const tools = [];
+    const added = appendRegistryOnlyTools(
+      tools,
+      [
+        {
+          name: "python-precompiled-linux-arm64",
+          aliases: [],
+          backends: ["github:astral-sh/python-build-standalone"],
+          description: "internal data file",
+          security: [],
+        },
+      ],
+      {},
+    );
+
+    assert.equal(added, 0);
+    assert.deepEqual(tools, []);
   });
 
   it("summarizes final manifest fields after registry-only rows are added", () => {

--- a/scripts/sync-to-d1.test.js
+++ b/scripts/sync-to-d1.test.js
@@ -163,6 +163,36 @@ describe("sync-to-d1.js", () => {
     );
   });
 
+  it("does not let appended registry aliases suppress registry shorts", () => {
+    const tools = [];
+    const added = appendRegistryOnlyTools(
+      tools,
+      [
+        {
+          name: "main-tool",
+          aliases: ["alias-tool"],
+          backends: ["github:example/main-tool"],
+          description: "Main tool",
+          security: [],
+        },
+        {
+          name: "alias-tool",
+          aliases: [],
+          backends: ["github:example/alias-tool"],
+          description: "Separate tool with an overlapping short",
+          security: [],
+        },
+      ],
+      {},
+    );
+
+    assert.equal(added, 2);
+    assert.deepEqual(
+      tools.map((tool) => tool.name),
+      ["main-tool", "alias-tool"],
+    );
+  });
+
   it("keeps excluded prefixes out of registry-only rows", () => {
     assert.equal(excludedToolName("python-precompiled-linux-arm64"), true);
     assert.equal(excludedToolName("python"), false);


### PR DESCRIPTION
## Summary
- add registry-only tools to the D1 sync payload with `version_count = 0` when no `docs/<tool>.toml` exists
- preserve registry backend/GitHub metadata for those rows so the GitHub mirror allowlist is not coupled to generated TOML files
- add focused tests for registry alias lookup, registry-only rows, and summary counts

## Tests
- `node --test scripts/sync-to-d1.test.js`
- `node --test scripts/*.test.js`
- `npx prettier --check scripts/sync-to-d1.js scripts/sync-to-d1.test.js`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the synced tool set and D1 upsert/delete behavior; logic is covered by tests but wrong dedup could add duplicate or missing tools in production metadata.
> 
> **Overview**
> The D1 sync manifest now **includes mise registry tools that lack a `docs/<tool>.toml`**, with null versions and `version_count: 0`, while still attaching registry backends, GitHub/repo URLs, and manual overrides so metadata (e.g. GitHub mirror allowlists) is not tied to generated TOMLs.
> 
> **Refactor:** registry parsing returns `{ lookup, tools }`; shared helpers (`buildToolMetadata`, `appendRegistryOnlyTools`, `excludedToolName`, `summarizeTools`) replace inlined logic. Registry-only rows are skipped when a TOML exists (by short or alias), when a TOML filename is present even if processing failed, or for excluded prefixes like `python-precompiled`. Logging adds a **registry-only** count.
> 
> **Tests:** new `scripts/sync-to-d1.test.js` covers alias lookup, registry-only append rules, exclusions, and CLI entry when run as `scripts/sync-to-d1.js`. Exports and a main guard allow importing without auto-running sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee31a1e8bb1db1075460121e00fa8327cbf549c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->