### PR TITLE
feat: add historical MAU story to stats

### DIFF
--- a/web/src/components/MAUCounter.tsx
+++ b/web/src/components/MAUCounter.tsx
@@ -1,14 +1,5 @@
 import { useState, useEffect } from "preact/hooks";
-
-function formatCompact(n: number): string {
-  if (n >= 1_000_000) {
-    return (n / 1_000_000).toFixed(n >= 10_000_000 ? 1 : 2) + "m";
-  }
-  if (n >= 1_000) {
-    return (n / 1_000).toFixed(n >= 10_000 ? 1 : 2) + "k";
-  }
-  return n.toString();
-}
+import { formatCompact } from "../lib/format";
 
 export function MAUCounter() {
   const [mau, setMAU] = useState<number | null>(null);

--- a/web/src/components/MauHistory.astro
+++ b/web/src/components/MauHistory.astro
@@ -1,4 +1,6 @@
 ---
+import { formatCompact } from "../lib/format";
+
 type MauPoint = { date: string; mau: number };
 
 interface Props {
@@ -8,12 +10,6 @@ interface Props {
 const { daily } = Astro.props;
 const data = daily.filter((point) => point.mau > 0);
 const latest = data.at(-1);
-
-function formatCompact(value: number): string {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}m`;
-  if (value >= 1_000) return `${(value / 1_000).toFixed(value >= 100_000 ? 0 : 1)}k`;
-  return value.toLocaleString();
-}
 
 function formatChange(current: number, previous?: number): number | null {
   if (!previous) return null;
@@ -72,17 +68,26 @@ const rawMax = values.length > 0 ? Math.max(...values) : 1;
 const range = Math.max(rawMax - rawMin, rawMax * 0.1, 1);
 const yMin = Math.max(0, rawMin - range * 0.12);
 const yMax = rawMax + range * 0.12;
-const xForIndex = (index: number) =>
-  data.length <= 1 ? chartWidth / 2 : (index / (data.length - 1)) * chartWidth;
+const timestampForDate = (date: string) =>
+  new Date(`${date}T00:00:00Z`).getTime();
+const firstTimestamp = data.length > 0 ? timestampForDate(data[0].date) : 0;
+const lastTimestamp = latest ? timestampForDate(latest.date) : firstTimestamp;
+const xForDate = (date: string) =>
+  firstTimestamp === lastTimestamp
+    ? chartWidth / 2
+    : ((timestampForDate(date) - firstTimestamp) /
+        (lastTimestamp - firstTimestamp)) *
+      chartWidth;
 const yForValue = (value: number) =>
   chartHeight - ((value - yMin) / (yMax - yMin)) * chartHeight;
 const mauPath = data
   .map(
     (point, index) =>
-      `${index === 0 ? "M" : "L"} ${xForIndex(index)} ${yForValue(point.mau)}`,
+      `${index === 0 ? "M" : "L"} ${xForDate(point.date)} ${yForValue(point.mau)}`,
   )
   .join(" ");
-const launchIndex = data.findIndex((point) => point.date >= quattroLaunch);
+const showQuattroLaunch =
+  data.length > 0 && quattroLaunch >= data[0].date && quattroLaunch <= latest!.date;
 const monthStarts = [
   ...data
     .reduce((months, point) => {
@@ -97,6 +102,7 @@ const xTicks = monthStarts.filter(
   (_, index) => index % tickInterval === 0 || index === monthStarts.length - 1,
 );
 const yTicks = [yMax, (yMax + yMin) / 2, yMin];
+const currentMonth = new Date().toISOString().slice(0, 7);
 ---
 
 {latest && (
@@ -138,7 +144,7 @@ const yTicks = [yMax, (yMax + yMin) / 2, yMin];
     </div>
 
     <div class="overflow-x-auto">
-      <svg viewBox={`0 0 ${width} ${height}`} class="min-w-[700px] w-full" role="img" aria-label="Trailing 30-day monthly active users over time">
+      <svg viewBox={`0 0 ${width} ${height}`} class="min-w-[700px] w-full" role="img" aria-label="Daily snapshots of trailing 30-day monthly active users over the past year">
         <g transform={`translate(${padding.left}, ${padding.top})`}>
           {yTicks.map((tick) => (
             <g>
@@ -148,31 +154,30 @@ const yTicks = [yMax, (yMax + yMin) / 2, yMin];
               </text>
             </g>
           ))}
-          {launchIndex >= 0 && (
+          {showQuattroLaunch && (
             <g>
               <line
-                x1={xForIndex(launchIndex)}
-                x2={xForIndex(launchIndex)}
+                x1={xForDate(quattroLaunch)}
+                x2={xForDate(quattroLaunch)}
                 y1="0"
                 y2={chartHeight}
                 stroke="#F472B6"
                 stroke-width="1.5"
                 stroke-dasharray="5 4"
               />
-              <text x={xForIndex(launchIndex) + 6} y="12" class="fill-pink-400 text-xs">Quattro</text>
+              <text x={xForDate(quattroLaunch) + 6} y="12" class="fill-pink-400 text-xs">Quattro</text>
             </g>
           )}
           <path d={mauPath} fill="none" stroke="#00D4FF" stroke-width="3" stroke-linejoin="round" />
-          {data.map((point, index) => (
-            <circle cx={xForIndex(index)} cy={yForValue(point.mau)} r="6" fill="transparent">
+          {data.map((point) => (
+            <circle cx={xForDate(point.date)} cy={yForValue(point.mau)} r="6" fill="transparent">
               <title>{point.date}: {point.mau.toLocaleString()} MAU</title>
             </circle>
           ))}
-          <circle cx={xForIndex(data.length - 1)} cy={yForValue(latest.mau)} r="4" fill="#00D4FF" />
+          <circle cx={xForDate(latest.date)} cy={yForValue(latest.mau)} r="4" fill="#00D4FF" />
           {xTicks.map((point) => {
-            const index = data.indexOf(point);
             return (
-              <text x={xForIndex(index)} y={chartHeight + 24} text-anchor="middle" class="fill-gray-500 text-xs">
+              <text x={xForDate(point.date)} y={chartHeight + 24} text-anchor="middle" class="fill-gray-500 text-xs">
                 {point.date.slice(0, 7)}
               </text>
             );
@@ -203,7 +208,7 @@ const yTicks = [yMax, (yMax + yMin) / 2, yMin];
                   <tr class="border-b border-dark-700 last:border-0">
                     <td class="py-2 pr-4 text-gray-300">
                       {new Date(`${point.date}T00:00:00Z`).toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" })}
-                      {point === latest && <span class="ml-2 text-xs text-gray-500">month to date</span>}
+                      {point === latest && point.date.startsWith(currentMonth) && <span class="ml-2 text-xs text-gray-500">month to date</span>}
                     </td>
                     <td class="py-2 px-4 text-gray-500">{point.date}</td>
                     <td class="py-2 px-4 text-right text-gray-300" title={`Snapshot from ${point.date}`}>

--- a/web/src/components/MauHistory.astro
+++ b/web/src/components/MauHistory.astro
@@ -1,0 +1,224 @@
+---
+type MauPoint = { date: string; mau: number };
+
+interface Props {
+  daily: MauPoint[];
+}
+
+const { daily } = Astro.props;
+const data = daily.filter((point) => point.mau > 0);
+const latest = data.at(-1);
+
+function formatCompact(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}m`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(value >= 100_000 ? 0 : 1)}k`;
+  return value.toLocaleString();
+}
+
+function formatChange(current: number, previous?: number): number | null {
+  if (!previous) return null;
+  return ((current - previous) / previous) * 100;
+}
+
+function snapshotAtOrBefore(date: string): MauPoint | undefined {
+  return data.findLast((point) => point.date <= date);
+}
+
+function daysBefore(date: string, days: number): string {
+  const timestamp = new Date(`${date}T00:00:00Z`).getTime() - days * 86400_000;
+  return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+function daysBetween(start: string, end: string): number {
+  return Math.round(
+    (new Date(`${end}T00:00:00Z`).getTime() -
+      new Date(`${start}T00:00:00Z`).getTime()) /
+      86400_000,
+  );
+}
+
+const monthEnds = [
+  ...data
+    .reduce((months, point) => {
+      months.set(point.date.slice(0, 7), point);
+      return months;
+    }, new Map<string, MauPoint>())
+    .values(),
+];
+const recentMonths = monthEnds.slice(-12);
+
+const thirtyDayBaseline = latest
+  ? snapshotAtOrBefore(daysBefore(latest.date, 30))
+  : undefined;
+const thirtyDayChange = latest
+  ? formatChange(latest.mau, thirtyDayBaseline?.mau)
+  : null;
+
+const quattroLaunch = "2026-08-14";
+const quattroBaseline = snapshotAtOrBefore(daysBefore(quattroLaunch, 1));
+const quattroChange =
+  latest && latest.date >= quattroLaunch
+    ? formatChange(latest.mau, quattroBaseline?.mau)
+    : null;
+
+const width = 1000;
+const height = 280;
+const padding = { top: 24, right: 24, bottom: 42, left: 70 };
+const chartWidth = width - padding.left - padding.right;
+const chartHeight = height - padding.top - padding.bottom;
+const values = data.map((point) => point.mau);
+const rawMin = values.length > 0 ? Math.min(...values) : 0;
+const rawMax = values.length > 0 ? Math.max(...values) : 1;
+const range = Math.max(rawMax - rawMin, rawMax * 0.1, 1);
+const yMin = Math.max(0, rawMin - range * 0.12);
+const yMax = rawMax + range * 0.12;
+const xForIndex = (index: number) =>
+  data.length <= 1 ? chartWidth / 2 : (index / (data.length - 1)) * chartWidth;
+const yForValue = (value: number) =>
+  chartHeight - ((value - yMin) / (yMax - yMin)) * chartHeight;
+const mauPath = data
+  .map(
+    (point, index) =>
+      `${index === 0 ? "M" : "L"} ${xForIndex(index)} ${yForValue(point.mau)}`,
+  )
+  .join(" ");
+const launchIndex = data.findIndex((point) => point.date >= quattroLaunch);
+const monthStarts = [
+  ...data
+    .reduce((months, point) => {
+      const month = point.date.slice(0, 7);
+      if (!months.has(month)) months.set(month, point);
+      return months;
+    }, new Map<string, MauPoint>())
+    .values(),
+];
+const tickInterval = Math.max(1, Math.ceil(monthStarts.length / 7));
+const xTicks = monthStarts.filter(
+  (_, index) => index % tickInterval === 0 || index === monthStarts.length - 1,
+);
+const yTicks = [yMax, (yMax + yMin) / 2, yMin];
+---
+
+{latest && (
+  <section class="bg-dark-800 border border-dark-600 rounded-lg p-4">
+    <div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between mb-4">
+      <div>
+        <h2 class="text-lg font-semibold text-gray-200">Monthly Active Users</h2>
+        <p class="text-xs text-gray-500">
+          Unique users across downloads and version checks in the trailing 30 days; daily snapshots make recent changes visible before a calendar month closes.
+        </p>
+      </div>
+      <span class="text-xs text-gray-500">through {latest.date}</span>
+    </div>
+
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5">
+      <div class="bg-dark-700 rounded p-3">
+        <div class="text-xs text-gray-400">Latest MAU snapshot</div>
+        <div class="text-2xl font-semibold text-cyan-400">{formatCompact(latest.mau)}</div>
+      </div>
+      <div class="bg-dark-700 rounded p-3">
+        <div class="text-xs text-gray-400">30-day change</div>
+        <div class={`text-2xl font-semibold ${thirtyDayChange === null ? 'text-gray-500' : thirtyDayChange >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+          {thirtyDayChange === null ? "—" : `${thirtyDayChange >= 0 ? "+" : ""}${thirtyDayChange.toFixed(1)}%`}
+        </div>
+        {thirtyDayBaseline && <div class="text-xs text-gray-500">from {formatCompact(thirtyDayBaseline.mau)}</div>}
+      </div>
+      <div class="bg-dark-700 rounded p-3">
+        <div class="text-xs text-gray-400">Since Omarchy Quattro</div>
+        <div class={`text-2xl font-semibold ${quattroChange === null ? 'text-gray-500' : quattroChange >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+          {quattroChange === null ? "—" : `${quattroChange >= 0 ? "+" : ""}${quattroChange.toFixed(1)}%`}
+        </div>
+        {quattroBaseline && latest.date >= quattroLaunch && (
+          <div class="text-xs text-gray-500">
+            {daysBetween(quattroLaunch, latest.date)} days since Aug 14 launch; baseline {formatCompact(quattroBaseline.mau)}
+          </div>
+        )}
+        <div class="text-[11px] text-gray-600 mt-1">Timing comparison, not causal attribution.</div>
+      </div>
+    </div>
+
+    <div class="overflow-x-auto">
+      <svg viewBox={`0 0 ${width} ${height}`} class="min-w-[700px] w-full" role="img" aria-label="Trailing 30-day monthly active users over time">
+        <g transform={`translate(${padding.left}, ${padding.top})`}>
+          {yTicks.map((tick) => (
+            <g>
+              <line x1="0" x2={chartWidth} y1={yForValue(tick)} y2={yForValue(tick)} stroke="#374151" stroke-width="1" />
+              <text x="-10" y={yForValue(tick) + 4} text-anchor="end" class="fill-gray-500 text-xs">
+                {formatCompact(Math.round(tick))}
+              </text>
+            </g>
+          ))}
+          {launchIndex >= 0 && (
+            <g>
+              <line
+                x1={xForIndex(launchIndex)}
+                x2={xForIndex(launchIndex)}
+                y1="0"
+                y2={chartHeight}
+                stroke="#F472B6"
+                stroke-width="1.5"
+                stroke-dasharray="5 4"
+              />
+              <text x={xForIndex(launchIndex) + 6} y="12" class="fill-pink-400 text-xs">Quattro</text>
+            </g>
+          )}
+          <path d={mauPath} fill="none" stroke="#00D4FF" stroke-width="3" stroke-linejoin="round" />
+          {data.map((point, index) => (
+            <circle cx={xForIndex(index)} cy={yForValue(point.mau)} r="6" fill="transparent">
+              <title>{point.date}: {point.mau.toLocaleString()} MAU</title>
+            </circle>
+          ))}
+          <circle cx={xForIndex(data.length - 1)} cy={yForValue(latest.mau)} r="4" fill="#00D4FF" />
+          {xTicks.map((point) => {
+            const index = data.indexOf(point);
+            return (
+              <text x={xForIndex(index)} y={chartHeight + 24} text-anchor="middle" class="fill-gray-500 text-xs">
+                {point.date.slice(0, 7)}
+              </text>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+
+    {recentMonths.length > 0 && (
+      <div class="mt-5">
+        <h3 class="text-sm font-medium text-gray-300 mb-2">Monthly history</h3>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-dark-600 text-left text-xs text-gray-500">
+                <th class="py-2 pr-4 font-medium">Month</th>
+                <th class="py-2 px-4 font-medium">Snapshot</th>
+                <th class="py-2 px-4 font-medium text-right">MAU snapshot</th>
+                <th class="py-2 pl-4 font-medium text-right">Month-over-month</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...recentMonths].reverse().map((point) => {
+                const index = monthEnds.indexOf(point);
+                const previous = index > 0 ? monthEnds[index - 1] : undefined;
+                const change = formatChange(point.mau, previous?.mau);
+                return (
+                  <tr class="border-b border-dark-700 last:border-0">
+                    <td class="py-2 pr-4 text-gray-300">
+                      {new Date(`${point.date}T00:00:00Z`).toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" })}
+                      {point === latest && <span class="ml-2 text-xs text-gray-500">month to date</span>}
+                    </td>
+                    <td class="py-2 px-4 text-gray-500">{point.date}</td>
+                    <td class="py-2 px-4 text-right text-gray-300" title={`Snapshot from ${point.date}`}>
+                      {point.mau.toLocaleString()}
+                    </td>
+                    <td class={`py-2 pl-4 text-right ${change === null ? 'text-gray-500' : change >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                      {change === null ? "—" : `${change >= 0 ? "+" : ""}${change.toFixed(1)}%`}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )}
+  </section>
+)}

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,9 @@
+export function formatCompact(n: number): string {
+  if (n >= 1_000_000) {
+    return (n / 1_000_000).toFixed(n >= 10_000_000 ? 1 : 2) + "m";
+  }
+  if (n >= 1_000) {
+    return (n / 1_000).toFixed(n >= 10_000 ? 1 : 2) + "k";
+  }
+  return n.toString();
+}

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -4,6 +4,7 @@ import MauHistory from '../components/MauHistory.astro';
 import { drizzle } from 'drizzle-orm/d1';
 import { setupAnalytics } from '../../../src/analytics';
 import { loadToolsJson, type ToolsData } from '../lib/data-loader';
+import { formatCompact } from '../lib/format';
 
 import { env } from "cloudflare:workers";
 // Version updates data type (now from D1)
@@ -58,16 +59,6 @@ try {
 }
 
 // Helper functions
-function formatCompact(n: number): string {
-  if (n >= 1_000_000) {
-    return (n / 1_000_000).toFixed(n >= 10_000_000 ? 1 : 2) + "m";
-  }
-  if (n >= 1_000) {
-    return (n / 1_000).toFixed(n >= 10_000 ? 1 : 2) + "k";
-  }
-  return n.toString();
-}
-
 function getBackendType(backend: string): string {
   const colonIndex = backend.indexOf(":");
   return colonIndex > 0 ? backend.slice(0, colonIndex) : backend;
@@ -315,7 +306,7 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
               const chartHeight = height - padding.top - padding.bottom;
               type DayData = { date: string; dau: number };
               const data: DayData[] = dauMauData.daily.slice(-29);
-              const maxDAU = Math.max(...data.map(d => d.dau));
+              const maxDAU = Math.max(...data.map(d => d.dau), 1);
               const barWidth = chartWidth / data.length - 2;
 
               return (

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import MauHistory from '../components/MauHistory.astro';
 import { drizzle } from 'drizzle-orm/d1';
 import { setupAnalytics } from '../../../src/analytics';
 import { loadToolsJson, type ToolsData } from '../lib/data-loader';
@@ -39,7 +40,7 @@ try {
 // Fetch analytics data with error handling for local dev
 let downloads: Record<string, number> = {};
 let backendStatsData: { downloads_by_backend: Array<{ backend: string; count: number }>; top_tools_by_backend: Record<string, Array<{ tool: string; count: number }>> } | null = null;
-let dauMauData: { daily: Array<{ date: string; dau: number }>; current_mau: number } | null = null;
+let dauMauData: { daily: Array<{ date: string; dau: number; mau: number }>; current_mau: number } | null = null;
 let growthData: { global: { wow: number | null; mom: number | null }; topGrowing: Array<{ tool: string; thisWeek: number; wow: number | null }>; topDeclining: Array<{ tool: string; thisWeek: number; wow: number | null }> } | null = null;
 let versionUpdatesData: VersionUpdatesData | null = null;
 
@@ -47,7 +48,7 @@ try {
   [downloads, backendStatsData, dauMauData, growthData, versionUpdatesData] = await Promise.all([
     analytics.getAll30DayDownloads(),
     analytics.getBackendStats(),
-    analytics.getDAUMAUHistory(30),
+    analytics.getDAUMAUHistory(370),
     analytics.getGrowthMetrics(),
     analytics.getVersionUpdates(30),
   ]);
@@ -296,15 +297,14 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
       </div>
     </div>
 
-    <!-- DAU/MAU and Version Updates charts -->
+    {dauMauData && <MauHistory daily={dauMauData.daily} />}
+
+    <!-- DAU and Version Updates charts -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
       {dauMauData && dauMauData.daily.length > 0 && (
         <div class="bg-dark-800 border border-dark-600 rounded-lg p-4">
           <h2 class="text-lg font-semibold text-gray-200 mb-3">
-            Daily & Monthly Active Users
-            <span class="text-sm font-normal text-gray-400 ml-2">
-              (MAU: {formatCompact(dauMauData.current_mau)})
-            </span>
+            Daily Active Users
           </h2>
           <div class="overflow-x-auto">
             {(() => {
@@ -313,49 +313,23 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
               const padding = { top: 20, right: 50, bottom: 30, left: 50 };
               const chartWidth = width - padding.left - padding.right;
               const chartHeight = height - padding.top - padding.bottom;
-              type DayData = { date: string; dau: number; mau?: number };
-              const data: DayData[] = dauMauData.daily;
+              type DayData = { date: string; dau: number };
+              const data: DayData[] = dauMauData.daily.slice(-29);
               const maxDAU = Math.max(...data.map(d => d.dau));
-              const maxMAU = Math.max(...data.map(d => d.mau || 0));
-              const yScaleDAU = (v: number) => chartHeight - (v / maxDAU) * chartHeight;
-              const yScaleMAU = (v: number) => chartHeight - (v / maxMAU) * chartHeight;
               const barWidth = chartWidth / data.length - 2;
-
-              // Build MAU polyline points using MAU scale
-              const mauPoints: string[] = [];
-              for (let i = 0; i < data.length; i++) {
-                const d = data[i];
-                if (d.mau && d.mau > 0) {
-                  const px = (i / data.length) * chartWidth + barWidth / 2;
-                  const py = yScaleMAU(d.mau);
-                  mauPoints.push(String(px) + "," + String(py));
-                }
-              }
-              const mauPath = mauPoints.length > 1 ? "M " + mauPoints.join(" L ") : "";
 
               return (
                 <svg width={width} height={height} class="min-w-[400px]">
-                  {/* Left Y-axis (DAU - purple) */}
                   <text x={padding.left - 10} y={padding.top} text-anchor="end" class="fill-purple-400 text-xs">
                     {formatCompact(maxDAU)}
                   </text>
                   <text x={padding.left - 10} y={padding.top + chartHeight} text-anchor="end" class="fill-purple-400 text-xs">
                     0
                   </text>
-                  {/* Right Y-axis (MAU - cyan) */}
-                  <text x={width - padding.right + 10} y={padding.top} text-anchor="start" class="fill-cyan-400 text-xs">
-                    {formatCompact(maxMAU)}
-                  </text>
-                  <text x={width - padding.right + 10} y={padding.top + chartHeight} text-anchor="start" class="fill-cyan-400 text-xs">
-                    0
-                  </text>
                   <g transform={`translate(${padding.left}, ${padding.top})`}>
                     {data.map((d, i) => {
                       const x = (i / data.length) * chartWidth + 1;
                       const barHeight = (d.dau / maxDAU) * chartHeight;
-                      const titleText = d.mau
-                        ? String(d.date) + ": " + d.dau.toLocaleString() + " DAU, " + d.mau.toLocaleString() + " MAU"
-                        : String(d.date) + ": " + d.dau.toLocaleString() + " DAU";
                       return (
                         <rect
                           x={x}
@@ -365,19 +339,10 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                           fill="#B026FF"
                           opacity="0.8"
                         >
-                          <title>{titleText}</title>
+                          <title>{d.date}: {d.dau.toLocaleString()} DAU</title>
                         </rect>
                       );
                     })}
-                    {mauPath.length > 0 && (
-                      <path d={mauPath} fill="none" stroke="#00D4FF" stroke-width="2" />
-                    )}
-                    <g transform={`translate(${chartWidth - 80}, -10)`}>
-                      <rect x={0} y={0} width={10} height={10} fill="#B026FF" opacity="0.8" />
-                      <text x={14} y={9} class="fill-gray-400 text-xs">DAU</text>
-                      <line x1={40} y1={5} x2={55} y2={5} stroke="#00D4FF" stroke-width="2" />
-                      <text x={59} y={9} class="fill-gray-400 text-xs">MAU</text>
-                    </g>
                     {data.map((d, i) => {
                       if (i % 7 !== 0 && i !== data.length - 1) return null;
                       const x = (i / data.length) * chartWidth + barWidth / 2;


### PR DESCRIPTION
## Summary

- expand MAU history from 30 days to roughly one year
- add latest-snapshot, 30-day growth, and post-Quattro comparison cards
- mark the August 14 Omarchy Quattro launch on the MAU trend
- add month-by-month MAU snapshots with month-over-month changes
- separate the short-term DAU chart from the longer-term MAU story
- clarify that the Quattro number is a timing comparison, not causal attribution

## What the current data says

The last complete pre-launch snapshot was 458,158 MAU on August 13. MAU reached 568,065 on August 24, a 24.0% increase over ten full post-launch days. The live MAU endpoint can differ slightly from the completed daily snapshot; on August 25 it reported 563,933 (+23.1%).

Because MAU is a trailing 30-day unique-user measure and Quattro launched recently, the page uses daily event snapshots for the launch comparison while retaining month-end snapshots for longer-term trends.

Quattro release: https://github.com/basecamp/omarchy/releases/tag/v4.0.0

## Testing

- `aube --dir web run build`
- `aube run test:js` (92 passed)
- `aube run test:shell` (31 passed)
- Prettier check on changed Astro files
- local D1 seed and visual browser check of the stats page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only stats UI and a longer read of existing analytics; no auth, payments, or write paths changed.
> 
> **Overview**
> Adds a dedicated **Monthly Active Users** section on the stats page with ~one year of daily trailing-30-day snapshots (analytics fetch widened from 30 to **370** days).
> 
> The new `MauHistory` block shows summary cards (latest MAU, 30-day % change, and a **Since Omarchy Quattro** timing comparison with a disclaimer), an SVG trend line with a **Quattro** launch marker on 2026-08-14, and a 12-month table with month-over-month deltas. The section hides when there is no usable MAU data.
> 
> The combined DAU/MAU chart is split: MAU moves into this section while the existing chart becomes **DAU-only**, using roughly the last 29 days of bars. **`formatCompact`** is extracted to `web/src/lib/format` and shared with `MAUCounter` and the stats page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f6c81e4837b0d93c487e9dff890c3c7d5c0f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a monthly active users history section with summary metrics, trend visualization, launch marker, tooltips, and monthly history.
  * Displays unavailable comparison values when baseline data is missing.
* **Improvements**
  * Extended activity data coverage to support long-term MAU history.
  * Simplified the existing activity chart to focus on daily active users and recent data.
  * Sections with no usable data are now hidden automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->