### PR TITLE
Broaden D1 overload retry detection

### DIFF
--- a/src/maintenance-pipeline.ts
+++ b/src/maintenance-pipeline.ts
@@ -138,7 +138,9 @@ function isTransientMaintenanceError(e: unknown): boolean {
   const msg = errMsg(e).toLowerCase();
   return (
     msg.includes("d1 db is overloaded") ||
+    msg.includes("d1 is overloaded") ||
     msg.includes("requests queued for too long") ||
+    msg.includes("too many requests queued") ||
     msg.includes('code":7429')
   );
 }


### PR DESCRIPTION
## Summary

- Recognize additional Cloudflare D1 overload text variants in maintenance retry detection:
  - `D1 is overloaded`
  - `Too many requests queued`

## Why

Follow-up from PR #252 review feedback. The existing matcher handled the overload text we observed in Actions logs (`D1 DB is overloaded. Requests queued for too long.`) and code `7429`, but these additional variants are low-risk and keep the retry wrapper aligned with Cloudflare's common D1 messages.

## Validation

- `mise x node -- node node_modules/typescript/lib/tsc.js --noEmit`
- `mise x node -- node node_modules/prettier/bin/prettier.cjs --check src/maintenance-pipeline.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-matching-only change in retry classification; no new behavior paths beyond retrying on additional transient D1 errors.
> 
> **Overview**
> Extends **`isTransientMaintenanceError`** in `maintenance-pipeline.ts` so **`withTransientRetry`** treats two more Cloudflare D1 overload message variants as transient: **`d1 is overloaded`** and **`too many requests queued`**.
> 
> Existing matchers (`d1 db is overloaded`, `requests queued for too long`, code `7429`) are unchanged. MAU, rollup, and version-stats backfill steps that already use transient retries may now backoff-and-retry on these alternate error strings instead of failing immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371e12173988fc728e2222556377c954e188eefc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->