### PR TITLE
Harden maintenance rollups

### DIFF
--- a/src/analytics/analytics-engine.ts
+++ b/src/analytics/analytics-engine.ts
@@ -11,8 +11,18 @@ export interface AnalyticsEngineQueryResult<T> {
   rows: T[];
 }
 
+const ANALYTICS_ENGINE_RETRY_ATTEMPTS = 3;
+
 function backendType(full: string | null): string {
   return full?.split(":")[0] || "unknown";
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableAnalyticsEngineFailure(status: number) {
+  return status === 429 || status >= 500;
 }
 
 export function writeDownloadEvent(
@@ -95,36 +105,52 @@ export async function queryAnalyticsEngine<T>(
     throw new Error("Analytics Engine SQL credentials are not configured");
   }
 
-  const response = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/analytics_engine/sql`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${config.apiToken}`,
+  for (let attempt = 0; attempt <= ANALYTICS_ENGINE_RETRY_ATTEMPTS; attempt++) {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/analytics_engine/sql`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.apiToken}`,
+        },
+        body: `${query}\nFORMAT JSON`,
       },
-      body: `${query}\nFORMAT JSON`,
-    },
-  );
+    );
 
-  const text = await response.text();
-  if (!response.ok) {
+    const text = await response.text();
+    if (!response.ok) {
+      if (
+        attempt < ANALYTICS_ENGINE_RETRY_ATTEMPTS &&
+        isRetryableAnalyticsEngineFailure(response.status)
+      ) {
+        const delay = 2 ** attempt * 1000;
+        console.warn(
+          `Analytics Engine query failed: ${response.status} ${text}; retrying in ${delay}ms`,
+        );
+        await sleep(delay);
+        continue;
+      }
+
+      throw new Error(
+        `Analytics Engine query failed: ${response.status} ${text}`,
+      );
+    }
+
+    try {
+      const parsed = JSON.parse(text) as { data?: T[]; errors?: unknown };
+      if (Array.isArray(parsed.data)) {
+        return { rows: parsed.data };
+      }
+    } catch {
+      // Fall through to a clearer error below.
+    }
+
     throw new Error(
-      `Analytics Engine query failed: ${response.status} ${text}`,
+      `Unexpected Analytics Engine response: ${text.slice(0, 200)}`,
     );
   }
 
-  try {
-    const parsed = JSON.parse(text) as { data?: T[]; errors?: unknown };
-    if (Array.isArray(parsed.data)) {
-      return { rows: parsed.data };
-    }
-  } catch {
-    // Fall through to a clearer error below.
-  }
-
-  throw new Error(
-    `Unexpected Analytics Engine response: ${text.slice(0, 200)}`,
-  );
+  throw new Error("Analytics Engine query failed after retries");
 }
 
 export function dateRangeSql(date: string) {

--- a/src/analytics/analytics-engine.ts
+++ b/src/analytics/analytics-engine.ts
@@ -150,6 +150,8 @@ export async function queryAnalyticsEngine<T>(
     );
   }
 
+  // Unreachable in practice: the bounded loop returns, throws, or continues on
+  // every iteration. Keep this to satisfy TypeScript control-flow analysis.
   throw new Error("Analytics Engine query failed after retries");
 }
 

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -363,7 +363,6 @@ export function createRollupFunctions(
       const users = new Set([...d1UserSet, ...aeUserSet]);
 
       const total = (d1Stats?.total ?? 0) + aeNumber(aeStats.rows[0]?.total);
-      if (total <= 0) return null;
 
       if (d1) {
         await d1
@@ -399,7 +398,6 @@ export function createRollupFunctions(
     const stats = result.rows[0];
     const total = aeNumber(stats?.total);
     const uniqueUsers = aeNumber(stats?.unique_users);
-    if (total <= 0) return null;
 
     if (d1) {
       await d1
@@ -1127,7 +1125,7 @@ export function createRollupFunctions(
       )
       .get();
 
-    if (stats && stats.total > 0) {
+    if (stats) {
       if (d1) {
         await d1
           .prepare(

--- a/src/maintenance-pipeline.ts
+++ b/src/maintenance-pipeline.ts
@@ -15,6 +15,7 @@ import { runAnalyticsMigrations, setupAnalytics } from "./analytics/index.js";
 
 const ROLLUP_BACKFILL_DAYS = 31;
 const MAU_BACKFILL_GAP_LIMIT = 1;
+const TRANSIENT_RETRY_ATTEMPTS = 3;
 
 interface PipelineEnv {
   DB: D1Database;
@@ -85,9 +86,8 @@ export async function runMaintenancePipeline(
     const failures: string[] = [];
     for (const date of targets) {
       try {
-        const refreshed = await analytics.populateDailyMauStats(
-          date,
-          env.ANALYTICS_DB,
+        const refreshed = await withTransientRetry(`mau ${date}`, () =>
+          analytics.populateDailyMauStats(date, env.ANALYTICS_DB),
         );
         if (refreshed) {
           ok++;
@@ -130,6 +130,48 @@ function errMsg(e: unknown): string {
   return String(e);
 }
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTransientMaintenanceError(e: unknown): boolean {
+  const msg = errMsg(e).toLowerCase();
+  return (
+    msg.includes("d1 db is overloaded") ||
+    msg.includes("requests queued for too long") ||
+    msg.includes('code":7429') ||
+    msg.includes("429") ||
+    msg.includes("analytics engine query failed: 5") ||
+    msg.includes("analytics engine query failed: 429")
+  );
+}
+
+async function withTransientRetry<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  for (let attempt = 0; attempt <= TRANSIENT_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (
+        attempt >= TRANSIENT_RETRY_ATTEMPTS ||
+        !isTransientMaintenanceError(e)
+      ) {
+        throw e;
+      }
+
+      const delay = 2 ** attempt * 1000;
+      console.warn(
+        `${label} failed transiently: ${errMsg(e)}; retrying in ${delay}ms`,
+      );
+      await sleep(delay);
+    }
+  }
+
+  throw new Error(`${label} failed after retries`);
+}
+
 async function runStep(
   out: StepResult[],
   name: string,
@@ -160,7 +202,7 @@ async function runDailyBackfill(
     for (let i = 0; i < days; i++) {
       const dateStr = dateStrAgo(now, i);
       try {
-        await fn(dateStr);
+        await withTransientRetry(`${name} ${dateStr}`, () => fn(dateStr));
         ok++;
       } catch (e) {
         failures.push(`${dateStr}: ${errMsg(e)}`);

--- a/src/maintenance-pipeline.ts
+++ b/src/maintenance-pipeline.ts
@@ -139,10 +139,7 @@ function isTransientMaintenanceError(e: unknown): boolean {
   return (
     msg.includes("d1 db is overloaded") ||
     msg.includes("requests queued for too long") ||
-    msg.includes('code":7429') ||
-    msg.includes("429") ||
-    msg.includes("analytics engine query failed: 5") ||
-    msg.includes("analytics engine query failed: 429")
+    msg.includes('code":7429')
   );
 }
 


### PR DESCRIPTION
## Summary

- Retry transient Analytics Engine SQL failures (`429`/`5xx`) with backoff.
- Retry transient maintenance per-day rollup failures, including D1 overloads like code `7429`, before marking a cron step failed.
- Materialize zero-count `daily_version_stats` rows so successful zero-result days advance rollup freshness instead of leaving the table looking stale.

## Why

The MAU data was repaired manually, but the automatic maintenance path was still vulnerable to transient Cloudflare overloads. The status workflow also showed `daily_version_stats` stuck on an old max date; successful zero-result days should be represented explicitly instead of leaving freshness ambiguous.

## Validation

- `mise x node -- node node_modules/typescript/lib/tsc.js --noEmit`
- `mise x node -- node node_modules/prettier/bin/prettier.cjs --check src/analytics/analytics-engine.ts src/analytics/rollups.ts src/maintenance-pipeline.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduled rollup/MAU paths and changes when zero-traffic days are written to analytics tables; behavior is intentional but affects operational metrics freshness.
> 
> **Overview**
> Adds **transient failure handling** across analytics maintenance so cron jobs survive short Cloudflare blips instead of failing whole steps.
> 
> `queryAnalyticsEngine` now retries up to three times on **429** and **5xx** responses with exponential backoff before surfacing an error. The maintenance pipeline wraps per-day rollup work and MAU refresh in `withTransientRetry`, matching D1 overload messages (including code **7429**) with the same backoff pattern.
> 
> **`daily_version_stats`** rollups no longer skip days when counts are zero: Analytics Engine and D1 paths always upsert rows (including zeros), and the D1-only path writes whenever stats exist instead of requiring `total > 0`. That lets successful quiet days advance freshness instead of leaving the table stuck on an old max date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9584575f2f64f9b3be29649d8cba56c3d5859305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->