### PR TITLE
fix(github): allow indirect Ruby metadata sources

### DIFF
--- a/scripts/github-registry.test.js
+++ b/scripts/github-registry.test.js
@@ -53,7 +53,7 @@ test("GitHub registry allowlist rejects unknown repos", async () => {
   assert.equal(allowed, false);
 });
 
-test("GitHub registry allowlist includes Erlang release repos", async () => {
+test("GitHub registry allowlist includes indirect release repos", async () => {
   const db = {
     prepare() {
       throw new Error("database should not be queried");
@@ -62,6 +62,10 @@ test("GitHub registry allowlist includes Erlang release repos", async () => {
 
   assert.equal(await isRegisteredGitHubRepo(db, "Erlang", "OTP"), true);
   assert.equal(await isRegisteredGitHubRepo(db, "Erlef", "OTP_Builds"), true);
+  assert.equal(
+    await isRegisteredGitHubRepo(db, "OneClick", "RubyInstaller2"),
+    true,
+  );
 });
 
 test("GitHub attestation allowlist includes python-build-standalone", () => {

--- a/web/src/lib/github/registry.ts
+++ b/web/src/lib/github/registry.ts
@@ -1,6 +1,10 @@
 const GITHUB_BACKEND_PREFIXES = ["aqua", "github", "ubi"] as const;
 
-const GITHUB_RELEASE_REPOS = new Set(["erlang/otp", "erlef/otp_builds"]);
+const GITHUB_RELEASE_REPOS = new Set([
+  "erlang/otp",
+  "erlef/otp_builds",
+  "oneclick/rubyinstaller2",
+]);
 
 const GITHUB_ATTESTATION_REPOS = new Set(["astral-sh/python-build-standalone"]);
 


### PR DESCRIPTION
## Summary

- allow `oneclick/rubyinstaller2` through the GitHub release mirror
- allow `jdx/ruby` through the GitHub attestation mirror
- cover both indirect repositories in the registry allowlist tests

## Root cause

`core:ruby` is a platform-specific special case with two indirect GitHub metadata sources that cannot be inferred from its `core:ruby` registry entry.

On macOS and Linux, mise installs Ruby from Ruby source or precompiled Ruby artifacts. On Windows, the same tool instead installs a RubyInstaller2 binary published from the separate `oneclick/rubyinstaller2` repository. When mise fills cross-platform lockfile metadata on macOS, it resolves that Windows release too. The D1-backed allowlist only sees `core:ruby`, so it rejected the indirect release repository with `403 GitHub repo is not in the mise registry` before mise fell back to GitHub.

The default precompiled Ruby path similarly verifies GitHub artifact attestations from `jdx/ruby`. The client deliberately uses `mise-versions` for that known source to reduce users' dependence on `GITHUB_TOKEN`, but the service's attestation exception list did not include it.

These fixed exceptions retain the registry gate while allowing the shared mirror to serve the metadata mise intentionally requests. The gate and its 403 response remain important: `mise-versions` uses a shared GitHub token pool to reduce anonymous API rate-limit failures, and it must not become an unrestricted public GitHub proxy.

## Validation

- `node --test scripts/github-registry.test.js`
- `mise exec -- npm test` (92 JavaScript tests and 31 shell tests passed)
