### PR TITLE
fix(update): omit moving version tags from TOML

### DIFF
--- a/scripts/generate-toml.js
+++ b/scripts/generate-toml.js
@@ -43,22 +43,43 @@ const UNSTABLE_TOOLS = existsSync(UNSTABLE_TOOLS_PATH)
     )
   : new Set();
 
-const IGNORED_VERSIONS_PATH = new URL(
-  "./ignored-versions.toml",
-  import.meta.url,
-).pathname;
+const IGNORED_VERSIONS_PATH =
+  process.env.MISE_VERSIONS_IGNORED_VERSIONS_PATH ||
+  new URL("./ignored-versions.toml", import.meta.url).pathname;
 
 function loadIgnoredVersionPatterns(path) {
   if (!existsSync(path)) return new Map();
 
-  const config = parse(readFileSync(path, "utf-8"));
+  let config;
+  try {
+    config = parse(readFileSync(path, "utf-8"));
+  } catch (e) {
+    console.error(
+      `Warning: Failed to read ignored versions config ${path}: ${e.message}`,
+    );
+    return new Map();
+  }
+
   const patterns = new Map();
   for (const [toolName, toolConfig] of Object.entries(config)) {
     const deny = Array.isArray(toolConfig?.deny) ? toolConfig.deny : [];
-    patterns.set(
-      toolName,
-      deny.map((pattern) => new RegExp(pattern)),
-    );
+    const compiled = [];
+    for (const pattern of deny) {
+      if (typeof pattern !== "string") {
+        console.error(
+          `Warning: Invalid ignored version pattern for ${toolName}: expected string, got ${typeof pattern}`,
+        );
+        continue;
+      }
+      try {
+        compiled.push(new RegExp(pattern));
+      } catch (e) {
+        console.error(
+          `Warning: Invalid ignored version pattern for ${toolName}: ${pattern}: ${e.message}`,
+        );
+      }
+    }
+    patterns.set(toolName, compiled);
   }
   return patterns;
 }

--- a/scripts/generate-toml.js
+++ b/scripts/generate-toml.js
@@ -43,6 +43,30 @@ const UNSTABLE_TOOLS = existsSync(UNSTABLE_TOOLS_PATH)
     )
   : new Set();
 
+const IGNORED_VERSIONS_PATH = new URL(
+  "./ignored-versions.toml",
+  import.meta.url,
+).pathname;
+
+function loadIgnoredVersionPatterns(path) {
+  if (!existsSync(path)) return new Map();
+
+  const config = parse(readFileSync(path, "utf-8"));
+  const patterns = new Map();
+  for (const [toolName, toolConfig] of Object.entries(config)) {
+    const deny = Array.isArray(toolConfig?.deny) ? toolConfig.deny : [];
+    patterns.set(
+      toolName,
+      deny.map((pattern) => new RegExp(pattern)),
+    );
+  }
+  return patterns;
+}
+
+const IGNORED_VERSION_PATTERNS = loadIgnoredVersionPatterns(
+  IGNORED_VERSIONS_PATH,
+);
+
 if (!tool) {
   console.error(
     "Usage: cat versions.ndjson | node generate-toml.js <tool> [existing_toml_path]",
@@ -122,7 +146,10 @@ if (existingTomlPath && existsSync(existingTomlPath)) {
 }
 
 // Parse new version data (preserves order from mise ls-remote)
-const newVersions = parseNdjson(stdinData);
+const ignoredVersionPatterns = IGNORED_VERSION_PATTERNS.get(tool) || [];
+const newVersions = parseNdjson(stdinData).filter(
+  (v) => !ignoredVersionPatterns.some((pattern) => pattern.test(v.version)),
+);
 
 // For "unstable" tools, sort by semver ascending so the output is
 // deterministic regardless of which fetch path produced the input. Versions

--- a/scripts/generate-toml.test.js
+++ b/scripts/generate-toml.test.js
@@ -314,6 +314,56 @@ describe("generate-toml.js", () => {
     });
   });
 
+  describe("ignored moving version tags", () => {
+    const ignoredVersions = [
+      ["bottom", "nightly-b3694fc3-1782177088"],
+      ["crush", "nightly"],
+      ["expert", "nightly"],
+      ["goreleaser", "2.17.0-cd5f16b4-nightly"],
+      ["infracost", "preview"],
+      ["k0sctl", "dev"],
+      ["liquibase", "nightly"],
+      ["rust-analyzer", "nightly"],
+      ["task", "nightly"],
+      ["yazi", "nightly"],
+      ["zig", "master"],
+    ];
+
+    for (const [toolName, ignoredVersion] of ignoredVersions) {
+      it(`should omit ${ignoredVersion} for ${toolName}`, async () => {
+        const input = [
+          '{"version":"1.0.0","created_at":"2024-01-01T00:00:00Z"}',
+          JSON.stringify({
+            version: ignoredVersion,
+            created_at: "2024-01-02T00:00:00Z",
+            prerelease: true,
+          }),
+        ].join("\n");
+
+        const { stdout, code } = await runGenerateToml(input, [toolName]);
+        assert.strictEqual(code, 0);
+
+        const parsed = parse(stdout);
+        assert.ok(parsed.versions["1.0.0"]);
+        assert.strictEqual(parsed.versions[ignoredVersion], undefined);
+      });
+    }
+
+    it("should keep nightly for tools without ignored-version config", async () => {
+      const input = [
+        '{"version":"1.0.0","created_at":"2024-01-01T00:00:00Z"}',
+        '{"version":"nightly","created_at":"2024-01-02T00:00:00Z","prerelease":true}',
+      ].join("\n");
+
+      const { stdout, code } = await runGenerateToml(input, ["test-tool"]);
+      assert.strictEqual(code, 0);
+
+      const parsed = parse(stdout);
+      assert.ok(parsed.versions["1.0.0"]);
+      assert.strictEqual(parsed.versions.nightly.prerelease, true);
+    });
+  });
+
   describe("unstable tool sorting", () => {
     it("should preserve input order for tools not in the unstable list", async () => {
       // terraform-style backport pattern: 0.12.30 published after 0.14.3

--- a/scripts/generate-toml.test.js
+++ b/scripts/generate-toml.test.js
@@ -319,6 +319,7 @@ describe("generate-toml.js", () => {
       ["bottom", "nightly-b3694fc3-1782177088"],
       ["crush", "nightly"],
       ["expert", "nightly"],
+      ["goreleaser", "nightly"],
       ["goreleaser", "2.17.0-cd5f16b4-nightly"],
       ["infracost", "preview"],
       ["k0sctl", "dev"],

--- a/scripts/generate-toml.test.js
+++ b/scripts/generate-toml.test.js
@@ -21,9 +21,10 @@ const SCRIPT_PATH = new URL("./generate-toml.js", import.meta.url).pathname;
 /**
  * Run generate-toml.js with given stdin input and arguments
  */
-function runGenerateToml(stdinInput, args = []) {
+function runGenerateToml(stdinInput, args = [], options = {}) {
   return new Promise((resolve, reject) => {
     const proc = spawn("node", [SCRIPT_PATH, ...args], {
+      env: { ...process.env, ...options.env },
       stdio: ["pipe", "pipe", "pipe"],
     });
 
@@ -362,6 +363,59 @@ describe("generate-toml.js", () => {
       const parsed = parse(stdout);
       assert.ok(parsed.versions["1.0.0"]);
       assert.strictEqual(parsed.versions.nightly.prerelease, true);
+    });
+
+    it("should warn and ignore malformed ignored-version config", async () => {
+      const ignoredVersionsToml = join(tempDir, "ignored-versions.toml");
+      writeFileSync(ignoredVersionsToml, "[test-tool\n");
+
+      const input = '{"version":"nightly","created_at":"2024-01-02T00:00:00Z"}';
+      const { stdout, stderr, code } = await runGenerateToml(
+        input,
+        ["test-tool"],
+        {
+          env: {
+            MISE_VERSIONS_IGNORED_VERSIONS_PATH: ignoredVersionsToml,
+          },
+        },
+      );
+      assert.strictEqual(code, 0);
+      assert.ok(stderr.includes("Warning: Failed to read ignored versions"));
+      assert.ok(parse(stdout).versions.nightly);
+    });
+
+    it("should warn and skip invalid ignored-version regexes", async () => {
+      const ignoredVersionsToml = join(tempDir, "ignored-versions.toml");
+      writeFileSync(
+        ignoredVersionsToml,
+        `[test-tool]
+deny = ["[unclosed", "^nightly$"]
+`,
+      );
+
+      const input = [
+        '{"version":"nightly","created_at":"2024-01-02T00:00:00Z"}',
+        '{"version":"1.0.0","created_at":"2024-01-01T00:00:00Z"}',
+      ].join("\n");
+      const { stdout, stderr, code } = await runGenerateToml(
+        input,
+        ["test-tool"],
+        {
+          env: {
+            MISE_VERSIONS_IGNORED_VERSIONS_PATH: ignoredVersionsToml,
+          },
+        },
+      );
+      assert.strictEqual(code, 0);
+      assert.ok(
+        stderr.includes(
+          "Warning: Invalid ignored version pattern for test-tool: [unclosed",
+        ),
+      );
+
+      const parsed = parse(stdout);
+      assert.ok(parsed.versions["1.0.0"]);
+      assert.strictEqual(parsed.versions.nightly, undefined);
     });
   });
 

--- a/scripts/ignored-versions.toml
+++ b/scripts/ignored-versions.toml
@@ -1,0 +1,39 @@
+# Tool-specific moving version tags that should not be written to docs/*.toml.
+#
+# The version catalog is meant to track immutable releases. Channels such as
+# "nightly", "dev", "preview", and "master" can point at different artifacts
+# over time, so recording their changing created_at metadata causes noisy churn.
+# Keep these patterns narrow and tool-scoped so normal prerelease tags remain.
+
+[bottom]
+deny = ["^nightly-"]
+
+[crush]
+deny = ["^nightly$"]
+
+[expert]
+deny = ["^nightly$"]
+
+[goreleaser]
+deny = ["-nightly$"]
+
+[infracost]
+deny = ["^preview$"]
+
+[k0sctl]
+deny = ["^dev$"]
+
+[liquibase]
+deny = ["^nightly$"]
+
+[rust-analyzer]
+deny = ["^nightly$"]
+
+[task]
+deny = ["^nightly$"]
+
+[yazi]
+deny = ["^nightly$"]
+
+[zig]
+deny = ["^master$"]

--- a/scripts/ignored-versions.toml
+++ b/scripts/ignored-versions.toml
@@ -15,7 +15,7 @@ deny = ["^nightly$"]
 deny = ["^nightly$"]
 
 [goreleaser]
-deny = ["-nightly$"]
+deny = ["^nightly$", "-nightly$"]
 
 [infracost]
 deny = ["^preview$"]


### PR DESCRIPTION
## Summary
- add a tool-scoped ignored-version config for moving channel tags
- filter configured moving tags before writing docs/*.toml
- cover nightly/dev/preview/master and rolling nightly patterns from recent commit churn

## Validation
- mise x -- aube run test
- mise x -- hk check
- mise x -- aube --dir web run build
- node --test scripts/*.test.js
- bash scripts/update.test.sh
- npx prettier --check scripts/generate-toml.js scripts/generate-toml.test.js

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the version-catalog generator with fail-open warnings; no auth, runtime install, or API behavior.
> 
> **Overview**
> Stops **moving channel tags** (e.g. `nightly`, `dev`, `preview`, `master`) from being written into `docs/*.toml`, so automated updates no longer churn when those tags point at new artifacts and `created_at` shifts.
> 
> Adds **`scripts/ignored-versions.toml`** with per-tool `deny` regex lists and wires **`generate-toml.js`** to load them (default path or `MISE_VERSIONS_IGNORED_VERSIONS_PATH`), drop matching versions after NDJSON parse, and **warn** on unreadable config or invalid patterns without failing the run. Tools without config are unchanged.
> 
> Tests cover each configured tool/tag pair, unconfigured tools keeping `nightly`, and malformed config / bad regex handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d9d4b236ac0a8468c9d4b33501a82487a01e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->