### PR TITLE
feat(search): add scalable tool catalog sitemaps

### DIFF
--- a/web/src/pages/algolia-sitemap.xml.ts
+++ b/web/src/pages/algolia-sitemap.xml.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { loadToolsJson } from "../lib/data-loader";
+import { ALGOLIA_TOOLS_PER_PAGE } from "./algolia-tools/[page]";
+
+const ORIGIN = "https://mise-versions.jdx.dev";
+
+export const GET: APIRoute = async () => {
+  const data = await loadToolsJson(env.ANALYTICS_DB);
+  if (!data) {
+    return new Response("Failed to load tools", { status: 500 });
+  }
+
+  const pageCount = Math.ceil(data.tool_count / ALGOLIA_TOOLS_PER_PAGE);
+  const urls = Array.from(
+    { length: pageCount },
+    (_, index) => `<url><loc>${ORIGIN}/algolia-tools/${index + 1}</loc></url>`,
+  ).join("");
+  const xml = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=600, stale-while-revalidate=3600",
+    },
+  });
+};

--- a/web/src/pages/algolia-tools/[page].ts
+++ b/web/src/pages/algolia-tools/[page].ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { loadToolsJson } from "../../lib/data-loader";
+
+export const ALGOLIA_TOOLS_PER_PAGE = 150;
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export const GET: APIRoute = async ({ params }) => {
+  const page = Number.parseInt(params.page ?? "", 10);
+  if (!Number.isInteger(page) || page < 1) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const data = await loadToolsJson(env.ANALYTICS_DB);
+  if (!data) {
+    return new Response("Failed to load tools", { status: 500 });
+  }
+
+  const start = (page - 1) * ALGOLIA_TOOLS_PER_PAGE;
+  const tools = data.tools.slice(start, start + ALGOLIA_TOOLS_PER_PAGE);
+  if (tools.length === 0) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const records = tools
+    .map((tool) => {
+      const name = escapeHtml(tool.name);
+      const href = escapeHtml(`/tools/${encodeURIComponent(tool.name)}`);
+      const description = escapeHtml(tool.description ?? "");
+      const backends = escapeHtml(tool.backends?.join(" ") ?? "");
+      return `<article class="algolia-tool" data-url="${href}"><h1>${name}</h1><p class="description">${description}</p><p class="backends">${backends}</p><code>mise use ${name}@latest</code></article>`;
+    })
+    .join("\n");
+
+  const html = `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><title>mise tools search feed ${page}</title></head><body><main>${records}</main></body></html>`;
+
+  return new Response(html, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=600, stale-while-revalidate=3600",
+    },
+  });
+};

--- a/web/src/pages/sitemap.xml.ts
+++ b/web/src/pages/sitemap.xml.ts
@@ -1,0 +1,39 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { loadToolsJson } from "../lib/data-loader";
+
+const ORIGIN = "https://mise-versions.jdx.dev";
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export const GET: APIRoute = async () => {
+  const data = await loadToolsJson(env.ANALYTICS_DB);
+  if (!data) {
+    return new Response("Failed to load tools", { status: 500 });
+  }
+
+  const urls = [
+    `${ORIGIN}/`,
+    `${ORIGIN}/stats`,
+    ...data.tools.map(
+      (tool) => `${ORIGIN}/tools/${encodeURIComponent(tool.name)}`,
+    ),
+  ]
+    .map((url) => `<url><loc>${escapeXml(url)}</loc></url>`)
+    .join("");
+  const xml = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=600, stale-while-revalidate=3600",
+    },
+  });
+};


### PR DESCRIPTION
## What changed

- add a standard sitemap containing the site and every canonical tool page
- add a crawler-specific sitemap whose page count is derived from the current tool count
- add compact, noindex Algolia feed pages containing at most 150 tool records each

## Why

The visible tool catalog uses client-side pagination, so the Algolia crawler could not discover later pages without a hardcoded URL list. Following links from those pages also made the crawler fetch every large tool detail page.

The new feed grows automatically as tools are added and exposes compact records without crawlable detail-page links. This removes the fixed page limit and sharply reduces crawl work.

## Validation

- `aube exec tsc --noEmit`
- `aube --dir web exec astro build`
- `prettier --check` on the new endpoints
