### PR TITLE
fix(update): collect releases without age delay

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,6 +29,9 @@ env:
   # entry (e.g. a version added without metadata after a GitHub rate limit)
   # gets re-ingested on the next run instead of being corrected from upstream.
   MISE_USE_VERSIONS_HOST: "false"
+  # Collect release metadata immediately. Clients apply their own
+  # minimum_release_age when selecting which version to install.
+  MISE_MINIMUM_RELEASE_AGE: "0s"
   # Include pre-release versions globally so the JSON output of
   # `mise ls-remote --json` carries `prerelease = true` for tags upstream
   # has flagged as pre-releases. Without this, mise filters them out before


### PR DESCRIPTION
## Summary

- disable `minimum_release_age` in the versions update workflow
- keep release-age enforcement with downstream mise clients

## Root cause

The update workflow uses `mise ls-remote` to populate release metadata. Since mise defaults `minimum_release_age` to 24 hours, newly published releases were omitted from the metadata service for their first day. During that window, clients could resolve GitHub’s `/releases/latest` response but fail to find its timestamp in the remote version metadata and fall back to the older ordered version list.

Setting `MISE_MINIMUM_RELEASE_AGE=0s` makes the metadata producer ingest releases immediately while preserving client-side release-age filtering.

This addresses the behavior investigated in jdx/mise#10957.

## Validation

- `mise x actionlint -- actionlint .github/workflows/update.yml`
- `git diff --check`
- `mise run lint` currently fails before linting this YAML because ESLint 10 cannot find an `eslint.config.*` file.