### PR TITLE
fix: preserve source order in version cache

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -37,6 +37,8 @@ env:
   # Backfill must read from upstream, not from mise-versions itself —
   # the whole point is to repair entries the host has wrong/stale.
   MISE_USE_VERSIONS_HOST: "false"
+  # Preserve canonical backend order regardless of user-facing ordering policy.
+  MISE_LS_REMOTE_SOURCE_ORDER: "true"
 
 jobs:
   backfill:

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 export MISE_NODE_MIRROR_URL="https://nodejs.org/dist/"
 export MISE_USE_VERSIONS_HOST=0
+export MISE_LS_REMOTE_SOURCE_ORDER=true
 export MISE_LIST_ALL_VERSIONS=1
 export MISE_LOG_HTTP=1
 
@@ -586,7 +587,7 @@ fetch() {
 	local stderr_file
 	stderr_file=$(mktemp)
 
-	if ! docker run --rm -e GITHUB_TOKEN="$token" -e MISE_USE_VERSIONS_HOST -e MISE_LIST_ALL_VERSIONS -e MISE_LOG_HTTP -e MISE_EXPERIMENTAL -e MISE_PRERELEASES -e MISE_TRUSTED_CONFIG_PATHS=/ \
+	if ! docker run --rm -e GITHUB_TOKEN="$token" -e MISE_USE_VERSIONS_HOST -e MISE_LS_REMOTE_SOURCE_ORDER -e MISE_LIST_ALL_VERSIONS -e MISE_LOG_HTTP -e MISE_EXPERIMENTAL -e MISE_PRERELEASES -e MISE_TRUSTED_CONFIG_PATHS=/ \
 		jdxcode/mise -y ls-remote "$tool" >"docs/$tool" 2>"$stderr_file"; then
 		log_error "Failed to fetch versions" "tool=$tool"
 		cat "$stderr_file" >&2


### PR DESCRIPTION
## Summary

- set `MISE_LS_REMOTE_SOURCE_ORDER=true` for the version collector
- pass the setting into the isolated Docker invocation used for plain-text version files
- apply the same setting to metadata backfills

## Why

[jdx/mise#11481](https://github.com/jdx/mise/pull/11481) makes `mise ls-remote` display the effective configured version order, matching version resolution. That is the least surprising behavior for users, but `mise-versions` has a different responsibility: it stores each backend's canonical source sequence so clients can apply their own ordering policy.

Without this explicit opt-out, registry defaults such as `version_order = "semver"` would be baked into the shared cache. A user choosing `version_order = "source"` would then be unable to recover the upstream sequence from the versions host.

The new environment variable is ignored by older mise releases, whose `ls-remote` output is already source-ordered, so this can land before the corresponding mise behavior without changing current output.

This follows the ordering design discussed in [jdx/mise discussion #10957](https://github.com/jdx/mise/discussions/10957).

## Validation

- `aube run test:shell` — 31 passed
- `mise run lint:fix` could not run because the current dependency resolution installs ESLint 10 while this repository still uses the pre-flat-config layout; the failure is unrelated to these shell/YAML changes

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved canonical backend ordering when retrieving remote version information.
  * Ensured consistent ordering across automated backfills and Docker-based update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->