### PR TITLE
Cache GitHub mirror responses at the edge

### DIFF
--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -103,6 +103,38 @@ export function attestationsCacheHeaders(response: GitHubAttestationsResponse) {
   });
 }
 
+export async function matchGitHubMirrorEdgeCache(
+  request: Request,
+): Promise<Response | null> {
+  try {
+    return (await defaultEdgeCache().match(edgeCacheRequest(request))) ?? null;
+  } catch (error) {
+    console.warn("failed to read GitHub mirror edge cache:", error);
+    return null;
+  }
+}
+
+export async function putGitHubMirrorEdgeCache(
+  request: Request,
+  response: Response,
+): Promise<void> {
+  if (response.status !== 200) return;
+
+  try {
+    await defaultEdgeCache().put(edgeCacheRequest(request), response.clone());
+  } catch (error) {
+    console.warn("failed to write GitHub mirror edge cache:", error);
+  }
+}
+
+function defaultEdgeCache(): Cache {
+  return (caches as unknown as { default: Cache }).default;
+}
+
+function edgeCacheRequest(request: Request): Request {
+  return new Request(request.url, { method: "GET" });
+}
+
 export function validRepoPart(value: string | undefined): value is string {
   return (
     !!value &&

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -14,6 +14,7 @@ const NEGATIVE_ATTESTATION_FRESH_MS = 30 * 60 * 1000;
 const EDGE_SHORT_TTL_SECONDS = 60 * 60;
 const EDGE_NEGATIVE_ATTESTATION_TTL_SECONDS = 30 * 60;
 const EDGE_IMMUTABLE_TTL_SECONDS = 365 * 24 * 60 * 60;
+const EDGE_MIRROR_CACHE_TTL_SECONDS = 60 * 60;
 
 interface CacheEntry<T> {
   cached_at: number;
@@ -121,10 +122,26 @@ export async function putGitHubMirrorEdgeCache(
   if (response.status !== 200) return;
 
   try {
-    await defaultEdgeCache().put(edgeCacheRequest(request), response.clone());
+    await defaultEdgeCache().put(
+      edgeCacheRequest(request),
+      edgeCacheResponse(response),
+    );
   } catch (error) {
     console.warn("failed to write GitHub mirror edge cache:", error);
   }
+}
+
+function edgeCacheResponse(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set(
+    "Cache-Control",
+    `public, max-age=600, s-maxage=${EDGE_MIRROR_CACHE_TTL_SECONDS}, stale-while-revalidate=86400`,
+  );
+  return new Response(response.clone().body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 function defaultEdgeCache(): Cache {
@@ -132,7 +149,13 @@ function defaultEdgeCache(): Cache {
 }
 
 function edgeCacheRequest(request: Request): Request {
-  return new Request(request.url, { method: "GET" });
+  // Query params are ignored by these mirror handlers, so strip them to avoid
+  // unbounded cache-key variants. Cache API cold misses are not coalesced, and
+  // cached allowlisted responses can outlive registry removals until this
+  // capped edge TTL expires.
+  const url = new URL(request.url);
+  url.search = "";
+  return new Request(url.toString(), { method: "GET" });
 }
 
 export function validRepoPart(value: string | undefined): value is string {

--- a/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
@@ -15,7 +15,7 @@ import {
   isRegisteredGitHubRepo,
 } from "../../../../../../../lib/github/registry";
 
-export const GET: APIRoute = async ({ params, request }) => {
+export const GET: APIRoute = async ({ params, request, locals }) => {
   const { owner, repo, digest } = params;
   if (!validRepoPart(owner) || !validRepoPart(repo) || !validDigest(digest)) {
     return errorResponse("Invalid GitHub attestation path", 400);
@@ -47,7 +47,7 @@ export const GET: APIRoute = async ({ params, request }) => {
       200,
       attestationsCacheHeaders(attestations),
     );
-    await putGitHubMirrorEdgeCache(request, response);
+    locals.cfContext.waitUntil(putGitHubMirrorEdgeCache(request, response));
     return response;
   } catch (error) {
     console.error(

--- a/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts
@@ -5,6 +5,8 @@ import {
   attestationsCacheHeaders,
   getCachedGitHubAttestations,
   githubStatus,
+  matchGitHubMirrorEdgeCache,
+  putGitHubMirrorEdgeCache,
   validDigest,
   validRepoPart,
 } from "../../../../../../../lib/github/mirror";
@@ -13,11 +15,14 @@ import {
   isRegisteredGitHubRepo,
 } from "../../../../../../../lib/github/registry";
 
-export const GET: APIRoute = async ({ params }) => {
+export const GET: APIRoute = async ({ params, request }) => {
   const { owner, repo, digest } = params;
   if (!validRepoPart(owner) || !validRepoPart(repo) || !validDigest(digest)) {
     return errorResponse("Invalid GitHub attestation path", 400);
   }
+
+  const cached = await matchGitHubMirrorEdgeCache(request);
+  if (cached) return cached;
 
   let registered: boolean;
   try {
@@ -37,11 +42,13 @@ export const GET: APIRoute = async ({ params }) => {
       repo,
       digest,
     );
-    return jsonResponse(
+    const response = jsonResponse(
       attestations,
       200,
       attestationsCacheHeaders(attestations),
     );
+    await putGitHubMirrorEdgeCache(request, response);
+    return response;
   } catch (error) {
     console.error(
       `GitHub attestation mirror failed for ${owner}/${repo}@${digest}:`,

--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../../../../lib/github/mirror";
 import { isRegisteredGitHubRepo } from "../../../../../../../lib/github/registry";
 
-export const GET: APIRoute = async ({ params, request }) => {
+export const GET: APIRoute = async ({ params, request, locals }) => {
   const { owner, repo } = params;
   // Cloudflare/Astro preserves percent-encoded characters (notably %2F) in
   // catch-all path params rather than decoding them, so tags such as
@@ -52,7 +52,7 @@ export const GET: APIRoute = async ({ params, request }) => {
       200,
       releaseCacheHeaders(tag, release),
     );
-    await putGitHubMirrorEdgeCache(request, response);
+    locals.cfContext.waitUntil(putGitHubMirrorEdgeCache(request, response));
     return response;
   } catch (error) {
     console.error(

--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -4,13 +4,15 @@ import { errorResponse, jsonResponse } from "../../../../../../../lib/api";
 import {
   getCachedGitHubRelease,
   githubStatus,
+  matchGitHubMirrorEdgeCache,
+  putGitHubMirrorEdgeCache,
   releaseCacheHeaders,
   validReleaseTag,
   validRepoPart,
 } from "../../../../../../../lib/github/mirror";
 import { isRegisteredGitHubRepo } from "../../../../../../../lib/github/registry";
 
-export const GET: APIRoute = async ({ params }) => {
+export const GET: APIRoute = async ({ params, request }) => {
   const { owner, repo } = params;
   // Cloudflare/Astro preserves percent-encoded characters (notably %2F) in
   // catch-all path params rather than decoding them, so tags such as
@@ -19,13 +21,18 @@ export const GET: APIRoute = async ({ params }) => {
   let tag: string | undefined;
   try {
     tag =
-      typeof params.tag === "string" ? decodeURIComponent(params.tag) : undefined;
+      typeof params.tag === "string"
+        ? decodeURIComponent(params.tag)
+        : undefined;
   } catch {
     return errorResponse("Invalid GitHub release path", 400);
   }
   if (!validRepoPart(owner) || !validRepoPart(repo) || !validReleaseTag(tag)) {
     return errorResponse("Invalid GitHub release path", 400);
   }
+
+  const cached = await matchGitHubMirrorEdgeCache(request);
+  if (cached) return cached;
 
   let registered: boolean;
   try {
@@ -40,7 +47,13 @@ export const GET: APIRoute = async ({ params }) => {
 
   try {
     const release = await getCachedGitHubRelease(env, owner, repo, tag);
-    return jsonResponse(release, 200, releaseCacheHeaders(tag, release));
+    const response = jsonResponse(
+      release,
+      200,
+      releaseCacheHeaders(tag, release),
+    );
+    await putGitHubMirrorEdgeCache(request, response);
+    return response;
   } catch (error) {
     console.error(
       `GitHub release mirror failed for ${owner}/${repo}@${tag}:`,


### PR DESCRIPTION
## Summary

- add `caches.default` read/write helpers for GitHub mirror responses
- return cached release/attestation responses before running D1 registry checks or token rotation
- populate the edge cache only after the existing allowlist validation and successful response generation

## Why

Full-sampling Worker logs showed D1 overload concentrated on hot GitHub mirror release and attestation URLs. Those requests currently run Worker code and hit D1 for registry checks, and cache misses/stale entries can also hit D1 for GitHub token rotation. Edge-cache hits now bypass that hot path entirely.

## Validation

- `mise x node -- zsh -lc './node_modules/.bin/prettier --write web/src/lib/github/mirror.ts "web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts" "web/src/pages/api/github/repos/[owner]/[repo]/attestations/[...digest].ts" && ./node_modules/.bin/tsx scripts/build-static-version-files.js && (cd web && ../node_modules/.bin/astro build)'`
- `tsc --noEmit --ignoreDeprecations 6.0` still reports existing web Env/fetch JSON typing errors; the new cache helper-specific type error was fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Edge hits skip per-request registry enforcement until the capped TTL, so removed repos could still be served briefly; mitigated by populating cache only after allowlist checks and documented TTL bounds.
> 
> **Overview**
> Adds **Cloudflare `caches.default`** read/write helpers for GitHub mirror APIs so repeat requests can be served without D1 registry checks or GitHub token rotation.
> 
> **Release** and **attestation** handlers now return an edge-cached `200` immediately after path validation when a match exists. On a miss, behavior is unchanged through registry allowlisting and KV/GitHub fetch; successful responses are stored asynchronously via `waitUntil`, with cache keys normalized by stripping query strings and a **1-hour** edge TTL (`stale-while-revalidate`).
> 
> Cache read/write failures are logged and fall back to the live path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea5d121385b32d2fda7f295723d7e20824f5835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub release and attestation responses now use edge caching for faster repeat requests.
  * Cached results can be returned immediately when the same content is requested again.

* **Bug Fixes**
  * Reduced unnecessary upstream fetches for GitHub mirror data.
  * Improved resilience when cache reads or writes fail, falling back safely to live responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->