### PR TITLE
fix(update): unskip stable version sync tools

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -542,8 +542,10 @@ fetch() {
 	local attempt="${2:-1}"
 	local status_file="$RESULTS_DIR/$tool.status"
 
+	# Keep only tools with unresolved sync blockers: fake/internal tools,
+	# unstable ordering, duplicate alias output, or mixed release channels.
 	case "$tool" in
-	awscli-local | jfrog-cli | minio | tiny | teleport-ent | flyctl | flyway | vim | awscli | aws | aws-cli | checkov | snyk | chromedriver | sui | rebar | dasel | cockroach)
+	tiny | vim | awscli | aws | aws-cli | chromedriver | sui)
 		echo "skipped" >"$status_file"
 		return
 		;;

--- a/scripts/update.test.sh
+++ b/scripts/update.test.sh
@@ -148,7 +148,10 @@ echo "--- Skip List Tests ---"
 skip_list_contains() {
 	local tool="$1"
 	local skipped_tools
-	skipped_tools=$(sed -n '/case "\$tool" in/{n;p;}' scripts/update.sh |
+	skipped_tools=$(awk '
+		/^fetch\(\) \{/ { in_fetch = 1; next }
+		in_fetch && /case "\$tool" in/ { getline; print; exit }
+	' scripts/update.sh |
 		tr '|' '\n' |
 		sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/\)$//' |
 		grep -v '^$')
@@ -183,6 +186,11 @@ test_phase_2_keeps_unresolved_tools_skipped() {
 	done
 }
 test_phase_2_keeps_unresolved_tools_skipped
+
+test_skip_list_parser_ignores_other_case_blocks() {
+	assert_skip_list_membership "cargo-binstall" "false" "cargo-binstall post-processing is not treated as hard-skipped"
+}
+test_skip_list_parser_ignores_other_case_blocks
 
 echo ""
 

--- a/scripts/update.test.sh
+++ b/scripts/update.test.sh
@@ -141,6 +141,52 @@ test_pipe_to_generate_toml
 echo ""
 
 # ============================================
+# Test: update skip list
+# ============================================
+echo "--- Skip List Tests ---"
+
+skip_list_contains() {
+	local tool="$1"
+	local skipped_tools
+	skipped_tools=$(sed -n '/case "\$tool" in/{n;p;}' scripts/update.sh |
+		tr '|' '\n' |
+		sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/\)$//' |
+		grep -v '^$')
+
+	grep -Fxq "$tool" <<<"$skipped_tools"
+}
+
+assert_skip_list_membership() {
+	local tool="$1"
+	local expected="$2"
+	local description="$3"
+	local actual="false"
+	if skip_list_contains "$tool"; then
+		actual="true"
+	fi
+
+	assert_equals "$expected" "$actual" "$description"
+}
+
+test_phase_2_unskips_stable_tools() {
+	local tool
+	for tool in awscli-local jfrog-cli minio teleport-ent flyctl flyway checkov snyk rebar dasel cockroach; do
+		assert_skip_list_membership "$tool" "false" "$tool is no longer hard-skipped"
+	done
+}
+test_phase_2_unskips_stable_tools
+
+test_phase_2_keeps_unresolved_tools_skipped() {
+	local tool
+	for tool in tiny vim aws aws-cli awscli chromedriver sui; do
+		assert_skip_list_membership "$tool" "true" "$tool remains hard-skipped"
+	done
+}
+test_phase_2_keeps_unresolved_tools_skipped
+
+echo ""
+
+# ============================================
 # Test: Statistics helpers (isolated)
 # ============================================
 echo "--- Statistics Helper Tests ---"


### PR DESCRIPTION
## Summary
- remove audited stable tools from the hard skip list so the update job can generate TOML for them again
- keep unresolved tools skipped: `tiny`, `vim`, `aws`/`aws-cli`/`awscli`, `chromedriver`, and `sui`
- add shell tests that pin both the newly unskipped tools and the intentionally skipped tools

## Audit
`MISE_USE_VERSIONS_HOST=0 MISE_LIST_ALL_VERSIONS=1 MISE_EXPERIMENTAL=1 mise -y ls-remote --prerelease --json <tool>` returned non-empty JSON for:

- `awscli-local`: 25 versions, latest observed `0.22.2`
- `jfrog-cli`: 60 versions, latest observed `2.112.0`
- `minio`: 7 versions, latest observed `2025.01.20.14.49.07`
- `teleport-ent`: 780 versions, latest observed `18.9.2`
- `flyctl`: 1329 versions, latest observed `0.4.63`
- `flyway`: 302 versions, latest observed `12.10.0`
- `checkov`: 409 versions, latest observed `3.3.6`
- `snyk`: 1787 versions, latest observed `1.1305.2`
- `rebar`: 77 versions, latest observed `3.27.0`
- `dasel`: 110 versions, latest observed `3.11.2`
- `cockroach`: 951 versions, latest observed `26.2.2`

## Left skipped
- `tiny`: fake/internal test plugin
- `vim`: observed unstable ordering between runs
- `aws`/`aws-cli`/`awscli`: duplicate alias/canonical TOML handling needs a separate decision
- `chromedriver`: newest-first output would make the TOML last entry stale unless sorted first
- `sui`: mixed `devnet`/`testnet`/`mainnet` channels need an explicit channel strategy

## Tests
- `node --test scripts/*.test.js`
- `bash scripts/update.test.sh`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only which tools are skipped in the update script and adds regression tests; no auth, data pipeline, or runtime behavior outside the scheduled sync job.
> 
> **Overview**
> Narrows the **`fetch()`** hard-skip list so the update job can sync TOML for eleven previously audited tools (`awscli-local`, `jfrog-cli`, `minio`, `teleport-ent`, `flyctl`, `flyway`, `checkov`, `snyk`, `rebar`, `dasel`, `cockroach`).
> 
> **Still skipped** are tools with known sync blockers: internal/fake (`tiny`), unstable ordering (`vim`), AWS alias duplication (`aws` / `aws-cli` / `awscli`), newest-first ordering (`chromedriver`), and mixed release channels (`sui`). A short comment in `update.sh` documents that intent.
> 
> **`update.test.sh`** adds skip-list tests that parse only the `fetch()` `case` block (so post-processing tools like `cargo-binstall` are not mistaken for hard-skips) and pin both the unskipped and still-skipped sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd3a6f0c8850d1927fce9a27c33cdbdc69c20a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->