### PR TITLE
fix(github): respect release immutable flag

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -109,6 +109,79 @@ test("GitHub release mirror follows API redirects", () => {
   `);
 });
 
+test("GitHub release mirror trusts explicit upstream immutable releases", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import { getCachedGitHubRelease } from "./web/src/lib/github/mirror.ts";
+
+    const writes = [];
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({
+        tag_name: "v1.0.0",
+        draft: false,
+        prerelease: false,
+        immutable: true,
+        created_at: "2026-01-01T00:00:00Z",
+        published_at: "2099-01-01T00:00:00Z",
+        assets: [{
+          name: "tool.tar.gz",
+          browser_download_url: "https://github.com/owner/repo/releases/download/v1.0.0/tool.tar.gz",
+          url: "https://api.github.com/repos/owner/repo/releases/assets/1",
+        }],
+      }), { status: 200 });
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async (key, value, options) => writes.push({ key, value, options }),
+      },
+    };
+
+    const release = await getCachedGitHubRelease(env, "owner", "repo", "v1.0.0");
+
+    assert.equal(release.immutable, true);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].options, undefined);
+  `);
+});
+
+test("GitHub release mirror trusts explicit upstream mutable releases", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import { getCachedGitHubRelease } from "./web/src/lib/github/mirror.ts";
+
+    const writes = [];
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({
+        tag_name: "v1.0.0",
+        draft: false,
+        prerelease: false,
+        immutable: false,
+        created_at: "2026-01-01T00:00:00Z",
+        published_at: "2026-01-01T00:00:00Z",
+        assets: [{
+          name: "tool.tar.gz",
+          browser_download_url: "https://github.com/owner/repo/releases/download/v1.0.0/tool.tar.gz",
+          url: "https://api.github.com/repos/owner/repo/releases/assets/1",
+        }],
+      }), { status: 200 });
+
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async () => null,
+        put: async (key, value, options) => writes.push({ key, value, options }),
+      },
+    };
+
+    const release = await getCachedGitHubRelease(env, "owner", "repo", "v1.0.0");
+
+    assert.equal(release.immutable, false);
+    assert.deepEqual(writes[0].options, { expirationTtl: 2592000 });
+  `);
+});
+
 test("GitHub release mirror rejects redirects outside the GitHub API", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -369,17 +369,14 @@ async function fetchGitHubRelease(
     `https://api.github.com/repos/${owner}/${repo}/${path}`,
     token,
   );
-  const publishedAt = data.published_at
-    ? new Date(data.published_at).getTime()
-    : NaN;
   const assets = data.assets ?? [];
   const immutable =
     assets.length > 0 &&
     tag !== "latest" &&
     !data.draft &&
     !data.prerelease &&
-    Number.isFinite(publishedAt) &&
-    Date.now() - publishedAt > RELEASE_IMMUTABLE_AFTER_MS;
+    (data.immutable === true ||
+      (data.immutable === undefined && releaseAgeImmutable(data.published_at)));
 
   return {
     tag_name: data.tag_name,
@@ -394,6 +391,14 @@ async function fetchGitHubRelease(
       digest: asset.digest ?? null,
     })),
   };
+}
+
+function releaseAgeImmutable(publishedAt: string | undefined): boolean {
+  const timestamp = publishedAt ? new Date(publishedAt).getTime() : NaN;
+  return (
+    Number.isFinite(timestamp) &&
+    Date.now() - timestamp > RELEASE_IMMUTABLE_AFTER_MS
+  );
 }
 
 async function fetchGitHubAttestations(


### PR DESCRIPTION
## Summary
- Trust GitHub's explicit `immutable` release field when deciding whether mirrored release metadata can be cached permanently.
- Treat `immutable: false` as authoritative so old mutable releases keep the normal expiring cache.
- Keep the age-based immutable heuristic only as a fallback for payloads where GitHub does not provide the field.
- Increase mutable release HTTP caching from 10 minutes to 1 hour for both browser and edge cache headers.

## Root Cause
`mise-versions` inferred immutable release metadata from release age alone. Some GitHub releases are explicitly mutable even after that age threshold, so asset replacements like `kellyjonbrazil/jc@v1.25.7` could leave stale asset ids and digests cached indefinitely.

## Validation
- `mise exec -- node --test scripts/github-mirror.test.js`