### PR TITLE
fix(github): allow jdx/ruby release metadata

### DIFF
--- a/scripts/github-registry.test.js
+++ b/scripts/github-registry.test.js
@@ -62,6 +62,7 @@ test("GitHub registry allowlist includes indirect release repos", async () => {
 
   assert.equal(await isRegisteredGitHubRepo(db, "Erlang", "OTP"), true);
   assert.equal(await isRegisteredGitHubRepo(db, "Erlef", "OTP_Builds"), true);
+  assert.equal(await isRegisteredGitHubRepo(db, "JDX", "Ruby"), true);
   assert.equal(
     await isRegisteredGitHubRepo(db, "OneClick", "RubyInstaller2"),
     true,

--- a/web/src/lib/github/registry.ts
+++ b/web/src/lib/github/registry.ts
@@ -3,6 +3,7 @@ const GITHUB_BACKEND_PREFIXES = ["aqua", "github", "ubi"] as const;
 const GITHUB_RELEASE_REPOS = new Set([
   "erlang/otp",
   "erlef/otp_builds",
+  "jdx/ruby",
   "oneclick/rubyinstaller2",
 ]);
 


### PR DESCRIPTION
## Summary

- allow `jdx/ruby` through the GitHub release metadata mirror
- cover the indirect release repository in the case-normalized allowlist test

## Why

`core:ruby` uses `jdx/ruby` as its default precompiled binary source. Exact locked build-revision and fallback release lookups are intentional requests from the core plugin, but the release mirror currently rejects the repository because the registry records only `core:ruby` and cannot infer this indirect source.

This keeps the registry gate intact while allowing the known default source. Custom `ruby.precompiled_url` repositories remain outside the allowlist and continue to use GitHub directly. This is the server-side prerequisite for retaining the versions-host path for the default source in jdx/mise#11154.

## Validation

- `node --test scripts/github-registry.test.js`
- `aube run test:js` (92 tests passed)
- `aube exec prettier --check web/src/lib/github/registry.ts scripts/github-registry.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `jdx/ruby` repository to the approved GitHub release registry.

* **Tests**
  * Added coverage confirming that `jdx/ruby` is recognized as an approved repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->