### PR TITLE
chore: exclude aube-lock.yaml from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,6 @@ bun.lock
 
 # Astro components — prettier-plugin-astro is not installed
 *.astro
+
+# aube-generated lockfile (not prettier-formatted)
+**/aube-lock.yaml


### PR DESCRIPTION
## Why

The shared `aube-lock` workflow ([jdx/renovate-config](https://github.com/jdx/renovate-config)) commits aube-regenerated lockfiles on `renovate/**` branches. But aube's generated `aube-lock.yaml` is **not** prettier-formatted, and this repo prettier-checks `**/*.yaml`, so those auto-fix commits would fail the prettier lint step.

Generated lockfiles shouldn't be prettier-checked (this repo already ignores other lockfiles). Add `aube-lock.yaml` to `.prettierignore`.

Discovered while fixing the equivalent issue in [jdx/hk#1095](https://github.com/jdx/hk/pull/1095).

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only `.prettierignore` change with no effect on application code or runtime behavior.
> 
> **Overview**
> **Ignores aube-generated lockfiles in Prettier** so CI lint no longer fails when the shared `aube-lock` workflow commits regenerated `aube-lock.yaml` on `renovate/**` branches.
> 
> Adds `**/aube-lock.yaml` under the existing lock-file section in `.prettierignore`, matching how `package-lock.json` and `bun.lock` are already excluded because generated lock output isn’t Prettier-formatted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf463403064e8ac79efa09720676b67df090170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->