### PR TITLE
Run version stats maintenance from GitHub Actions

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,15 +1,20 @@
 name: maintenance
 
 on:
+  schedule:
+    - cron: "20 2 * * *"
   workflow_dispatch:
     inputs:
       task:
         description: "Maintenance task to run"
-        required: true
+        required: false
+        default: refresh-all
         type: choice
         options:
           - status
           - refresh-mau
+          - refresh-version-stats
+          - refresh-all
       date:
         description: "Base date in UTC (YYYY-MM-DD); defaults to today"
         required: false
@@ -17,37 +22,56 @@ on:
       days:
         description: "Number of days to refresh, counting backward from date"
         required: false
-        default: "2"
         type: string
 
 concurrency:
-  group: maintenance-${{ github.event.inputs.task }}
+  group: maintenance-${{ github.event_name == 'schedule' && 'scheduled' || inputs.task }}
   cancel-in-progress: false
 
 jobs:
   maintenance:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      TASK: ${{ github.event_name == 'schedule' && 'refresh-all' || inputs.task }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
       - name: Maintenance status
-        if: github.event.inputs.task == 'status'
+        if: env.TASK == 'status'
         run: node scripts/maintenance-status-direct.js
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Refresh MAU directly
-        if: github.event.inputs.task == 'refresh-mau'
+        if: env.TASK == 'refresh-mau' || env.TASK == 'refresh-all'
         run: |
           args=(--days="${INPUT_DAYS:-2}")
           if [ -n "$INPUT_DATE" ]; then
             args+=(--date="$INPUT_DATE")
           fi
           node scripts/refresh-mau-direct.js "${args[@]}"
+        env:
+          INPUT_DAYS: ${{ github.event.inputs.days }}
+          INPUT_DATE: ${{ github.event.inputs.date }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ANALYTICS_ENGINE_ACCOUNT_ID: ${{ secrets.ANALYTICS_ENGINE_ACCOUNT_ID }}
+          ANALYTICS_ENGINE_API_TOKEN: ${{ secrets.ANALYTICS_ENGINE_API_TOKEN }}
+          ANALYTICS_ENGINE_DATASET: mise_analytics_events
+          ANALYTICS_ENGINE_CUTOVER_DATE: "2026-06-12"
+
+      - name: Refresh version stats directly
+        if: env.TASK == 'refresh-version-stats' || env.TASK == 'refresh-all'
+        run: |
+          args=(--days="${INPUT_DAYS:-31}")
+          if [ -n "$INPUT_DATE" ]; then
+            args+=(--date="$INPUT_DATE")
+          fi
+          node scripts/refresh-version-stats-direct.js "${args[@]}"
         env:
           INPUT_DAYS: ${{ github.event.inputs.days }}
           INPUT_DATE: ${{ github.event.inputs.date }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -49,7 +49,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Refresh MAU directly
+        id: refresh_mau
         if: env.TASK == 'refresh-mau' || env.TASK == 'refresh-all'
+        continue-on-error: ${{ env.TASK == 'refresh-all' }}
         run: |
           args=(--days="${INPUT_DAYS:-2}")
           if [ -n "$INPUT_DATE" ]; then
@@ -83,3 +85,7 @@ jobs:
           ANALYTICS_ENGINE_API_TOKEN: ${{ secrets.ANALYTICS_ENGINE_API_TOKEN }}
           ANALYTICS_ENGINE_DATASET: mise_analytics_events
           ANALYTICS_ENGINE_CUTOVER_DATE: "2026-06-12"
+
+      - name: Fail if MAU refresh failed
+        if: env.TASK == 'refresh-all' && steps.refresh_mau.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -25,7 +25,7 @@ on:
         type: string
 
 concurrency:
-  group: maintenance-${{ github.event_name == 'schedule' && 'scheduled' || github.event.inputs.task || 'refresh-all' }}
+  group: maintenance-${{ github.event.inputs.task || 'refresh-all' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -25,7 +25,7 @@ on:
         type: string
 
 concurrency:
-  group: maintenance-${{ github.event_name == 'schedule' && 'scheduled' || inputs.task }}
+  group: maintenance-${{ github.event_name == 'schedule' && 'scheduled' || github.event.inputs.task || 'refresh-all' }}
   cancel-in-progress: false
 
 jobs:
@@ -33,9 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      TASK: ${{ github.event_name == 'schedule' && 'refresh-all' || inputs.task }}
+      TASK: ${{ github.event_name == 'schedule' && 'refresh-all' || github.event.inputs.task || 'refresh-all' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 

--- a/scripts/refresh-version-stats-direct.js
+++ b/scripts/refresh-version-stats-direct.js
@@ -10,6 +10,7 @@ const DEFAULT_ANALYTICS_DB_ID = "21a8b89a-c2cc-4a8a-9805-b4bcfcd4f6c8";
 const DEFAULT_DATASET = "mise_analytics_events";
 const DEFAULT_CUTOVER_DATE = "2026-06-12";
 const CLOUDFLARE_RETRY_ATTEMPTS = 3;
+const CLOUDFLARE_FETCH_TIMEOUT_MS = 30_000;
 
 function usage() {
   console.error(`Usage: node scripts/refresh-version-stats-direct.js [--date=YYYY-MM-DD] [--days=N]
@@ -87,14 +88,28 @@ async function cfFetch(url, token, options = {}) {
   const { retries = CLOUDFLARE_RETRY_ATTEMPTS, ...fetchOptions } = options;
 
   for (let attempt = 0; attempt <= retries; attempt++) {
-    const response = await fetch(url, {
-      ...fetchOptions,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        ...fetchOptions.headers,
-      },
-    });
+    let response;
+    try {
+      response = await fetch(url, {
+        ...fetchOptions,
+        signal: AbortSignal.timeout(CLOUDFLARE_FETCH_TIMEOUT_MS),
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          ...fetchOptions.headers,
+        },
+      });
+    } catch (error) {
+      const message = `Cloudflare API request failed: ${error instanceof Error ? error.message : String(error)}`;
+      if (attempt < retries) {
+        const delay = 2 ** attempt * 1000;
+        console.warn(`${message}; retrying in ${delay}ms`);
+        await sleep(delay);
+        continue;
+      }
+      throw new Error(message);
+    }
+
     const text = await response.text();
     let data;
     try {
@@ -209,12 +224,72 @@ async function refreshVersionStatsFromD1(config, date) {
   };
 }
 
+async function refreshCutoverVersionStats(config, date) {
+  const d1Stats = await refreshVersionStatsFromD1(config, date);
+  const { start, end } = dateRange(date);
+  const dateStart = timestamp(`${date} 00:00:00`);
+  const dateEnd = dateStart + 86400;
+
+  const d1Users = await queryD1({
+    accountId: config.cloudflareAccountId,
+    token: config.cloudflareApiToken,
+    databaseId: config.analyticsDbId,
+    sql: `
+      SELECT DISTINCT ip_hash
+      FROM version_requests
+      WHERE created_at >= ? AND created_at < ?
+    `,
+    params: [dateStart, dateEnd],
+  });
+  const aeUsers = await queryAnalyticsEngine({
+    accountId: config.analyticsEngineAccountId,
+    token: config.analyticsEngineApiToken,
+    dataset: config.dataset,
+    sql: `
+      SELECT index1 AS ip_hash
+      FROM ${config.dataset}
+      WHERE
+        blob1 = 'version_request'
+        AND timestamp >= toDateTime('${start}')
+        AND timestamp <= toDateTime('${end}')
+      GROUP BY index1
+    `,
+  });
+  const aeStats = await queryAnalyticsEngine({
+    accountId: config.analyticsEngineAccountId,
+    token: config.analyticsEngineApiToken,
+    dataset: config.dataset,
+    sql: `
+      SELECT sum(_sample_interval) AS total_requests
+      FROM ${config.dataset}
+      WHERE
+        blob1 = 'version_request'
+        AND timestamp >= toDateTime('${start}')
+        AND timestamp <= toDateTime('${end}')
+    `,
+  });
+
+  const users = new Set();
+  for (const row of d1Users) users.add(row.ip_hash);
+  for (const row of aeUsers) users.add(row.ip_hash);
+
+  return {
+    totalRequests:
+      d1Stats.totalRequests + Number(aeStats[0]?.total_requests ?? 0),
+    uniqueUsers: users.size,
+  };
+}
+
 async function refreshVersionStatsForDate(config, date) {
   console.log(`Refreshing version stats for ${date}`);
-  const stats =
-    date >= config.cutoverDate
-      ? await refreshVersionStatsFromAnalyticsEngine(config, date)
-      : await refreshVersionStatsFromD1(config, date);
+  let stats;
+  if (date === config.cutoverDate) {
+    stats = await refreshCutoverVersionStats(config, date);
+  } else if (date > config.cutoverDate) {
+    stats = await refreshVersionStatsFromAnalyticsEngine(config, date);
+  } else {
+    stats = await refreshVersionStatsFromD1(config, date);
+  }
 
   if (
     !Number.isFinite(stats.totalRequests) ||

--- a/scripts/refresh-version-stats-direct.js
+++ b/scripts/refresh-version-stats-direct.js
@@ -135,11 +135,9 @@ async function cfFetch(url, token, options = {}) {
 
     throw new Error(message);
   }
-
-  throw new Error("Cloudflare API failed after retries");
 }
 
-async function queryAnalyticsEngine({ accountId, token, dataset, sql }) {
+async function queryAnalyticsEngine({ accountId, token, sql }) {
   console.log(`Analytics Engine SQL:\n${sql.trim()}\n`);
   const data = await cfFetch(
     `https://api.cloudflare.com/client/v4/accounts/${accountId}/analytics_engine/sql`,
@@ -182,7 +180,6 @@ async function refreshVersionStatsFromAnalyticsEngine(config, date) {
   const rows = await queryAnalyticsEngine({
     accountId: config.analyticsEngineAccountId,
     token: config.analyticsEngineApiToken,
-    dataset: config.dataset,
     sql: `
       SELECT
         sum(_sample_interval) AS total_requests,
@@ -244,7 +241,6 @@ async function refreshCutoverVersionStats(config, date) {
   const aeUsers = await queryAnalyticsEngine({
     accountId: config.analyticsEngineAccountId,
     token: config.analyticsEngineApiToken,
-    dataset: config.dataset,
     sql: `
       SELECT index1 AS ip_hash
       FROM ${config.dataset}
@@ -258,7 +254,6 @@ async function refreshCutoverVersionStats(config, date) {
   const aeStats = await queryAnalyticsEngine({
     accountId: config.analyticsEngineAccountId,
     token: config.analyticsEngineApiToken,
-    dataset: config.dataset,
     sql: `
       SELECT sum(_sample_interval) AS total_requests
       FROM ${config.dataset}

--- a/scripts/refresh-version-stats-direct.js
+++ b/scripts/refresh-version-stats-direct.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * Refresh daily_version_stats directly from GitHub Actions.
+ *
+ * This avoids the Worker/admin endpoint so long backfills do not hit Worker
+ * invocation limits and Cloudflare API errors are visible in GHA logs.
+ */
+
+const DEFAULT_ANALYTICS_DB_ID = "21a8b89a-c2cc-4a8a-9805-b4bcfcd4f6c8";
+const DEFAULT_DATASET = "mise_analytics_events";
+const DEFAULT_CUTOVER_DATE = "2026-06-12";
+const CLOUDFLARE_RETRY_ATTEMPTS = 3;
+
+function usage() {
+  console.error(`Usage: node scripts/refresh-version-stats-direct.js [--date=YYYY-MM-DD] [--days=N]
+
+Environment:
+  CLOUDFLARE_ACCOUNT_ID       Cloudflare account id
+  CLOUDFLARE_API_TOKEN        Cloudflare API token with D1 edit access
+  ANALYTICS_ENGINE_ACCOUNT_ID Optional; defaults to CLOUDFLARE_ACCOUNT_ID
+  ANALYTICS_ENGINE_API_TOKEN  Optional; defaults to CLOUDFLARE_API_TOKEN
+  ANALYTICS_ENGINE_DATASET    Optional; defaults to ${DEFAULT_DATASET}
+  ANALYTICS_ENGINE_CUTOVER_DATE Optional; defaults to ${DEFAULT_CUTOVER_DATE}
+  ANALYTICS_DB_ID             Optional; defaults to production ANALYTICS_DB id
+`);
+}
+
+function parseArgs(argv) {
+  const args = { date: null, days: 31 };
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    }
+    if (arg.startsWith("--date=")) {
+      args.date = arg.slice("--date=".length);
+    } else if (arg.startsWith("--days=")) {
+      args.days = Number(arg.slice("--days=".length));
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (args.date && !/^\d{4}-\d{2}-\d{2}$/.test(args.date)) {
+    throw new Error(`Invalid --date: ${args.date}`);
+  }
+  if (!Number.isInteger(args.days) || args.days < 1 || args.days > 31) {
+    throw new Error("--days must be an integer from 1 to 31");
+  }
+  return args;
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function dateStrAgo(baseDate, daysAgo) {
+  const d = new Date(`${baseDate}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  return d.toISOString().split("T")[0];
+}
+
+function dateRange(date) {
+  return {
+    start: `${date} 00:00:00`,
+    end: `${date} 23:59:59`,
+  };
+}
+
+function timestamp(dateTime) {
+  return Math.floor(new Date(`${dateTime}Z`).getTime() / 1000);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableCloudflareFailure(status, data) {
+  const codes = Array.isArray(data?.errors)
+    ? data.errors.map((error) => error?.code)
+    : [];
+  return status === 429 || status >= 500 || codes.includes(7429);
+}
+
+async function cfFetch(url, token, options = {}) {
+  const { retries = CLOUDFLARE_RETRY_ATTEMPTS, ...fetchOptions } = options;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const response = await fetch(url, {
+      ...fetchOptions,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        ...fetchOptions.headers,
+      },
+    });
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+
+    if (response.ok && data?.success !== false) {
+      return data;
+    }
+
+    const message = `Cloudflare API failed ${response.status}: ${JSON.stringify(data)}`;
+    if (
+      attempt < retries &&
+      isRetryableCloudflareFailure(response.status, data)
+    ) {
+      const delay = 2 ** attempt * 1000;
+      console.warn(`${message}; retrying in ${delay}ms`);
+      await sleep(delay);
+      continue;
+    }
+
+    throw new Error(message);
+  }
+
+  throw new Error("Cloudflare API failed after retries");
+}
+
+async function queryAnalyticsEngine({ accountId, token, dataset, sql }) {
+  console.log(`Analytics Engine SQL:\n${sql.trim()}\n`);
+  const data = await cfFetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/analytics_engine/sql`,
+    token,
+    {
+      method: "POST",
+      body: `${sql}\nFORMAT JSON`,
+    },
+  );
+  if (!Array.isArray(data.data)) {
+    throw new Error(
+      `Unexpected Analytics Engine response: ${JSON.stringify(data)}`,
+    );
+  }
+  console.log(`Analytics Engine returned ${data.data.length} row(s)`);
+  return data.data;
+}
+
+async function queryD1({ accountId, token, databaseId, sql, params = [] }) {
+  console.log(`D1 SQL:\n${sql.trim()}\nparams: ${JSON.stringify(params)}\n`);
+  const data = await cfFetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`,
+    token,
+    {
+      method: "POST",
+      body: JSON.stringify({ sql, params }),
+    },
+  );
+  const first = Array.isArray(data.result) ? data.result[0] : data.result;
+  if (!first?.success) {
+    throw new Error(`D1 query failed: ${JSON.stringify(data)}`);
+  }
+  const rows = first.results ?? [];
+  console.log(`D1 returned ${rows.length} row(s)`);
+  return rows;
+}
+
+async function refreshVersionStatsFromAnalyticsEngine(config, date) {
+  const { start, end } = dateRange(date);
+  const rows = await queryAnalyticsEngine({
+    accountId: config.analyticsEngineAccountId,
+    token: config.analyticsEngineApiToken,
+    dataset: config.dataset,
+    sql: `
+      SELECT
+        sum(_sample_interval) AS total_requests,
+        count(DISTINCT index1) AS unique_users
+      FROM ${config.dataset}
+      WHERE
+        blob1 = 'version_request'
+        AND timestamp >= toDateTime('${start}')
+        AND timestamp <= toDateTime('${end}')
+    `,
+  });
+
+  return {
+    totalRequests: Number(rows[0]?.total_requests ?? 0),
+    uniqueUsers: Number(rows[0]?.unique_users ?? 0),
+  };
+}
+
+async function refreshVersionStatsFromD1(config, date) {
+  const dateStart = timestamp(`${date} 00:00:00`);
+  const dateEnd = dateStart + 86400;
+  const rows = await queryD1({
+    accountId: config.cloudflareAccountId,
+    token: config.cloudflareApiToken,
+    databaseId: config.analyticsDbId,
+    sql: `
+      SELECT
+        COUNT(*) AS total_requests,
+        COUNT(DISTINCT ip_hash) AS unique_users
+      FROM version_requests
+      WHERE created_at >= ? AND created_at < ?
+    `,
+    params: [dateStart, dateEnd],
+  });
+
+  return {
+    totalRequests: Number(rows[0]?.total_requests ?? 0),
+    uniqueUsers: Number(rows[0]?.unique_users ?? 0),
+  };
+}
+
+async function refreshVersionStatsForDate(config, date) {
+  console.log(`Refreshing version stats for ${date}`);
+  const stats =
+    date >= config.cutoverDate
+      ? await refreshVersionStatsFromAnalyticsEngine(config, date)
+      : await refreshVersionStatsFromD1(config, date);
+
+  if (
+    !Number.isFinite(stats.totalRequests) ||
+    !Number.isFinite(stats.uniqueUsers)
+  ) {
+    throw new Error(
+      `Unexpected version stats for ${date}: ${JSON.stringify(stats)}`,
+    );
+  }
+
+  await queryD1({
+    accountId: config.cloudflareAccountId,
+    token: config.cloudflareApiToken,
+    databaseId: config.analyticsDbId,
+    sql: `
+      INSERT OR REPLACE INTO daily_version_stats
+        (date, total_requests, unique_users)
+      VALUES (?, ?, ?)
+    `,
+    params: [date, stats.totalRequests, stats.uniqueUsers],
+  });
+
+  console.log(
+    `Refreshed ${date}: ${stats.totalRequests} total request(s), ${stats.uniqueUsers} unique user(s)`,
+  );
+  return { date, ...stats };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const cloudflareAccountId = requiredEnv("CLOUDFLARE_ACCOUNT_ID");
+  const cloudflareApiToken = requiredEnv("CLOUDFLARE_API_TOKEN");
+  const config = {
+    cloudflareAccountId,
+    cloudflareApiToken,
+    analyticsEngineAccountId:
+      process.env.ANALYTICS_ENGINE_ACCOUNT_ID || cloudflareAccountId,
+    analyticsEngineApiToken:
+      process.env.ANALYTICS_ENGINE_API_TOKEN || cloudflareApiToken,
+    analyticsDbId: process.env.ANALYTICS_DB_ID || DEFAULT_ANALYTICS_DB_ID,
+    dataset: process.env.ANALYTICS_ENGINE_DATASET || DEFAULT_DATASET,
+    cutoverDate:
+      process.env.ANALYTICS_ENGINE_CUTOVER_DATE || DEFAULT_CUTOVER_DATE,
+  };
+
+  const baseDate = args.date || new Date().toISOString().split("T")[0];
+  const dates = Array.from({ length: args.days }, (_, i) =>
+    dateStrAgo(baseDate, i),
+  );
+  console.log(`Refreshing version stats for: ${dates.join(", ")}`);
+
+  const results = [];
+  for (const date of dates) {
+    results.push(await refreshVersionStatsForDate(config, date));
+  }
+  console.log(JSON.stringify({ success: true, results }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changed

- Added `scripts/refresh-version-stats-direct.js` to refresh `daily_version_stats` through Cloudflare REST APIs from GitHub Actions.
- Extended the `maintenance` workflow with `refresh-version-stats` and `refresh-all` tasks.
- Scheduled the direct maintenance workflow daily at `02:20 UTC`, with MAU defaulting to 2 days and version stats defaulting to 31 days.

## Why

`daily_version_stats` was still stale while the Worker/admin maintenance path is too large for one Worker invocation and gives poor logs. Running this directly in GHA makes the failing backfill visible and avoids the Worker invocation/API-request ceiling for this part of maintenance.

## Validation

- `mise x node -- zsh -lc 'node --check scripts/refresh-version-stats-direct.js && node scripts/refresh-version-stats-direct.js --help && (node scripts/refresh-version-stats-direct.js --days=0 >/tmp/refresh-version-stats-invalid.out 2>&1; test $? -ne 0)'`
- `mise x node -- zsh -lc './node_modules/.bin/prettier --check .github/workflows/maintenance.yml scripts/refresh-version-stats-direct.js'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes production D1 analytics aggregates using repo secrets and runs on a schedule; mistakes could skew public stats or spam Cloudflare APIs, though scope is limited to maintenance scripts and existing MAU patterns.
> 
> **Overview**
> Moves **daily version stats** backfills out of the Worker/admin path into GitHub Actions so long runs avoid Worker limits and failures show up clearly in workflow logs.
> 
> Adds **`scripts/refresh-version-stats-direct.js`**, which aggregates `version_request` metrics from D1 and/or Analytics Engine (including a cutover-day merge), then upserts **`daily_version_stats`** via Cloudflare REST APIs with retries on transient API errors.
> 
> The **`maintenance`** workflow now runs on a **daily schedule** (02:20 UTC), defaults manual runs to **`refresh-all`**, and wires **`refresh-version-stats`** (31-day default) alongside MAU (2-day default). **`refresh-all`** lets MAU fail without stopping the version-stats step, then fails the job if MAU still failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96104a7a4b2d75fcc1a2cb22b5e3d5cff8fede40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new maintenance mode to refresh version stats directly.
  * Made maintenance runs default to a full refresh when no task is selected.
  * Added a new command-line utility to refresh version statistics across one or more days.

* **Bug Fixes**
  * Improved maintenance scheduling so task selection works consistently across scheduled and manual runs.
  * Added retry handling for cloud API requests to make refreshes more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->