### PR TITLE
retry transient Cloudflare deploy failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,10 +34,24 @@ jobs:
         run: aube --dir web run build
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          for attempt in 1 2 3; do
+            if aube exec wrangler deploy; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Cloudflare deployment failed after $attempt attempts"
+              exit 1
+            fi
+
+            delay=$((attempt * 15))
+            echo "::warning::Cloudflare deployment attempt $attempt failed; retrying in ${delay}s"
+            sleep "$delay"
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Run database migrations
         run: node scripts/migrate.js run


### PR DESCRIPTION
## Summary

- replace the one-shot Wrangler action with the repository-pinned Wrangler CLI
- retry Cloudflare deployments up to three times
- use 15-second and 30-second backoff delays before subsequent attempts
- preserve the existing database migration ordering so migrations only run after a successful deploy

## Root cause

Deploy run 29516954290 built successfully but Cloudflare's `assets-upload-session` endpoint returned transient API error `10013`. The same run succeeded immediately when retried, and the preceding deployments used the same Wrangler version and asset count successfully.

## Validation

- reran deploy run 29516954290 successfully
- `prettier --check .github/workflows/deploy.yml`
- parsed the workflow as YAML
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only deploy orchestration change; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Replaces the one-shot **`cloudflare/wrangler-action`** step with **`aube exec wrangler deploy`** so deploys use the repo-pinned Wrangler CLI. A shell loop runs up to **three** deploy attempts with **15s / 30s** backoff (`attempt * 15`) and GitHub **`::warning` / `::error`** annotations on failure.
> 
> Cloudflare credentials are unchanged (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`). The **Run database migrations** step still runs only after a successful deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2255617885156d321adbc2ce3ec1b63f25fa0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->