### PR TITLE
fix: preserve rolling version metadata

### DIFF
--- a/scripts/generate-toml.js
+++ b/scripts/generate-toml.js
@@ -7,7 +7,7 @@
  *
  * Input JSON format (NDJSON from stdin):
  *   {"version":"1.1.0"}
- *   {"version":"1.0.0","created_at":"2024-01-15T10:30:00Z","release_url":"https://github.com/...","prerelease":false}
+ *   {"version":"nightly","created_at":"2024-01-15T10:30:00Z","release_url":"https://github.com/...","rolling":true}
  *
  * Output TOML format (same order as input). Note that created_at is emitted
  * as a TOML offset datetime (unquoted), not a string:
@@ -15,6 +15,7 @@
  *   "1.1.0" = { created_at = 2024-02-20T14:45:00.000Z }
  *   "1.0.0" = { created_at = 2024-01-15T10:30:00.000Z, release_url = "https://github.com/..." }
  *   "1.2.0-rc1" = { created_at = 2024-02-25T09:00:00.000Z, prerelease = true }
+ *   "nightly" = { created_at = 2024-02-26T09:00:00.000Z, rolling = true }
  *
  * `prerelease = true` is emitted only when the upstream signal says so
  * (currently github + aqua via the GitHub release flag). It is omitted when
@@ -118,6 +119,7 @@ function parseNdjson(ndjsonData) {
           // Only an explicit boolean from the JSON path is definitive.
           prerelease:
             typeof obj.prerelease === "boolean" ? obj.prerelease : null,
+          rolling: typeof obj.rolling === "boolean" ? obj.rolling : null,
         });
       }
     } catch (e) {
@@ -158,6 +160,7 @@ if (existingTomlPath && existsSync(existingTomlPath)) {
           created_at: toISOString(data.created_at),
           release_url: data.release_url || null,
           prerelease: data.prerelease === true,
+          rolling: data.rolling === true,
         };
       }
     }
@@ -206,10 +209,12 @@ for (const v of newVersions) {
   // majority of entries stay one column narrower.
   const prerelease =
     v.prerelease !== null ? v.prerelease : existing.prerelease === true;
+  const rolling = v.rolling !== null ? v.rolling : existing.rolling === true;
 
   const parts = [`created_at = ${isoDate}`];
   if (releaseUrl) parts.push(`release_url = "${releaseUrl}"`);
   if (prerelease) parts.push(`prerelease = true`);
+  if (rolling) parts.push(`rolling = true`);
   lines.push(`"${v.version}" = { ${parts.join(", ")} }`);
 }
 

--- a/scripts/generate-toml.test.js
+++ b/scripts/generate-toml.test.js
@@ -315,6 +315,62 @@ describe("generate-toml.js", () => {
     });
   });
 
+  describe("rolling", () => {
+    it("should emit rolling = true when input flags it", async () => {
+      const input =
+        '{"version":"nightly","created_at":"2024-01-15T10:30:00Z","rolling":true}\n';
+      const { stdout, code } = await runGenerateToml(input, ["test-tool"]);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(parse(stdout).versions.nightly.rolling, true);
+    });
+
+    it("should omit rolling when input is false or missing", async () => {
+      const input = [
+        '{"version":"stable","rolling":false}',
+        '{"version":"1.0.0"}',
+      ].join("\n");
+      const { stdout, code } = await runGenerateToml(input, ["test-tool"]);
+      assert.strictEqual(code, 0);
+      const parsed = parse(stdout);
+      assert.strictEqual(parsed.versions.stable.rolling, undefined);
+      assert.strictEqual(parsed.versions["1.0.0"].rolling, undefined);
+    });
+
+    it("should preserve rolling from existing TOML when input lacks it", async () => {
+      const existingToml = join(tempDir, "existing.toml");
+      writeFileSync(
+        existingToml,
+        `[versions]
+"nightly" = { created_at = 2024-01-15T10:30:00.000Z, rolling = true }
+`,
+      );
+      const input = '{"version":"nightly"}\n';
+      const { stdout, code } = await runGenerateToml(input, [
+        "test-tool",
+        existingToml,
+      ]);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(parse(stdout).versions.nightly.rolling, true);
+    });
+
+    it("should let API value override an existing rolling flag", async () => {
+      const existingToml = join(tempDir, "existing.toml");
+      writeFileSync(
+        existingToml,
+        `[versions]
+"stable" = { created_at = 2024-01-15T10:30:00.000Z, rolling = true }
+`,
+      );
+      const input = '{"version":"stable","rolling":false}\n';
+      const { stdout, code } = await runGenerateToml(input, [
+        "test-tool",
+        existingToml,
+      ]);
+      assert.strictEqual(code, 0);
+      assert.strictEqual(parse(stdout).versions.stable.rolling, undefined);
+    });
+  });
+
   describe("ignored moving version tags", () => {
     const ignoredVersions = [
       ["bottom", "nightly-b3694fc3-1782177088"],


### PR DESCRIPTION
## Summary
- preserve `rolling: true` from `mise ls-remote --json`
- emit `rolling = true` in generated version TOML
- retain rolling metadata when a later collection falls back to metadata-free output

This deliberately does not publish `checksum`: version collection runs on Ubuntu x86_64, while rolling release asset digests can vary by OS and architecture. Updated mise clients use this platform-independent flag to decide when to fetch the platform-specific metadata directly.

Part of the fix for jdx/mise#10017. Companion PRs:
- mise-plugins/vfox-neovim#5
- jdx/mise#12440

## Testing
- `node --test scripts/generate-toml.test.js` — 43 passed
- `bash scripts/update.test.sh` — 31 passed
- Prettier check passed

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for rolling version metadata.
  - Rolling status can be preserved from existing configuration or provided explicitly.
  - Enabled rolling versions are emitted in generated TOML output.

- **Documentation**
  - Added usage examples for rolling-version input and output.

- **Tests**
  - Added coverage for enabled, disabled, missing, preserved, and overridden rolling values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->