### PR TITLE
fix: refine stats history and mobile layout

### DIFF
--- a/web/src/components/AdminButton.tsx
+++ b/web/src/components/AdminButton.tsx
@@ -47,7 +47,8 @@ export function AdminButton() {
       </a>
       <a
         href="/admin"
-        class="hidden text-sm text-gray-400 hover:text-neon-purple transition-colors xl:flex items-center gap-1.5"
+        aria-label="Admin"
+        class="flex items-center gap-1.5 text-sm text-gray-400 transition-colors hover:text-neon-purple"
       >
         <svg
           class="w-4 h-4"
@@ -68,7 +69,7 @@ export function AdminButton() {
             d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
           />
         </svg>
-        Admin
+        <span class="hidden xl:inline">Admin</span>
       </a>
     </>
   );

--- a/web/src/components/AdminButton.tsx
+++ b/web/src/components/AdminButton.tsx
@@ -26,7 +26,7 @@ export function AdminButton() {
     <>
       <a
         href="https://github.com/jdx/mise-versions"
-        class="text-sm text-gray-400 hover:text-neon-purple transition-colors flex items-center gap-1.5"
+        class="hidden text-sm text-gray-400 hover:text-neon-purple transition-colors xl:flex items-center gap-1.5"
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -47,7 +47,7 @@ export function AdminButton() {
       </a>
       <a
         href="/admin"
-        class="text-sm text-gray-400 hover:text-neon-purple transition-colors flex items-center gap-1.5"
+        class="hidden text-sm text-gray-400 hover:text-neon-purple transition-colors xl:flex items-center gap-1.5"
       >
         <svg
           class="w-4 h-4"

--- a/web/src/components/AuthButton.tsx
+++ b/web/src/components/AuthButton.tsx
@@ -61,28 +61,38 @@ export function AuthButton() {
 
   if (state.authenticated) {
     return (
-      <div class="flex items-center gap-3">
-        <span class="text-gray-400 text-sm">
-          <GitHubIcon />
-        </span>
-        <span class="text-gray-300">{state.username}</span>
+      <>
         <a
           href={logoutUrl}
-          class="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+          aria-label={`Logout ${state.username || "GitHub user"}`}
+          class="text-gray-400 transition-colors hover:text-gray-200 xl:hidden"
         >
-          Logout
+          <GitHubIcon />
         </a>
-      </div>
+        <div class="hidden items-center gap-3 xl:flex">
+          <span class="text-gray-400 text-sm">
+            <GitHubIcon />
+          </span>
+          <span class="text-gray-300">{state.username}</span>
+          <a
+            href={logoutUrl}
+            class="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+          >
+            Logout
+          </a>
+        </div>
+      </>
     );
   }
 
   return (
     <a
       href={loginUrl}
-      class="flex items-center gap-2 px-3 py-1.5 bg-dark-700 hover:bg-dark-600 border border-dark-500 rounded-lg text-gray-300 hover:text-white transition-colors"
+      aria-label="Login with GitHub"
+      class="flex items-center gap-2 px-2 py-1.5 xl:px-3 bg-dark-700 hover:bg-dark-600 border border-dark-500 rounded-lg text-gray-300 hover:text-white transition-colors"
     >
       <GitHubIcon />
-      <span>Login with GitHub</span>
+      <span class="hidden xl:inline">Login with GitHub</span>
     </a>
   );
 }

--- a/web/src/components/DownloadsPane.tsx
+++ b/web/src/components/DownloadsPane.tsx
@@ -64,7 +64,6 @@ function DailyBarChart({
             <div
               key={d.date}
               class="flex-1 h-full flex items-end group relative outline-none"
-              title={`${label}: ${d.count} downloads`}
               aria-label={`${label}: ${d.count.toLocaleString()} downloads`}
               tabIndex={0}
             >

--- a/web/src/components/DownloadsPane.tsx
+++ b/web/src/components/DownloadsPane.tsx
@@ -63,15 +63,17 @@ function DailyBarChart({
           return (
             <div
               key={d.date}
-              class="flex-1 h-full flex items-end group relative"
+              class="flex-1 h-full flex items-end group relative outline-none"
               title={`${label}: ${d.count} downloads`}
+              aria-label={`${label}: ${d.count.toLocaleString()} downloads`}
+              tabIndex={0}
             >
               <div
                 class="w-full bg-neon-purple hover:bg-neon-pink transition-colors rounded-t"
                 style={{ height: `${Math.max(height, 2)}%` }}
               />
-              <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-dark-700 rounded text-xs text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-10">
-                {label}: {d.count.toLocaleString()}
+              <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-dark-700 rounded text-xs text-gray-300 opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-10">
+                {label}: {d.count.toLocaleString()} downloads
               </div>
             </div>
           );

--- a/web/src/components/MauHistory.astro
+++ b/web/src/components/MauHistory.astro
@@ -8,7 +8,10 @@ interface Props {
 }
 
 const { daily } = Astro.props;
-const data = daily.filter((point) => point.mau > 0);
+const reliableHistoryStart = "2026-03-01";
+const data = daily.filter(
+  (point) => point.mau > 0 && point.date >= reliableHistoryStart,
+);
 const latest = data.at(-1);
 
 function formatChange(current: number, previous?: number): number | null {
@@ -112,6 +115,7 @@ const currentMonth = new Date().toISOString().slice(0, 7);
         <h2 class="text-lg font-semibold text-gray-200">Monthly Active Users</h2>
         <p class="text-xs text-gray-500">
           Unique users across downloads and version checks in the trailing 30 days; daily snapshots make recent changes visible before a calendar month closes.
+          Comparable history is shown from March 2026.
         </p>
       </div>
       <span class="text-xs text-gray-500">through {latest.date}</span>
@@ -144,7 +148,7 @@ const currentMonth = new Date().toISOString().slice(0, 7);
     </div>
 
     <div class="overflow-x-auto">
-      <svg viewBox={`0 0 ${width} ${height}`} class="min-w-[700px] w-full" role="img" aria-label="Daily snapshots of trailing 30-day monthly active users over the past year">
+      <svg viewBox={`0 0 ${width} ${height}`} class="min-w-[700px] w-full" role="img" aria-label="Daily snapshots of trailing 30-day monthly active users since March 2026">
         <g transform={`translate(${padding.left}, ${padding.top})`}>
           {yTicks.map((tick) => (
             <g>
@@ -196,7 +200,7 @@ const currentMonth = new Date().toISOString().slice(0, 7);
                 <th class="py-2 pr-4 font-medium">Month</th>
                 <th class="py-2 px-4 font-medium">Snapshot</th>
                 <th class="py-2 px-4 font-medium text-right">MAU snapshot</th>
-                <th class="py-2 pl-4 font-medium text-right">Month-over-month</th>
+                <th class="py-2 pl-4 font-medium text-right">Change vs prior snapshot</th>
               </tr>
             </thead>
             <tbody>

--- a/web/src/components/NavSearch.tsx
+++ b/web/src/components/NavSearch.tsx
@@ -26,7 +26,8 @@ export function NavSearch({ initialQuery = "" }: { initialQuery?: string }) {
       );
       // Drop responses whose query no longer matches the input (out-of-order
       // resolves or a superseded keystroke) so the dropdown never goes stale.
-      if (inputRef.current && inputRef.current.value.trim() !== q.trim()) return;
+      if (inputRef.current && inputRef.current.value.trim() !== q.trim())
+        return;
       if (!res.ok) {
         setSuggestions([]);
         return;
@@ -104,7 +105,7 @@ export function NavSearch({ initialQuery = "" }: { initialQuery?: string }) {
   };
 
   return (
-    <div class="relative w-40 sm:w-56 md:w-64">
+    <div class="relative min-w-0 flex-1 sm:w-56 sm:flex-none md:w-64">
       <input
         ref={inputRef}
         type="text"

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -63,14 +63,14 @@ const currentPath = Astro.url.pathname;
   </head>
   <body class="bg-dark-900 text-gray-100 font-sans min-h-screen">
     <header class="bg-dark-800 border-b border-dark-600 relative">
-      <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+      <div class="max-w-6xl mx-auto px-4 py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <a
           href="/"
-          class="text-xl font-bold text-neon-purple hover:text-neon-pink transition-colors"
+          class="text-xl font-bold text-neon-purple hover:text-neon-pink transition-colors whitespace-nowrap"
         >
           mise versions
         </a>
-        <nav class="flex items-center gap-6">
+        <nav class="flex w-full min-w-0 items-center gap-3 sm:w-auto sm:gap-6">
           <NavSearch initialQuery={Astro.url.searchParams.get("q") || ""} client:load />
           <a
             href="/stats"
@@ -83,7 +83,7 @@ const currentPath = Astro.url.pathname;
           </a>
           <a
             href="https://mise.jdx.dev"
-            class="text-sm text-gray-400 hover:text-neon-purple transition-colors flex items-center gap-1.5"
+            class="hidden text-sm text-gray-400 hover:text-neon-purple transition-colors xl:flex items-center gap-1.5"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -94,7 +94,7 @@ const currentPath = Astro.url.pathname;
           </a>
           <a
             href="https://github.com/jdx/mise"
-            class="text-sm text-gray-400 hover:text-neon-purple transition-colors flex items-center gap-1.5"
+            class="hidden text-sm text-gray-400 hover:text-neon-purple transition-colors xl:flex items-center gap-1.5"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -323,17 +323,41 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                     {data.map((d, i) => {
                       const x = (i / data.length) * chartWidth + 1;
                       const barHeight = (d.dau / maxDAU) * chartHeight;
+                      const tooltipWidth = 150;
+                      const tooltipX = Math.min(
+                        Math.max(x + barWidth / 2 - tooltipWidth / 2, 0),
+                        chartWidth - tooltipWidth,
+                      );
                       return (
-                        <rect
-                          x={x}
-                          y={chartHeight - barHeight}
-                          width={barWidth}
-                          height={barHeight}
-                          fill="#B026FF"
-                          opacity="0.8"
-                        >
-                          <title>{d.date}: {d.dau.toLocaleString()} DAU</title>
-                        </rect>
+                        <g class="group">
+                          <rect
+                            x={x}
+                            y={0}
+                            width={barWidth}
+                            height={chartHeight}
+                            fill="transparent"
+                            class="cursor-default outline-none"
+                            tabindex="0"
+                            aria-label={`${d.date}: ${d.dau.toLocaleString()} daily active users`}
+                          >
+                            <title>{d.date}: {d.dau.toLocaleString()} daily active users</title>
+                          </rect>
+                          <rect
+                            x={x}
+                            y={chartHeight - barHeight}
+                            width={barWidth}
+                            height={barHeight}
+                            fill="#B026FF"
+                            opacity="0.8"
+                            pointer-events="none"
+                          />
+                          <g class="pointer-events-none opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                            <rect x={tooltipX} y={-18} width={tooltipWidth} height={22} rx={4} fill="#374151" />
+                            <text x={tooltipX + tooltipWidth / 2} y={-4} text-anchor="middle" class="fill-gray-200 text-xs">
+                              {d.date.slice(5)} · {d.dau.toLocaleString()} users
+                            </text>
+                          </g>
+                        </g>
                       );
                     })}
                     {data.map((d, i) => {
@@ -386,17 +410,41 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                     {data.map((d, i) => {
                       const x = (i / data.length) * chartWidth + 1;
                       const barHeight = (d.count / maxCount) * chartHeight;
+                      const tooltipWidth = 150;
+                      const tooltipX = Math.min(
+                        Math.max(x + barWidth / 2 - tooltipWidth / 2, 0),
+                        chartWidth - tooltipWidth,
+                      );
                       return (
-                        <rect
-                          x={x}
-                          y={chartHeight - barHeight}
-                          width={barWidth}
-                          height={barHeight}
-                          fill="#00D4FF"
-                          opacity="0.8"
-                        >
-                          <title>{d.date}: {d.count} tools updated</title>
-                        </rect>
+                        <g class="group">
+                          <rect
+                            x={x}
+                            y={0}
+                            width={barWidth}
+                            height={chartHeight}
+                            fill="transparent"
+                            class="cursor-default outline-none"
+                            tabindex="0"
+                            aria-label={`${d.date}: ${d.count.toLocaleString()} version updates`}
+                          >
+                            <title>{d.date}: {d.count.toLocaleString()} version updates</title>
+                          </rect>
+                          <rect
+                            x={x}
+                            y={chartHeight - barHeight}
+                            width={barWidth}
+                            height={barHeight}
+                            fill="#00D4FF"
+                            opacity="0.8"
+                            pointer-events="none"
+                          />
+                          <g class="pointer-events-none opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                            <rect x={tooltipX} y={-18} width={tooltipWidth} height={22} rx={4} fill="#374151" />
+                            <text x={tooltipX + tooltipWidth / 2} y={-4} text-anchor="middle" class="fill-gray-200 text-xs">
+                              {d.date.slice(5)} · {d.count.toLocaleString()} updates
+                            </text>
+                          </g>
+                        </g>
                       );
                     })}
                     {data.map((d, i) => {

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -208,9 +208,10 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
             </span>
           )}
         </div>
+        <div class="text-xs text-gray-500 mt-1">vs prior 30 days</div>
       </div>
       <div class="bg-dark-800 border border-dark-600 rounded-lg p-6">
-        <div class="text-sm text-gray-400 mb-1">Week-over-Week</div>
+        <div class="text-sm text-gray-400 mb-1">Downloads Week-over-Week</div>
         <div class="text-3xl font-bold">
           {growthData?.global.wow !== null ? (
             <span class={`inline-flex items-center gap-1 px-2 py-0.5 rounded ${growthData.global.wow >= 0 ? 'bg-green-400/10 text-green-400' : 'bg-red-400/10 text-red-400'} text-sm font-medium`}>
@@ -220,6 +221,7 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
             <span class="text-gray-500">...</span>
           )}
         </div>
+        <div class="text-xs text-gray-500 mt-1">vs prior 7 days</div>
       </div>
     </div>
 
@@ -335,7 +337,8 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                       );
                     })}
                     {data.map((d, i) => {
-                      if (i % 7 !== 0 && i !== data.length - 1) return null;
+                      const lastIndex = data.length - 1;
+                      if (i !== lastIndex && (i % 7 !== 0 || lastIndex - i < 3)) return null;
                       const x = (i / data.length) * chartWidth + barWidth / 2;
                       const dateLabel = d.date.slice(5);
                       return (
@@ -397,7 +400,8 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                       );
                     })}
                     {data.map((d, i) => {
-                      if (i % 7 !== 0 && i !== data.length - 1) return null;
+                      const lastIndex = data.length - 1;
+                      if (i !== lastIndex && (i % 7 !== 0 || lastIndex - i < 3)) return null;
                       const x = (i / data.length) * chartWidth + barWidth / 2;
                       const dateLabel = d.date.slice(5);
                       return (

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -339,9 +339,7 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                             class="cursor-default outline-none"
                             tabindex="0"
                             aria-label={`${d.date}: ${d.dau.toLocaleString()} daily active users`}
-                          >
-                            <title>{d.date}: {d.dau.toLocaleString()} daily active users</title>
-                          </rect>
+                          />
                           <rect
                             x={x}
                             y={chartHeight - barHeight}
@@ -426,9 +424,7 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                             class="cursor-default outline-none"
                             tabindex="0"
                             aria-label={`${d.date}: ${d.count.toLocaleString()} version updates`}
-                          >
-                            <title>{d.date}: {d.count.toLocaleString()} version updates</title>
-                          </rect>
+                          />
                           <rect
                             x={x}
                             y={chartHeight - barHeight}


### PR DESCRIPTION
## Summary

- start comparable MAU history at March 1, excluding inflated early rollups and the February recalculation discontinuity from the chart and monthly table
- label monthly deltas as changes versus the prior snapshot so the current partial month is not presented as a completed month-over-month comparison
- clarify the comparison windows on the download growth cards
- use a compact two-row header and responsive account controls to eliminate document-level mobile overflow
- suppress near-duplicate final x-axis ticks on the DAU and Version Updates charts
- show exact date and daily count tooltips on hover or keyboard focus for all daily column charts, including zero-count days

## Testing

- `aube --dir web run build`
- `aube run test:js` (92 passed)
- Prettier and diff checks
- local D1 visual verification of MAU history and chart labels
- responsive browser verification at 390px: document and navigation both fit the viewport with no horizontal page overflow
- browser verification of DAU and Version Updates daily hit targets and exact-count focus tooltips

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, labeling, and presentation-only analytics filtering with no auth or API behavior changes.
> 
> **Overview**
> **Stats and MAU presentation** now treat history as comparable only from **March 2026** onward (chart, table, and copy), and monthly deltas are labeled **change vs prior snapshot** so a partial month is not read as a finished month-over-month comparison. Download growth cards spell out **vs prior 30 days** and **vs prior 7 days**, and the WoW card title is prefixed with “Downloads.”
> 
> **Mobile header and auth** use a stacked layout with a flexible search field; Docs, GitHub, Repo, and long button labels hide below the `xl` breakpoint in favor of icons and `aria-label`s. Logged-in users get a compact GitHub-icon logout on small screens and the full username + “Logout” row on `xl+`.
> 
> **Daily charts** (downloads pane, DAU, version updates) gain keyboard-focusable bars, `aria-label`s, hover/focus tooltips with exact counts (including zero days), and DAU/version charts avoid crowding the last x-axis tick when it would duplicate a weekly label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 954654cbf58822ee637047187b9a65f88b663ecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->