### PR TITLE
fix(github): cache mutable release responses longer

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -149,7 +149,10 @@ test("GitHub release mirror trusts explicit upstream immutable releases", () => 
 test("GitHub release mirror trusts explicit upstream mutable releases", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";
-    import { getCachedGitHubRelease } from "./web/src/lib/github/mirror.ts";
+    import {
+      getCachedGitHubRelease,
+      releaseCacheHeaders,
+    } from "./web/src/lib/github/mirror.ts";
 
     const writes = [];
     globalThis.fetch = async () =>
@@ -179,6 +182,10 @@ test("GitHub release mirror trusts explicit upstream mutable releases", () => {
 
     assert.equal(release.immutable, false);
     assert.deepEqual(writes[0].options, { expirationTtl: 2592000 });
+    assert.equal(
+      releaseCacheHeaders("v1.0.0", release)["Cache-Control"],
+      "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400",
+    );
   `);
 });
 

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -11,7 +11,7 @@ const NEGATIVE_RELEASE_NOT_FOUND_FRESH_MS = 30 * 60 * 1000;
 const NEGATIVE_RELEASE_AUTH_FRESH_MS = 5 * 60 * 1000;
 const NEGATIVE_RELEASE_TRANSIENT_FRESH_MS = 60 * 1000;
 const NEGATIVE_ATTESTATION_FRESH_MS = 30 * 60 * 1000;
-const EDGE_SHORT_TTL_SECONDS = 10 * 60;
+const EDGE_SHORT_TTL_SECONDS = 60 * 60;
 const EDGE_NEGATIVE_ATTESTATION_TTL_SECONDS = 30 * 60;
 const EDGE_IMMUTABLE_TTL_SECONDS = 365 * 24 * 60 * 60;
 
@@ -87,6 +87,7 @@ export function cacheHeaders({
 export function releaseCacheHeaders(tag: string, release: GitHubRelease) {
   const immutable = tag !== "latest" && release.immutable === true;
   return cacheHeaders({
+    browserMaxAge: immutable ? 600 : EDGE_SHORT_TTL_SECONDS,
     edgeMaxAge: immutable ? EDGE_IMMUTABLE_TTL_SECONDS : EDGE_SHORT_TTL_SECONDS,
     immutable,
   });


### PR DESCRIPTION
## Summary
- Increase mutable GitHub release response HTTP caching from 10 minutes to 1 hour.
- Apply the 1-hour TTL to both browser `max-age` and edge `s-maxage` for mutable release responses.
- Keep immutable release edge caching behavior unchanged.

## Context
PR #254 fixed permanent caching for GitHub releases that explicitly report `immutable: false`. With that in place, mutable release responses can still use a longer short-lived HTTP cache without being frozen indefinitely.

## Validation
- `mise exec -- node --test scripts/github-mirror.test.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts HTTP cache headers for mutable release JSON; immutable release and KV refresh logic are unchanged.
> 
> **Overview**
> **Mutable GitHub release mirror responses** now advertise **1 hour** HTTP caching instead of **10 minutes** on the edge, and browsers get the same **1 hour** `max-age` for those responses (previously **10 minutes** edge / **10 minutes** default browser for non-immutable paths).
> 
> `releaseCacheHeaders` passes **`browserMaxAge: EDGE_SHORT_TTL_SECONDS`** for non-immutable releases so **`max-age` and `s-maxage` align** at 3600s, with **`stale-while-revalidate=86400`** unchanged. **Explicitly immutable** releases still use short browser cache (**600s**) and long edge **`immutable`** caching.
> 
> A mirror test now asserts **`Cache-Control`** for upstream **`immutable: false`** releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb068e6f6d499c17f07730eef379065ef730f501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->