### PR TITLE
fix: clarify stats dates and comparisons

### DIFF
--- a/web/src/components/DownloadsPane.tsx
+++ b/web/src/components/DownloadsPane.tsx
@@ -20,6 +20,29 @@ function formatAxisNumber(n: number): string {
   return n.toString();
 }
 
+function moveDailyBarFocus(event: KeyboardEvent) {
+  const current = event.currentTarget as HTMLElement;
+  const bars = [
+    ...(current.parentElement?.querySelectorAll<HTMLElement>(
+      "[data-daily-bar]",
+    ) || []),
+  ];
+  const currentIndex = bars.indexOf(current);
+  let nextIndex = currentIndex;
+
+  if (event.key === "ArrowLeft") nextIndex = Math.max(0, currentIndex - 1);
+  else if (event.key === "ArrowRight") {
+    nextIndex = Math.min(bars.length - 1, currentIndex + 1);
+  } else if (event.key === "Home") nextIndex = 0;
+  else if (event.key === "End") nextIndex = bars.length - 1;
+  else return;
+
+  event.preventDefault();
+  for (const bar of bars) bar.tabIndex = -1;
+  bars[nextIndex].tabIndex = 0;
+  bars[nextIndex].focus();
+}
+
 function DailyBarChart({
   daily,
 }: {
@@ -52,8 +75,12 @@ function DailyBarChart({
         <span>0</span>
       </div>
       {/* Chart */}
-      <div class="flex-1 h-32 flex items-end gap-0.5">
-        {days.map((d) => {
+      <div
+        class="flex-1 h-32 flex items-end gap-0.5"
+        role="group"
+        aria-label="Daily downloads by date. Use the left and right arrow keys to inspect days."
+      >
+        {days.map((d, index) => {
           const height = maxCount > 0 ? (d.count / maxCount) * 100 : 0;
           const dateObj = new Date(d.date);
           const label = dateObj.toLocaleDateString("en-US", {
@@ -65,7 +92,9 @@ function DailyBarChart({
               key={d.date}
               class="flex-1 h-full flex items-end group relative outline-none"
               aria-label={`${label}: ${d.count.toLocaleString()} downloads`}
-              tabIndex={0}
+              data-daily-bar
+              tabIndex={index === days.length - 1 ? 0 : -1}
+              onKeyDown={moveDailyBarFocus}
             >
               <div
                 class="w-full bg-neon-purple hover:bg-neon-pink transition-colors rounded-t"

--- a/web/src/components/MAUCounter.tsx
+++ b/web/src/components/MAUCounter.tsx
@@ -27,7 +27,7 @@ export function MAUCounter() {
           <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
         </svg>
         <span class="text-xs text-gray-500">
-          mise loved by {formatCompact(mau)} devs this month
+          mise used by {formatCompact(mau)} devs in the last 30 days
         </span>
       </div>
     </div>

--- a/web/src/components/MauHistory.astro
+++ b/web/src/components/MauHistory.astro
@@ -36,6 +36,31 @@ function daysBetween(start: string, end: string): number {
   );
 }
 
+function formatDate(date: string, month: "short" | "long" = "short"): string {
+  return new Date(`${date}T00:00:00Z`).toLocaleDateString("en-US", {
+    month,
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function formatMonth(date: string): string {
+  return new Date(`${date}T00:00:00Z`).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function niceStep(span: number, targetTicks = 6): number {
+  const roughStep = Math.max(span / targetTicks, 1);
+  const magnitude = 10 ** Math.floor(Math.log10(roughStep));
+  const normalized = roughStep / magnitude;
+  const multiplier = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return multiplier * magnitude;
+}
+
 const monthEnds = [
   ...data
     .reduce((months, point) => {
@@ -69,8 +94,10 @@ const values = data.map((point) => point.mau);
 const rawMin = values.length > 0 ? Math.min(...values) : 0;
 const rawMax = values.length > 0 ? Math.max(...values) : 1;
 const range = Math.max(rawMax - rawMin, rawMax * 0.1, 1);
-const yMin = Math.max(0, rawMin - range * 0.12);
-const yMax = rawMax + range * 0.12;
+const yStep = niceStep(range);
+const yMin = Math.max(0, Math.floor(rawMin / yStep) * yStep);
+const roundedYMax = Math.ceil(rawMax / yStep) * yStep;
+const yMax = roundedYMax > yMin ? roundedYMax : yMin + yStep;
 const timestampForDate = (date: string) =>
   new Date(`${date}T00:00:00Z`).getTime();
 const firstTimestamp = data.length > 0 ? timestampForDate(data[0].date) : 0;
@@ -104,43 +131,47 @@ const tickInterval = Math.max(1, Math.ceil(monthStarts.length / 7));
 const xTicks = monthStarts.filter(
   (_, index) => index % tickInterval === 0 || index === monthStarts.length - 1,
 );
-const yTicks = [yMax, (yMax + yMin) / 2, yMin];
-const currentMonth = new Date().toISOString().slice(0, 7);
+const yTicks = Array.from(
+  { length: Math.round((yMax - yMin) / yStep) + 1 },
+  (_, index) => yMax - index * yStep,
+);
 ---
 
 {latest && (
   <section class="bg-dark-800 border border-dark-600 rounded-lg p-4">
-    <div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between mb-4">
-      <div>
-        <h2 class="text-lg font-semibold text-gray-200">Monthly Active Users</h2>
-        <p class="text-xs text-gray-500">
-          Unique users across downloads and version checks in the trailing 30 days; daily snapshots make recent changes visible before a calendar month closes.
-          Comparable history is shown from March 2026.
-        </p>
-      </div>
-      <span class="text-xs text-gray-500">through {latest.date}</span>
+    <div class="mb-4">
+      <h2 class="text-lg font-semibold text-gray-200">Monthly Active Users</h2>
+      <p class="text-xs text-gray-500">
+        Unique users across downloads and version checks in the trailing 30 days; daily snapshots make recent changes visible before a calendar month closes.
+        Comparable history is shown from March 2026.
+      </p>
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5">
       <div class="bg-dark-700 rounded p-3">
         <div class="text-xs text-gray-400">Latest MAU snapshot</div>
         <div class="text-2xl font-semibold text-cyan-400">{formatCompact(latest.mau)}</div>
+        <div class="text-xs text-gray-500">As of {formatDate(latest.date, "long")}</div>
       </div>
       <div class="bg-dark-700 rounded p-3">
         <div class="text-xs text-gray-400">30-day change</div>
         <div class={`text-2xl font-semibold ${thirtyDayChange === null ? 'text-gray-500' : thirtyDayChange >= 0 ? 'text-green-400' : 'text-red-400'}`}>
           {thirtyDayChange === null ? "—" : `${thirtyDayChange >= 0 ? "+" : ""}${thirtyDayChange.toFixed(1)}%`}
         </div>
-        {thirtyDayBaseline && <div class="text-xs text-gray-500">from {formatCompact(thirtyDayBaseline.mau)}</div>}
+        {thirtyDayBaseline && (
+          <div class="text-xs text-gray-500">
+            From {formatCompact(thirtyDayBaseline.mau)} on {formatDate(thirtyDayBaseline.date)}
+          </div>
+        )}
       </div>
       <div class="bg-dark-700 rounded p-3">
-        <div class="text-xs text-gray-400">Since Omarchy Quattro</div>
+        <div class="text-xs text-gray-400">Change since Omarchy Quattro launch</div>
         <div class={`text-2xl font-semibold ${quattroChange === null ? 'text-gray-500' : quattroChange >= 0 ? 'text-green-400' : 'text-red-400'}`}>
           {quattroChange === null ? "—" : `${quattroChange >= 0 ? "+" : ""}${quattroChange.toFixed(1)}%`}
         </div>
         {quattroBaseline && latest.date >= quattroLaunch && (
           <div class="text-xs text-gray-500">
-            {daysBetween(quattroLaunch, latest.date)} days since Aug 14 launch; baseline {formatCompact(quattroBaseline.mau)}
+            {daysBetween(quattroLaunch, latest.date)} days after Aug 14; from {formatCompact(quattroBaseline.mau)} on {formatDate(quattroBaseline.date)}
           </div>
         )}
         <div class="text-[11px] text-gray-600 mt-1">Timing comparison, not causal attribution.</div>
@@ -169,7 +200,7 @@ const currentMonth = new Date().toISOString().slice(0, 7);
                 stroke-width="1.5"
                 stroke-dasharray="5 4"
               />
-              <text x={xForDate(quattroLaunch) + 6} y="12" class="fill-pink-400 text-xs">Quattro</text>
+              <text x={xForDate(quattroLaunch) - 6} y="12" text-anchor="end" class="fill-pink-400 text-xs">Quattro · Aug 14</text>
             </g>
           )}
           <path d={mauPath} fill="none" stroke="#00D4FF" stroke-width="3" stroke-linejoin="round" />
@@ -182,7 +213,7 @@ const currentMonth = new Date().toISOString().slice(0, 7);
           {xTicks.map((point) => {
             return (
               <text x={xForDate(point.date)} y={chartHeight + 24} text-anchor="middle" class="fill-gray-500 text-xs">
-                {point.date.slice(0, 7)}
+                {new Date(`${point.date}T00:00:00Z`).toLocaleDateString("en-US", { month: "short", timeZone: "UTC" })}
               </text>
             );
           })}
@@ -193,12 +224,12 @@ const currentMonth = new Date().toISOString().slice(0, 7);
     {recentMonths.length > 0 && (
       <div class="mt-5">
         <h3 class="text-sm font-medium text-gray-300 mb-2">Monthly history</h3>
-        <div class="overflow-x-auto">
+        <div class="hidden overflow-x-auto sm:block">
           <table class="w-full text-sm">
             <thead>
               <tr class="border-b border-dark-600 text-left text-xs text-gray-500">
                 <th class="py-2 pr-4 font-medium">Month</th>
-                <th class="py-2 px-4 font-medium">Snapshot</th>
+                <th class="py-2 px-4 font-medium">Snapshot date</th>
                 <th class="py-2 px-4 font-medium text-right">MAU snapshot</th>
                 <th class="py-2 pl-4 font-medium text-right">Change vs prior snapshot</th>
               </tr>
@@ -210,11 +241,11 @@ const currentMonth = new Date().toISOString().slice(0, 7);
                 const change = formatChange(point.mau, previous?.mau);
                 return (
                   <tr class="border-b border-dark-700 last:border-0">
-                    <td class="py-2 pr-4 text-gray-300">
-                      {new Date(`${point.date}T00:00:00Z`).toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" })}
-                      {point === latest && point.date.startsWith(currentMonth) && <span class="ml-2 text-xs text-gray-500">month to date</span>}
+                    <td class="py-2 pr-4 text-gray-300 whitespace-nowrap">
+                      {formatMonth(point.date)}
+                      {point === latest && <span class="ml-2 text-xs text-gray-500">latest</span>}
                     </td>
-                    <td class="py-2 px-4 text-gray-500">{point.date}</td>
+                    <td class="py-2 px-4 text-gray-500 whitespace-nowrap">{formatDate(point.date)}</td>
                     <td class="py-2 px-4 text-right text-gray-300" title={`Snapshot from ${point.date}`}>
                       {point.mau.toLocaleString()}
                     </td>
@@ -226,6 +257,34 @@ const currentMonth = new Date().toISOString().slice(0, 7);
               })}
             </tbody>
           </table>
+        </div>
+        <div class="space-y-2 sm:hidden">
+          {[...recentMonths].reverse().map((point) => {
+            const index = monthEnds.indexOf(point);
+            const previous = index > 0 ? monthEnds[index - 1] : undefined;
+            const change = formatChange(point.mau, previous?.mau);
+            return (
+              <div class="rounded border border-dark-600 bg-dark-700 p-3">
+                <div class="flex items-start justify-between gap-3">
+                  <div>
+                    <div class="text-sm text-gray-300">
+                      {formatMonth(point.date)}
+                      {point === latest && <span class="ml-2 text-xs text-gray-500">latest</span>}
+                    </div>
+                    <div class="text-xs text-gray-500">As of {formatDate(point.date)}</div>
+                  </div>
+                  <div class="text-right">
+                    <div class="font-medium text-gray-200">{point.mau.toLocaleString()}</div>
+                    <div class={`text-xs ${change === null ? 'text-gray-500' : change >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                      {change === null
+                        ? "No prior snapshot"
+                        : `${change >= 0 ? "+" : ""}${change.toFixed(1)}% vs ${formatDate(previous!.date).replace(/, \d{4}$/, "")}`}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
     )}

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -108,7 +108,7 @@ const currentPath = Astro.url.pathname;
         </nav>
       </div>
       <!-- MAU tab hanging below header -->
-      <MAUCounter client:load />
+      {currentPath !== "/stats" && <MAUCounter client:load />}
     </header>
     <main class="max-w-6xl mx-auto px-4 py-8">
       <slot />

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ const {
 
 const fullTitle = title === "mise versions" ? title : `${title} | mise versions`;
 const canonicalUrl = new URL(Astro.url.pathname, "https://mise-tools.jdx.dev").href;
-const currentPath = Astro.url.pathname;
+const currentPath = Astro.url.pathname.replace(/\/+$/, "") || "/";
 ---
 
 <!doctype html>

--- a/web/src/pages/stats.astro
+++ b/web/src/pages/stats.astro
@@ -5,6 +5,7 @@ import { drizzle } from 'drizzle-orm/d1';
 import { setupAnalytics } from '../../../src/analytics';
 import { loadToolsJson, type ToolsData } from '../lib/data-loader';
 import { formatCompact } from '../lib/format';
+import type { GrowthData } from '../hooks/useGrowth';
 
 import { env } from "cloudflare:workers";
 // Version updates data type (now from D1)
@@ -42,7 +43,7 @@ try {
 let downloads: Record<string, number> = {};
 let backendStatsData: { downloads_by_backend: Array<{ backend: string; count: number }>; top_tools_by_backend: Record<string, Array<{ tool: string; count: number }>> } | null = null;
 let dauMauData: { daily: Array<{ date: string; dau: number; mau: number }>; current_mau: number } | null = null;
-let growthData: { global: { wow: number | null; mom: number | null }; topGrowing: Array<{ tool: string; thisWeek: number; wow: number | null }>; topDeclining: Array<{ tool: string; thisWeek: number; wow: number | null }> } | null = null;
+let growthData: GrowthData | null = null;
 let versionUpdatesData: VersionUpdatesData | null = null;
 
 try {
@@ -124,6 +125,18 @@ const totalDownloads = downloads
   ? Object.values(downloads).reduce((sum, count) => sum + count, 0)
   : 0;
 
+const latestStatsDate = dauMauData?.daily.findLast(
+  (point) => point.dau > 0 || point.mau > 0,
+)?.date;
+const formattedLatestStatsDate = latestStatsDate
+  ? new Date(`${latestStatsDate}T00:00:00Z`).toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      timeZone: "UTC",
+    })
+  : null;
+
 // Top tools by backend
 const topToolsByBackend = backendStatsData?.top_tools_by_backend || {};
 const topBackends = backendDownloads.slice(0, 5).map((b: { label: string }) => b.label);
@@ -180,6 +193,9 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
   <div class="space-y-8">
     <div>
       <h1 class="text-2xl font-bold text-gray-100">Ecosystem Stats</h1>
+      {formattedLatestStatsDate && (
+        <p class="mt-1 text-sm text-gray-500">Daily analytics through {formattedLatestStatsDate}</p>
+      )}
     </div>
 
     <!-- Overview cards -->
@@ -211,15 +227,16 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
         <div class="text-xs text-gray-500 mt-1">vs prior 30 days</div>
       </div>
       <div class="bg-dark-800 border border-dark-600 rounded-lg p-6">
-        <div class="text-sm text-gray-400 mb-1">Downloads Week-over-Week</div>
-        <div class="text-3xl font-bold">
+        <div class="text-sm text-gray-400 mb-1">Downloads (7d)</div>
+        <div class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold text-gray-100">
+            {growthData ? formatCompact(growthData.global.thisWeek) : "..."}
+          </span>
           {growthData?.global.wow !== null ? (
-            <span class={`inline-flex items-center gap-1 px-2 py-0.5 rounded ${growthData.global.wow >= 0 ? 'bg-green-400/10 text-green-400' : 'bg-red-400/10 text-red-400'} text-sm font-medium`}>
+            <span class={`text-xs ${growthData.global.wow >= 0 ? 'text-green-400' : 'text-red-400'}`}>
               {growthData.global.wow >= 0 ? '↑' : '↓'} {Math.abs(growthData.global.wow).toFixed(1)}%
             </span>
-          ) : (
-            <span class="text-gray-500">...</span>
-          )}
+          ) : null}
         </div>
         <div class="text-xs text-gray-500 mt-1">vs prior 7 days</div>
       </div>
@@ -312,7 +329,14 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
               const barWidth = chartWidth / data.length - 2;
 
               return (
-                <svg width={width} height={height} class="min-w-[400px]">
+                <svg
+                  width={width}
+                  height={height}
+                  class="min-w-[400px]"
+                  role="group"
+                  aria-label="Daily active users by date. Use the left and right arrow keys to inspect days."
+                  data-daily-chart
+                >
                   <text x={padding.left - 10} y={padding.top} text-anchor="end" class="fill-purple-400 text-xs">
                     {formatCompact(maxDAU)}
                   </text>
@@ -337,7 +361,8 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                             height={chartHeight}
                             fill="transparent"
                             class="cursor-default outline-none"
-                            tabindex="0"
+                            tabindex={i === data.length - 1 ? "0" : "-1"}
+                            data-daily-bar
                             aria-label={`${d.date}: ${d.dau.toLocaleString()} daily active users`}
                           />
                           <rect
@@ -397,7 +422,14 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
               const barWidth = chartWidth / data.length - 2;
 
               return (
-                <svg width={width} height={height} class="min-w-[400px]">
+                <svg
+                  width={width}
+                  height={height}
+                  class="min-w-[400px]"
+                  role="group"
+                  aria-label="Version updates by date. Use the left and right arrow keys to inspect days."
+                  data-daily-chart
+                >
                   <text x={padding.left - 10} y={padding.top} text-anchor="end" class="fill-gray-500 text-xs">
                     {maxCount}
                   </text>
@@ -422,7 +454,8 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                             height={chartHeight}
                             fill="transparent"
                             class="cursor-default outline-none"
-                            tabindex="0"
+                            tabindex={i === data.length - 1 ? "0" : "-1"}
+                            data-daily-bar
                             aria-label={`${d.date}: ${d.count.toLocaleString()} version updates`}
                           />
                           <rect
@@ -462,6 +495,37 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
         </div>
       )}
     </div>
+
+    <script>
+      for (const chart of document.querySelectorAll<SVGSVGElement>(
+        "[data-daily-chart]",
+      )) {
+        chart.addEventListener("keydown", (event) => {
+          const current = (event.target as Element).closest<SVGGraphicsElement>(
+            "[data-daily-bar]",
+          );
+          if (!current) return;
+
+          const bars = [
+            ...chart.querySelectorAll<SVGGraphicsElement>("[data-daily-bar]"),
+          ];
+          const currentIndex = bars.indexOf(current);
+          let nextIndex = currentIndex;
+
+          if (event.key === "ArrowLeft") nextIndex = Math.max(0, currentIndex - 1);
+          else if (event.key === "ArrowRight") {
+            nextIndex = Math.min(bars.length - 1, currentIndex + 1);
+          } else if (event.key === "Home") nextIndex = 0;
+          else if (event.key === "End") nextIndex = bars.length - 1;
+          else return;
+
+          event.preventDefault();
+          for (const bar of bars) bar.tabIndex = -1;
+          bars[nextIndex].tabIndex = 0;
+          bars[nextIndex].focus();
+        });
+      }
+    </script>
 
     <!-- Trending Tools -->
     {growthData && (growthData.topGrowing.length > 0 || growthData.topDeclining.length > 0) && (


### PR DESCRIPTION
## Summary

- replace detached ISO freshness text with readable, contextual dates and dated comparison baselines
- show the current 7-day download total alongside its week-over-week change
- distinguish the header MAU estimate from the dated stats snapshot and hide the duplicate counter on the stats page
- use clean month labels and rounded MAU chart ticks, with a dated Quattro launch annotation
- replace the cramped mobile history table with stacked snapshot cards
- reduce daily charts to one keyboard tab stop each, with arrow, Home, and End navigation between exact-count tooltips

## Testing

- `aube --dir web run build`
- `aube run test:js` (92 passed)
- `mise run types:check`
- `hk check`
- local D1 visual verification at 1440px and 390px
- verified no document overflow at 390px
- verified daily chart focus moves from Aug 24 to Aug 23 with ArrowLeft and updates the exact accessible value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to presentation, copy, and client-side chart focus behavior with no analytics or auth logic changes.
> 
> **Overview**
> This PR tightens how **stats and MAU** are labeled and compared, and improves **keyboard access** on daily bar charts.
> 
> **Copy and context:** The header MAU chip now says **“used by … in the last 30 days”** instead of “loved by … this month,” and it is **hidden on `/stats`** so it does not duplicate the dated MAU section. The stats page adds **“Daily analytics through …”** from the latest DAU/MAU day with data, and the **Downloads** overview card shows the **current 7-day total** plus week-over-week change instead of only a WoW badge.
> 
> **MAU history:** Snapshot and comparison cards use **readable dates** on baselines (30-day and Quattro launch). The line chart gets **rounded Y-axis ticks**, **short month** X labels, and a **“Quattro · Aug 14”** marker. The monthly table is **desktop-only**; on small screens it is replaced with **stacked snapshot cards**. Layout path matching **strips trailing slashes** so `/stats/` still behaves correctly.
> 
> **Accessibility:** Daily download bars (component and stats SVG charts) use **one tab stop per chart** (latest day focused by default) with **ArrowLeft/Right, Home, and End** to move focus and expose exact counts via existing labels/tooltips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff4c33acd9dab166edb728a802ee8fc9d54c1d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added keyboard navigation and improved accessibility for daily download, DAU, and MAU charts.
  - Added mobile-friendly cards for monthly history data.
  - Added clearer date labels, baseline details, and Quattro launch information.
  - Added the latest available DAU/MAU reporting date.
  - Added a 7-day downloads overview with week-over-week growth.

- **Improvements**
  - Updated MAU messaging to reflect usage over the last 30 days.
  - Improved chart axes with rounded, evenly spaced values.
  - Removed the MAU counter from the stats page for a clearer layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->