### PR TITLE
Fix stats rollup resilience

### DIFF
--- a/src/analytics/growth.ts
+++ b/src/analytics/growth.ts
@@ -8,6 +8,7 @@ export function createGrowthFunctions(db: ReturnType<typeof drizzle>) {
     // Get growth metrics (week-over-week and month-over-month)
     async getGrowthMetrics() {
       const now = Math.floor(Date.now() / 1000);
+      const today = new Date(now * 1000).toISOString().split("T")[0];
 
       // Calculate timestamps for each period
       const sevenDaysAgo = now - 7 * 86400;
@@ -35,7 +36,12 @@ export function createGrowthFunctions(db: ReturnType<typeof drizzle>) {
           total: sql<number>`coalesce(sum(${dailyStats.total_downloads}), 0)`,
         })
         .from(dailyStats)
-        .where(sql`${dailyStats.date} >= ${thisWeekStart}`)
+        .where(
+          and(
+            sql`${dailyStats.date} >= ${thisWeekStart}`,
+            sql`${dailyStats.date} < ${today}`,
+          ),
+        )
         .get();
 
       // Global stats for last week
@@ -58,7 +64,12 @@ export function createGrowthFunctions(db: ReturnType<typeof drizzle>) {
           total: sql<number>`coalesce(sum(${dailyStats.total_downloads}), 0)`,
         })
         .from(dailyStats)
-        .where(sql`${dailyStats.date} >= ${thisMonthStart}`)
+        .where(
+          and(
+            sql`${dailyStats.date} >= ${thisMonthStart}`,
+            sql`${dailyStats.date} < ${today}`,
+          ),
+        )
         .get();
 
       // Global stats for last month
@@ -97,7 +108,12 @@ export function createGrowthFunctions(db: ReturnType<typeof drizzle>) {
           downloads: sql<number>`coalesce(sum(${dailyToolStats.downloads}), 0)`,
         })
         .from(dailyToolStats)
-        .where(sql`${dailyToolStats.date} >= ${thisWeekStart}`)
+        .where(
+          and(
+            sql`${dailyToolStats.date} >= ${thisWeekStart}`,
+            sql`${dailyToolStats.date} < ${today}`,
+          ),
+        )
         .groupBy(dailyToolStats.tool_id)
         .all();
 

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -451,15 +451,11 @@ export function createRollupFunctions(
       )
     `;
 
-    const [
-      globalRows,
-      combinedRows,
-      toolRows,
-      backendRows,
-      toolBackendRows,
-      versionRows,
-      platformRows,
-    ] = await Promise.all([
+    // Persist the two small, user-visible activity rollups before running the
+    // high-cardinality dimension queries. A timeout or response limit while
+    // grouping versions/platforms should not leave DAU and global growth at
+    // zero for an otherwise healthy day.
+    const [globalRows, combinedRows] = await Promise.all([
       queryAnalyticsEngine<AeCountRow>(
         analyticsEngine!,
         `
@@ -477,62 +473,6 @@ export function createRollupFunctions(
           WHERE blob1 IN ('download', 'version_request') AND ${range}
         `,
       ),
-      queryAnalyticsEngine<AeToolRow>(
-        analyticsEngine!,
-        `
-          SELECT
-            tool,
-            sum(sample_weight) AS downloads,
-            count(DISTINCT ip_hash) AS unique_users
-          FROM ${dedupedDownloads}
-          GROUP BY tool
-        `,
-      ),
-      queryAnalyticsEngine<AeBackendRow>(
-        analyticsEngine!,
-        `
-          SELECT
-            backend_type,
-            sum(sample_weight) AS downloads,
-            count(DISTINCT ip_hash) AS unique_users
-          FROM ${dedupedDownloads}
-          GROUP BY backend_type
-        `,
-      ),
-      queryAnalyticsEngine<AeToolBackendRow>(
-        analyticsEngine!,
-        `
-          SELECT
-            tool,
-            backend_type,
-            sum(sample_weight) AS downloads
-          FROM ${dedupedDownloads}
-          GROUP BY tool, backend_type
-        `,
-      ),
-      queryAnalyticsEngine<AeVersionRow>(
-        analyticsEngine!,
-        `
-          SELECT
-            tool,
-            version,
-            sum(sample_weight) AS downloads
-          FROM ${dedupedDownloads}
-          GROUP BY tool, version
-        `,
-      ),
-      queryAnalyticsEngine<AePlatformRow>(
-        analyticsEngine!,
-        `
-          SELECT
-            tool,
-            os,
-            arch,
-            sum(sample_weight) AS downloads
-          FROM ${dedupedDownloads}
-          GROUP BY tool, os, arch
-        `,
-      ),
     ]);
 
     let globalStats = globalRows.rows[0]
@@ -542,6 +482,96 @@ export function createRollupFunctions(
         }
       : undefined;
     let combinedDau = aeNumber(combinedRows.rows[0]?.unique_users);
+    const cutoverDate = analyticsEngineCutoverDate(analyticsEngine);
+    let activityStatsPersisted = false;
+
+    if (date !== cutoverDate) {
+      if (globalStats) {
+        await runStatement(
+          sql`
+            INSERT OR REPLACE INTO daily_stats (date, total_downloads, unique_users)
+            VALUES (${date}, ${globalStats.total}, ${globalStats.unique_users})
+          `,
+          d1,
+          "INSERT OR REPLACE INTO daily_stats (date, total_downloads, unique_users) VALUES (?, ?, ?)",
+          [date, globalStats.total, globalStats.unique_users],
+        );
+      }
+
+      if (combinedDau > 0) {
+        await runStatement(
+          sql`
+            INSERT OR REPLACE INTO daily_combined_stats (date, unique_users)
+            VALUES (${date}, ${combinedDau})
+          `,
+          d1,
+          "INSERT OR REPLACE INTO daily_combined_stats (date, unique_users) VALUES (?, ?)",
+          [date, combinedDau],
+        );
+      }
+      activityStatsPersisted = true;
+    }
+
+    const [toolRows, backendRows, toolBackendRows, versionRows, platformRows] =
+      await Promise.all([
+        queryAnalyticsEngine<AeToolRow>(
+          analyticsEngine!,
+          `
+          SELECT
+            tool,
+            sum(sample_weight) AS downloads,
+            count(DISTINCT ip_hash) AS unique_users
+          FROM ${dedupedDownloads}
+          GROUP BY tool
+        `,
+        ),
+        queryAnalyticsEngine<AeBackendRow>(
+          analyticsEngine!,
+          `
+          SELECT
+            backend_type,
+            sum(sample_weight) AS downloads,
+            count(DISTINCT ip_hash) AS unique_users
+          FROM ${dedupedDownloads}
+          GROUP BY backend_type
+        `,
+        ),
+        queryAnalyticsEngine<AeToolBackendRow>(
+          analyticsEngine!,
+          `
+          SELECT
+            tool,
+            backend_type,
+            sum(sample_weight) AS downloads
+          FROM ${dedupedDownloads}
+          GROUP BY tool, backend_type
+        `,
+        ),
+        queryAnalyticsEngine<AeVersionRow>(
+          analyticsEngine!,
+          `
+          SELECT
+            tool,
+            version,
+            sum(sample_weight) AS downloads
+          FROM ${dedupedDownloads}
+          GROUP BY tool, version
+        `,
+        ),
+        queryAnalyticsEngine<AePlatformRow>(
+          analyticsEngine!,
+          `
+          SELECT
+            tool,
+            os,
+            arch,
+            sum(sample_weight) AS downloads
+          FROM ${dedupedDownloads}
+          GROUP BY tool, os, arch
+        `,
+        ),
+      ]);
+
     let toolStatsRows = toolRows.rows.map((row) => ({
       ...row,
       downloads: aeNumber(row.downloads),
@@ -564,8 +594,6 @@ export function createRollupFunctions(
       ...row,
       downloads: aeNumber(row.downloads),
     }));
-    const cutoverDate = analyticsEngineCutoverDate(analyticsEngine);
-
     if (cutoverDate && date === cutoverDate) {
       const d1Start = Math.floor(
         new Date(`${date}T00:00:00Z`).getTime() / 1000,
@@ -742,7 +770,7 @@ export function createRollupFunctions(
       return null;
     }
 
-    if (globalStats) {
+    if (!activityStatsPersisted && globalStats) {
       await runStatement(
         sql`
           INSERT OR REPLACE INTO daily_stats (date, total_downloads, unique_users)
@@ -754,7 +782,7 @@ export function createRollupFunctions(
       );
     }
 
-    if (combinedDau > 0) {
+    if (!activityStatsPersisted && combinedDau > 0) {
       await runStatement(
         sql`
           INSERT OR REPLACE INTO daily_combined_stats (date, unique_users)

--- a/src/analytics/rollups.ts
+++ b/src/analytics/rollups.ts
@@ -451,10 +451,74 @@ export function createRollupFunctions(
       )
     `;
 
-    // Persist the two small, user-visible activity rollups before running the
-    // high-cardinality dimension queries. A timeout or response limit while
-    // grouping versions/platforms should not leave DAU and global growth at
-    // zero for an otherwise healthy day.
+    // Start the high-cardinality work immediately, but handle its rejection
+    // so it cannot become unhandled while the core activity queries finish.
+    // This keeps all Analytics Engine requests concurrent without allowing a
+    // dimension failure to prevent the user-visible totals from being saved.
+    const dimensionRowsPromise = Promise.all([
+      queryAnalyticsEngine<AeToolRow>(
+        analyticsEngine!,
+        `
+          SELECT
+            tool,
+            sum(sample_weight) AS downloads,
+            count(DISTINCT ip_hash) AS unique_users
+          FROM ${dedupedDownloads}
+          GROUP BY tool
+        `,
+      ),
+      queryAnalyticsEngine<AeBackendRow>(
+        analyticsEngine!,
+        `
+          SELECT
+            backend_type,
+            sum(sample_weight) AS downloads,
+            count(DISTINCT ip_hash) AS unique_users
+          FROM ${dedupedDownloads}
+          GROUP BY backend_type
+        `,
+      ),
+      queryAnalyticsEngine<AeToolBackendRow>(
+        analyticsEngine!,
+        `
+          SELECT
+            tool,
+            backend_type,
+            sum(sample_weight) AS downloads
+          FROM ${dedupedDownloads}
+          GROUP BY tool, backend_type
+        `,
+      ),
+      queryAnalyticsEngine<AeVersionRow>(
+        analyticsEngine!,
+        `
+          SELECT
+            tool,
+            version,
+            sum(sample_weight) AS downloads
+          FROM ${dedupedDownloads}
+          GROUP BY tool, version
+        `,
+      ),
+      queryAnalyticsEngine<AePlatformRow>(
+        analyticsEngine!,
+        `
+          SELECT
+            tool,
+            os,
+            arch,
+            sum(sample_weight) AS downloads
+          FROM ${dedupedDownloads}
+          GROUP BY tool, os, arch
+        `,
+      ),
+    ]).then(
+      (rows) => ({ ok: true as const, rows }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+
+    // Persist the two small, user-visible activity rollups as soon as they
+    // finish, before awaiting the concurrently running dimension queries.
     const [globalRows, combinedRows] = await Promise.all([
       queryAnalyticsEngine<AeCountRow>(
         analyticsEngine!,
@@ -512,65 +576,10 @@ export function createRollupFunctions(
       activityStatsPersisted = true;
     }
 
+    const dimensionResult = await dimensionRowsPromise;
+    if (!dimensionResult.ok) throw dimensionResult.error;
     const [toolRows, backendRows, toolBackendRows, versionRows, platformRows] =
-      await Promise.all([
-        queryAnalyticsEngine<AeToolRow>(
-          analyticsEngine!,
-          `
-          SELECT
-            tool,
-            sum(sample_weight) AS downloads,
-            count(DISTINCT ip_hash) AS unique_users
-          FROM ${dedupedDownloads}
-          GROUP BY tool
-        `,
-        ),
-        queryAnalyticsEngine<AeBackendRow>(
-          analyticsEngine!,
-          `
-          SELECT
-            backend_type,
-            sum(sample_weight) AS downloads,
-            count(DISTINCT ip_hash) AS unique_users
-          FROM ${dedupedDownloads}
-          GROUP BY backend_type
-        `,
-        ),
-        queryAnalyticsEngine<AeToolBackendRow>(
-          analyticsEngine!,
-          `
-          SELECT
-            tool,
-            backend_type,
-            sum(sample_weight) AS downloads
-          FROM ${dedupedDownloads}
-          GROUP BY tool, backend_type
-        `,
-        ),
-        queryAnalyticsEngine<AeVersionRow>(
-          analyticsEngine!,
-          `
-          SELECT
-            tool,
-            version,
-            sum(sample_weight) AS downloads
-          FROM ${dedupedDownloads}
-          GROUP BY tool, version
-        `,
-        ),
-        queryAnalyticsEngine<AePlatformRow>(
-          analyticsEngine!,
-          `
-          SELECT
-            tool,
-            os,
-            arch,
-            sum(sample_weight) AS downloads
-          FROM ${dedupedDownloads}
-          GROUP BY tool, os, arch
-        `,
-        ),
-      ]);
+      dimensionResult.rows;
 
     let toolStatsRows = toolRows.rows.map((row) => ({
       ...row,


### PR DESCRIPTION
## Summary

- persist global download and combined DAU rollups before high-cardinality dimension queries
- exclude the partial current UTC day from week-over-week and month-over-month growth calculations

## Root cause

The stats page showed DAU dropping to zero after July 8 even though Analytics Engine still contained healthy activity data. The Analytics Engine rollup queried every tool, backend, version, and platform dimension before writing the small user-visible activity totals. A timeout or response limit in that expensive dimension work could therefore prevent otherwise healthy DAU and global totals from landing.

This change writes the core activity rollups first, so dimension failures cannot blank the DAU chart or global growth data. Growth comparisons also ignore incomplete current-day rows.

## Rebase note

Upstream moved maintenance ownership out of the Worker and deleted `src/maintenance-pipeline.ts`. The rebase preserves that deletion; the earlier scheduling-order change is no longer part of this PR.

## Validation

- `npx tsc --noEmit`
- `node --test scripts/*.test.js` (88 tests)
- `npm run build -w web`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how stats are persisted and how growth windows are computed; wrong ordering or date bounds could affect DAU charts and WoW/MoM numbers, but scope is analytics rollups only.
> 
> **Overview**
> Makes Analytics Engine daily rollups **save global downloads and combined DAU** (`daily_stats`, `daily_combined_stats`) as soon as the small aggregate queries return, instead of waiting for tool/backend/version/platform dimension queries that can time out or hit response limits.
> 
> Dimension work still runs **in parallel** from the start, with rejections captured so failures there do not become unhandled while totals are written; cutover-day merging still recomputes totals before insert, guarded by an `activityStatsPersisted` flag so rows are not written twice.
> 
> **Growth metrics** now treat the current UTC calendar day as incomplete: week-over-week and month-over-month sums (global and per-tool “this week”) use `date < today` so partial today rows do not skew comparisons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6295dfe1d498acb19ac4ca709634aad3dc5ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->