### PR TITLE
feat(web): move tool search into the navbar

### DIFF
--- a/web/src/components/NavSearch.tsx
+++ b/web/src/components/NavSearch.tsx
@@ -1,0 +1,135 @@
+import { useState, useRef, useEffect } from "preact/hooks";
+
+const MAX_SUGGESTIONS = 8;
+
+interface Suggestion {
+  name: string;
+  description?: string;
+}
+
+function getInitialQuery(): string {
+  if (typeof window === "undefined") return "";
+  return new URLSearchParams(window.location.search).get("q") || "";
+}
+
+export function NavSearch() {
+  const [query, setQuery] = useState(getInitialQuery);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const debounceRef = useRef<number>();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const fetchSuggestions = async (q: string) => {
+    if (!q.trim()) {
+      setSuggestions([]);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/tools?q=${encodeURIComponent(q.trim())}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setSuggestions((data.tools || []).slice(0, MAX_SUGGESTIONS));
+    } catch (e) {
+      console.error("Failed to fetch search suggestions:", e);
+    }
+  };
+
+  const handleInput = (value: string) => {
+    setQuery(value);
+    setShowSuggestions(true);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => fetchSuggestions(value), 300);
+  };
+
+  // Auto-select first suggestion when the list changes
+  useEffect(() => {
+    setSelectedIndex(suggestions.length > 0 ? 0 : -1);
+  }, [suggestions]);
+
+  const goToTool = (name: string) => {
+    window.location.href = `/tools/${name}`;
+  };
+
+  const goToResults = () => {
+    const q = query.trim();
+    if (!q) return;
+    window.location.href = `/?q=${encodeURIComponent(q)}`;
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setShowSuggestions(false);
+      inputRef.current?.blur();
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (
+        showSuggestions &&
+        selectedIndex >= 0 &&
+        selectedIndex < suggestions.length
+      ) {
+        goToTool(suggestions[selectedIndex].name);
+      } else {
+        goToResults();
+      }
+      return;
+    }
+    if (!showSuggestions || suggestions.length === 0) return;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev + 1) % suggestions.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedIndex(
+          (prev) => (prev - 1 + suggestions.length) % suggestions.length,
+        );
+        break;
+    }
+  };
+
+  return (
+    <div class="relative w-40 sm:w-56 md:w-64">
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="Search tools..."
+        value={query}
+        onInput={(e) => handleInput((e.target as HTMLInputElement).value)}
+        onFocus={() => setShowSuggestions(true)}
+        onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+        onKeyDown={handleKeyDown}
+        class="w-full px-3 py-1.5 bg-dark-900 border border-dark-600 rounded-lg text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-neon-purple focus:ring-1 focus:ring-neon-purple"
+        autocomplete="off"
+      />
+      {showSuggestions && suggestions.length > 0 && (
+        <div class="absolute z-50 w-full mt-1 bg-dark-800 border border-dark-600 rounded-lg shadow-lg overflow-hidden">
+          {suggestions.map((tool, index) => (
+            <button
+              key={tool.name}
+              type="button"
+              onMouseDown={() => goToTool(tool.name)}
+              class={`w-full px-3 py-2 text-left text-sm transition-colors ${
+                index === selectedIndex
+                  ? "bg-neon-purple/20 text-neon-purple"
+                  : "text-gray-300 hover:bg-dark-700"
+              }`}
+            >
+              {tool.name}
+              {tool.description && (
+                <span class="ml-2 text-xs text-gray-500">
+                  {tool.description.slice(0, 40)}
+                  {tool.description.length > 40 ? "..." : ""}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/NavSearch.tsx
+++ b/web/src/components/NavSearch.tsx
@@ -7,13 +7,8 @@ interface Suggestion {
   description?: string;
 }
 
-function getInitialQuery(): string {
-  if (typeof window === "undefined") return "";
-  return new URLSearchParams(window.location.search).get("q") || "";
-}
-
-export function NavSearch() {
-  const [query, setQuery] = useState(getInitialQuery);
+export function NavSearch({ initialQuery = "" }: { initialQuery?: string }) {
+  const [query, setQuery] = useState(initialQuery);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -26,12 +21,21 @@ export function NavSearch() {
       return;
     }
     try {
-      const res = await fetch(`/api/tools?q=${encodeURIComponent(q.trim())}`);
-      if (!res.ok) return;
+      const res = await fetch(
+        `/api/tools?q=${encodeURIComponent(q.trim())}&limit=${MAX_SUGGESTIONS}`,
+      );
+      // Drop responses whose query no longer matches the input (out-of-order
+      // resolves or a superseded keystroke) so the dropdown never goes stale.
+      if (inputRef.current && inputRef.current.value.trim() !== q.trim()) return;
+      if (!res.ok) {
+        setSuggestions([]);
+        return;
+      }
       const data = await res.json();
       setSuggestions((data.tools || []).slice(0, MAX_SUGGESTIONS));
     } catch (e) {
       console.error("Failed to fetch search suggestions:", e);
+      setSuggestions([]);
     }
   };
 
@@ -42,10 +46,14 @@ export function NavSearch() {
     debounceRef.current = window.setTimeout(() => fetchSuggestions(value), 300);
   };
 
-  // Auto-select first suggestion when the list changes
+  // Reset the highlight when the list changes. -1 means "nothing selected", so
+  // Enter runs a full search (/?q=) instead of jumping to the first tool.
   useEffect(() => {
-    setSelectedIndex(suggestions.length > 0 ? 0 : -1);
+    setSelectedIndex(-1);
   }, [suggestions]);
+
+  // Cancel a pending debounce if we unmount before it fires.
+  useEffect(() => () => clearTimeout(debounceRef.current), []);
 
   const goToTool = (name: string) => {
     window.location.href = `/tools/${name}`;
@@ -53,8 +61,8 @@ export function NavSearch() {
 
   const goToResults = () => {
     const q = query.trim();
-    if (!q) return;
-    window.location.href = `/?q=${encodeURIComponent(q)}`;
+    // Empty query resets to the full, unfiltered list.
+    window.location.href = q ? `/?q=${encodeURIComponent(q)}` : "/";
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -81,12 +89,15 @@ export function NavSearch() {
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();
-        setSelectedIndex((prev) => (prev + 1) % suggestions.length);
+        // Cycle forward, passing through -1 (no selection) after the last item.
+        setSelectedIndex((prev) =>
+          prev < suggestions.length - 1 ? prev + 1 : -1,
+        );
         break;
       case "ArrowUp":
         e.preventDefault();
-        setSelectedIndex(
-          (prev) => (prev - 1 + suggestions.length) % suggestions.length,
+        setSelectedIndex((prev) =>
+          prev > -1 ? prev - 1 : suggestions.length - 1,
         );
         break;
     }

--- a/web/src/components/ToolSearch.tsx
+++ b/web/src/components/ToolSearch.tsx
@@ -1,6 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "preact/hooks";
-
-const MAX_SUGGESTIONS = 8;
+import { useState, useMemo, useRef } from "preact/hooks";
 
 type SortKey = "name" | "downloads" | "updated";
 
@@ -259,12 +257,7 @@ export function ToolSearch({
   const [selectedBackends, setSelectedBackends] = useState<Set<string>>(
     new Set(initialBackends),
   );
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(-1);
   const [isLoading, setIsLoading] = useState(false);
-  const searchRef = useRef<HTMLInputElement>(null);
-  const searchDebounceRef = useRef<number>();
-  const isInitialMount = useRef(true);
 
   // Fetch tools from API
   const fetchTools = async (params: {
@@ -328,21 +321,6 @@ export function ToolSearch({
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
-  // Handle search change with debounce
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    setShowSuggestions(true);
-    clearTimeout(searchDebounceRef.current);
-    searchDebounceRef.current = window.setTimeout(() => {
-      fetchTools({
-        page: 1,
-        search: value,
-        sort: sortBy,
-        backends: [...selectedBackends],
-      });
-    }, 300);
-  };
-
   // Handle sort change
   const handleSortChange = (newSort: SortKey) => {
     setSortBy(newSort);
@@ -382,20 +360,6 @@ export function ToolSearch({
     });
   };
 
-  // Autocomplete suggestions
-  const suggestions = useMemo(() => {
-    if (!tools || !search.trim()) return [];
-    const query = search.toLowerCase();
-    return tools
-      .filter((t) => t.name.toLowerCase().includes(query))
-      .slice(0, MAX_SUGGESTIONS);
-  }, [tools, search]);
-
-  useEffect(() => {
-    // Auto-select first suggestion when searching
-    setSelectedIndex(suggestions.length > 0 ? 0 : -1);
-  }, [suggestions]);
-
   // Convert backendCounts object to sorted Map for rendering
   const sortedBackendCounts = useMemo(() => {
     return new Map(Object.entries(backendCounts).sort((a, b) => b[1] - a[1]));
@@ -409,50 +373,6 @@ export function ToolSearch({
       downloads_30d: downloads?.[t.name] || 0,
     }));
   }, [tools, downloads]);
-
-  const clearSearch = () => {
-    setSearch("");
-    setShowSuggestions(false);
-    clearTimeout(searchDebounceRef.current);
-    fetchTools({
-      page: 1,
-      search: "",
-      sort: sortBy,
-      backends: [...selectedBackends],
-    });
-    searchRef.current?.focus();
-  };
-
-  const handleSearchKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      clearSearch();
-      return;
-    }
-    if (!showSuggestions || suggestions.length === 0) return;
-    switch (e.key) {
-      case "ArrowDown":
-        e.preventDefault();
-        setSelectedIndex((prev) => (prev + 1) % suggestions.length);
-        break;
-      case "ArrowUp":
-        e.preventDefault();
-        setSelectedIndex(
-          (prev) => (prev - 1 + suggestions.length) % suggestions.length,
-        );
-        break;
-      case "Enter":
-        e.preventDefault();
-        if (selectedIndex >= 0 && selectedIndex < suggestions.length) {
-          window.location.href = `/tools/${suggestions[selectedIndex].name}`;
-        }
-        break;
-    }
-  };
-
-  const selectSuggestion = (name: string) => {
-    window.location.href = `/tools/${name}`;
-  };
 
   // Merge trending tools with tool metadata
   const hotTools = useMemo(() => {
@@ -682,69 +602,7 @@ export function ToolSearch({
           </div>
         )}
 
-      <div class="mb-4 flex items-center justify-between gap-4">
-        <div class="relative w-full max-w-md">
-          <input
-            ref={searchRef}
-            type="text"
-            placeholder="Search tools..."
-            value={search}
-            onInput={(e) =>
-              handleSearchChange((e.target as HTMLInputElement).value)
-            }
-            onFocus={() => setShowSuggestions(true)}
-            onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
-            onKeyDown={handleSearchKeyDown}
-            class="w-full px-4 py-2 pr-10 bg-dark-800 border border-dark-600 rounded-lg text-gray-100 placeholder-gray-500 focus:outline-none focus:border-neon-purple focus:ring-1 focus:ring-neon-purple"
-            autocomplete="off"
-          />
-          {search && (
-            <button
-              type="button"
-              onClick={clearSearch}
-              class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 transition-colors"
-              title="Clear search (Esc)"
-            >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
-          )}
-          {showSuggestions && suggestions.length > 0 && (
-            <div class="absolute z-50 w-full mt-1 bg-dark-800 border border-dark-600 rounded-lg shadow-lg overflow-hidden">
-              {suggestions.map((tool, index) => (
-                <button
-                  key={tool.name}
-                  type="button"
-                  onMouseDown={() => selectSuggestion(tool.name)}
-                  class={`w-full px-4 py-2 text-left text-sm transition-colors ${
-                    index === selectedIndex
-                      ? "bg-neon-purple/20 text-neon-purple"
-                      : "text-gray-300 hover:bg-dark-700"
-                  }`}
-                >
-                  <HighlightedName name={tool.name} />
-                  {tool.description && (
-                    <span class="ml-2 text-xs text-gray-500 truncate">
-                      {tool.description.slice(0, 50)}
-                      {tool.description.length > 50 ? "..." : ""}
-                    </span>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+      <div class="mb-4 flex items-center justify-end gap-4">
         <div class="text-sm text-gray-500 whitespace-nowrap flex items-center gap-2">
           {isLoading && (
             <svg

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -71,7 +71,7 @@ const currentPath = Astro.url.pathname;
           mise versions
         </a>
         <nav class="flex items-center gap-6">
-          <NavSearch client:load />
+          <NavSearch initialQuery={Astro.url.searchParams.get("q") || ""} client:load />
           <a
             href="/stats"
             class={`text-sm transition-colors flex items-center gap-1.5 ${currentPath === '/stats' ? 'text-neon-purple' : 'text-gray-400 hover:text-neon-purple'}`}

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import { AuthButton } from '../components/AuthButton';
 import { AdminButton } from '../components/AdminButton';
 import { MAUCounter } from '../components/MAUCounter';
+import { NavSearch } from '../components/NavSearch';
 import '../index.css';
 
 interface Props {
@@ -70,6 +71,7 @@ const currentPath = Astro.url.pathname;
           mise versions
         </a>
         <nav class="flex items-center gap-6">
+          <NavSearch client:load />
           <a
             href="/stats"
             class={`text-sm transition-colors flex items-center gap-1.5 ${currentPath === '/stats' ? 'text-neon-purple' : 'text-gray-400 hover:text-neon-purple'}`}


### PR DESCRIPTION
## What

Moves the tool search from the index-page body into the shared top navbar so it's reachable from every page (tool detail, stats, etc.), not just the home page.

## How

- New `NavSearch` Preact island in `Layout.astro`'s `<nav>`.
  - Autocomplete suggestions fetched from the existing `/api/tools?q=` endpoint (debounced).
  - Picking a suggestion → `/tools/{name}`; Enter with no selection → `/?q=<query>` (the index already reads `?q=` server-side).
  - Initializes its value from `?q=` so it reflects the active query on the index page.
- Removes the now-redundant search input (and its dead handlers/state) from `ToolSearch.tsx`, keeping the `search` state that sort / backend-filter / pagination derive from the `?q=` param.

## Testing

Ran the worker locally (`wrangler dev`) backed by real production data pulled from the public `/api/tools` (1037 tools):
- Suggestions resolve (`q=terra` → terraform, terragrunt, …).
- Enter → `/?q=kube` server-filters to matching tools.
- Suggestion click → `/tools/{name}` renders (200).
- Navbar search present + hydrated on index and tool pages.
- `astro build` and `tsc` clean.

## Notes

Pure front-end change; the `/api/tools` contract is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a search field to the top navigation.
  * Search suggestions appear as you type, with tool names and descriptions.
  * Supports keyboard navigation, Enter to select, and Escape to dismiss.
  * Selecting a suggestion opens the tool; submitting a query opens search results.

* **Improvements**
  * Simplified the dedicated tool search page while retaining filtering, sorting, and pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->