### PR TITLE
fix(admin): harden token observability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Configure Resend alert secret
-        run: printf '%s' "$RESEND_API_KEY" | aube exec wrangler secret put RESEND_API_KEY
+        run: |
+          if [ -z "${RESEND_API_KEY:-}" ]; then
+            echo "::warning::RESEND_API_KEY is not configured; preserving the existing Worker secret"
+            exit 0
+          fi
+          printf '%s' "$RESEND_API_KEY" | aube exec wrangler secret put RESEND_API_KEY
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ _Timeline showing the number of tools updated each day over the last 30 days_
 
 ## Token pool observability
 
-The authenticated `/admin` dashboard records GitHub core-rate-limit snapshots
-every 15 minutes. It shows aggregate quota headroom, quota burn per hour, token
-checkout rate, estimated time until the 1,000-request-per-token reserve, and
-the latest headroom for each pool token.
+The scheduled Worker records GitHub core-rate-limit snapshots every 15 minutes,
+and the authenticated `/admin` dashboard displays them. It shows aggregate
+quota headroom, quota burn per hour, token checkout rate, estimated time until
+the 1,000-request-per-token reserve, and the latest headroom for each pool token.
+
+Each run checks at most 45 tokens to stay within the Workers Free-plan external
+subrequest limit while leaving room for alerts. Larger pools rotate through
+batches and are shown as incomplete rather than being classified as critical.
 
 The monitor warns when only one token is available, a token cannot be checked,
 a token falls below reserve, less than 35% of aggregate quota remains, or the

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -77,10 +77,13 @@ async function ensureTokenObservationIndexes(
 async function preserveTokenObservationSnapshots(
   db: ReturnType<typeof drizzle>,
 ): Promise<void> {
-  console.log("Running migration 6: preserve_token_observation_snapshots");
+  console.log("Ensuring token observation snapshots are stable");
 
   const columns = (await db.all(
     sql`PRAGMA table_info(token_observations)`,
+  )) as Array<{ name: string }>;
+  const replacementColumns = (await db.all(
+    sql`PRAGMA table_info(token_observations_new)`,
   )) as Array<{ name: string }>;
   const foreignKeys = (await db.all(
     sql`PRAGMA foreign_key_list(token_observations)`,
@@ -91,56 +94,99 @@ async function preserveTokenObservationSnapshots(
   const referencesTokens = foreignKeys.some(
     (foreignKey) => foreignKey.table === "tokens",
   );
+  const replacementExists = replacementColumns.length > 0;
+
+  if (columns.length === 0) {
+    if (replacementExists) {
+      await db.$client.batch([
+        db.$client.prepare(
+          "ALTER TABLE token_observations_new RENAME TO token_observations",
+        ),
+        db.$client.prepare(
+          `CREATE INDEX IF NOT EXISTS idx_token_observations_time
+           ON token_observations(observed_at)`,
+        ),
+        db.$client.prepare(
+          `CREATE INDEX IF NOT EXISTS idx_token_observations_token_time
+           ON token_observations(token_id, observed_at)`,
+        ),
+      ]);
+    } else {
+      await addTokenObservabilitySchema(db, false);
+    }
+    return;
+  }
 
   if (hasIdentityColumns && !referencesTokens) {
+    if (replacementExists) {
+      await db.$client.batch([
+        db.$client.prepare(
+          `INSERT INTO token_observations
+             (token_id, user_id, user_name, observed_at, remaining,
+              limit_count, reset_at, usage_count, is_available, error)
+           SELECT n.token_id, n.user_id, n.user_name, n.observed_at,
+                  n.remaining, n.limit_count, n.reset_at, n.usage_count,
+                  n.is_available, n.error
+           FROM token_observations_new n
+           WHERE NOT EXISTS (
+             SELECT 1 FROM token_observations o
+             WHERE o.token_id = n.token_id AND o.observed_at = n.observed_at
+           )`,
+        ),
+        db.$client.prepare("DROP TABLE token_observations_new"),
+      ]);
+    }
     await ensureTokenObservationIndexes(db);
     return;
   }
 
-  await db.run(sql`DROP TABLE IF EXISTS token_observations_new`);
-  await db.run(sql`
-    CREATE TABLE token_observations_new (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      token_id INTEGER NOT NULL,
-      user_id TEXT,
-      user_name TEXT,
-      observed_at TEXT NOT NULL,
-      remaining INTEGER,
-      limit_count INTEGER,
-      reset_at TEXT,
-      usage_count INTEGER NOT NULL,
-      is_available INTEGER NOT NULL,
-      error TEXT
-    )
-  `);
+  const copySql = hasIdentityColumns
+    ? `INSERT INTO token_observations_new
+         (id, token_id, user_id, user_name, observed_at, remaining, limit_count,
+          reset_at, usage_count, is_available, error)
+       SELECT id, token_id, user_id, user_name, observed_at, remaining,
+              limit_count, reset_at, usage_count, is_available, error
+       FROM token_observations`
+    : `INSERT INTO token_observations_new
+         (id, token_id, user_id, user_name, observed_at, remaining, limit_count,
+          reset_at, usage_count, is_available, error)
+       SELECT o.id, o.token_id, t.user_id, t.user_name, o.observed_at,
+              o.remaining, o.limit_count, o.reset_at, o.usage_count,
+              o.is_available, o.error
+       FROM token_observations o
+       LEFT JOIN tokens t ON t.id = o.token_id`;
 
-  if (hasIdentityColumns) {
-    await db.run(sql`
-      INSERT INTO token_observations_new
-        (id, token_id, user_id, user_name, observed_at, remaining, limit_count,
-         reset_at, usage_count, is_available, error)
-      SELECT id, token_id, user_id, user_name, observed_at, remaining,
-             limit_count, reset_at, usage_count, is_available, error
-      FROM token_observations
-    `);
-  } else {
-    await db.run(sql`
-      INSERT INTO token_observations_new
-        (id, token_id, user_id, user_name, observed_at, remaining, limit_count,
-         reset_at, usage_count, is_available, error)
-      SELECT o.id, o.token_id, t.user_id, t.user_name, o.observed_at,
-             o.remaining, o.limit_count, o.reset_at, o.usage_count,
-             o.is_available, o.error
-      FROM token_observations o
-      LEFT JOIN tokens t ON t.id = o.token_id
-    `);
-  }
-
-  await db.run(sql`DROP TABLE token_observations`);
-  await db.run(
-    sql`ALTER TABLE token_observations_new RENAME TO token_observations`,
-  );
-  await ensureTokenObservationIndexes(db);
+  await db.$client.batch([
+    db.$client.prepare("DROP TABLE IF EXISTS token_observations_new"),
+    db.$client.prepare(
+      `CREATE TABLE token_observations_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        token_id INTEGER NOT NULL,
+        user_id TEXT,
+        user_name TEXT,
+        observed_at TEXT NOT NULL,
+        remaining INTEGER,
+        limit_count INTEGER,
+        reset_at TEXT,
+        usage_count INTEGER NOT NULL,
+        is_available INTEGER NOT NULL,
+        error TEXT
+      )`,
+    ),
+    db.$client.prepare(copySql),
+    db.$client.prepare("DROP TABLE token_observations"),
+    db.$client.prepare(
+      "ALTER TABLE token_observations_new RENAME TO token_observations",
+    ),
+    db.$client.prepare(
+      `CREATE INDEX IF NOT EXISTS idx_token_observations_time
+       ON token_observations(observed_at)`,
+    ),
+    db.$client.prepare(
+      `CREATE INDEX IF NOT EXISTS idx_token_observations_token_time
+       ON token_observations(token_id, observed_at)`,
+    ),
+  ]);
 }
 
 export const migrations: Migration[] = [
@@ -290,6 +336,13 @@ export const migrations: Migration[] = [
   {
     id: 6,
     name: "preserve_token_observation_snapshots",
+    async up(db) {
+      await preserveTokenObservationSnapshots(db);
+    },
+  },
+  {
+    id: 7,
+    name: "stabilize_token_observation_snapshots",
     async up(db) {
       await preserveTokenObservationSnapshots(db);
     },

--- a/src/token-observability.test.ts
+++ b/src/token-observability.test.ts
@@ -4,10 +4,28 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   getAlertDecision,
+  selectTokenBatch,
   summarizeTokenPool,
   type AlertState,
   type TokenObservation,
 } from "./token-observability.js";
+
+test("rotates bounded token batches between observation intervals", () => {
+  const tokens = [1, 2, 3, 4, 5];
+
+  assert.deepEqual(
+    selectTokenBatch(tokens, new Date("1970-01-01T00:00:00.000Z"), 2),
+    [1, 2],
+  );
+  assert.deepEqual(
+    selectTokenBatch(tokens, new Date("1970-01-01T00:15:00.000Z"), 2),
+    [3, 4],
+  );
+  assert.deepEqual(
+    selectTokenBatch(tokens, new Date("1970-01-01T00:30:00.000Z"), 2),
+    [5],
+  );
+});
 
 function observation(
   tokenId: number,
@@ -93,6 +111,24 @@ test("excludes deleted tokens from current burn rates", () => {
 
   assert.equal(summary.quotaBurnPerHour, 100);
   assert.equal(summary.checkoutRatePerHour, 2);
+});
+
+test("marks a bounded observation as incomplete without a false critical", () => {
+  const current = observation(1, "2026-08-27T13:00:00.000Z", 500, 12);
+  const summary = summarizeTokenPool(
+    [current],
+    [current],
+    current.observedAt,
+    60,
+  );
+
+  assert.equal(summary.level, "warning");
+  assert.equal(summary.complete, false);
+  assert.equal(summary.checkedTokens, 1);
+  assert.equal(summary.tokenCount, 60);
+  assert.equal(summary.quotaBurnPerHour, null);
+  assert.doesNotMatch(summary.reasons.join(" "), /No token has/);
+  assert.match(summary.reasons.join(" "), /59 tokens were deferred/);
 });
 
 test("warns when the pool has only one token with reserve", () => {

--- a/src/token-observability.test.ts
+++ b/src/token-observability.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   getAlertDecision,
+  selectCurrentObservations,
   selectTokenBatch,
   summarizeTokenPool,
   type AlertState,
@@ -24,6 +25,38 @@ test("rotates bounded token batches between observation intervals", () => {
   assert.deepEqual(
     selectTokenBatch(tokens, new Date("1970-01-01T00:30:00.000Z"), 2),
     [5],
+  );
+});
+
+test("combines fresh rotating batches for the current pool", () => {
+  const now = new Date("2026-08-27T13:00:00.000Z");
+  const stale = observation(1, "2026-08-27T12:00:00.000Z", 4_500, 1);
+  const tokenOne = observation(1, "2026-08-27T12:45:00.000Z", 4_000, 2);
+  const tokenTwo = observation(2, "2026-08-27T12:30:00.000Z", 3_500, 3);
+  const deleted = observation(3, "2026-08-27T12:50:00.000Z", 3_000, 4);
+
+  const current = selectCurrentObservations(
+    [stale, tokenTwo, tokenOne, deleted],
+    [1, 2],
+    now,
+    1,
+  );
+
+  assert.deepEqual(current, [tokenOne, tokenTwo]);
+  const summary = summarizeTokenPool(current, current, now.toISOString(), 2);
+  assert.equal(summary.complete, true);
+  assert.equal(
+    getAlertDecision(
+      {
+        level: "warning",
+        fingerprint: "unhealthy",
+        last_sent_at: "2026-08-27T12:00:00.000Z",
+      },
+      summary,
+      "healthy",
+      now,
+    ).recovery,
+    true,
   );
 });
 

--- a/src/token-observability.test.ts
+++ b/src/token-observability.test.ts
@@ -6,6 +6,7 @@ import {
   getAlertDecision,
   selectCurrentObservations,
   selectTokenBatch,
+  shouldEvaluateAlert,
   summarizeTokenPool,
   type AlertState,
   type TokenObservation,
@@ -38,8 +39,6 @@ test("combines fresh rotating batches for the current pool", () => {
   const current = selectCurrentObservations(
     [stale, tokenTwo, tokenOne, deleted],
     [1, 2],
-    now,
-    1,
   );
 
   assert.deepEqual(current, [tokenOne, tokenTwo]);
@@ -58,6 +57,12 @@ test("combines fresh rotating batches for the current pool", () => {
     ).recovery,
     true,
   );
+});
+
+test("keeps the last-known snapshot when scheduled checks are delayed", () => {
+  const lastKnown = observation(1, "2026-08-27T12:00:00.000Z", 4_500, 1);
+
+  assert.deepEqual(selectCurrentObservations([lastKnown], [1]), [lastKnown]);
 });
 
 function observation(
@@ -162,6 +167,19 @@ test("marks a bounded observation as incomplete without a false critical", () =>
   assert.equal(summary.quotaBurnPerHour, null);
   assert.doesNotMatch(summary.reasons.join(" "), /No token has/);
   assert.match(summary.reasons.join(" "), /59 tokens were deferred/);
+  assert.equal(shouldEvaluateAlert(summary), true);
+});
+
+test("defers alert decisions only when partial data has no concrete issue", () => {
+  const current = observation(1, "2026-08-27T13:00:00.000Z", 4_000, 12);
+  const summary = summarizeTokenPool(
+    [current],
+    [current],
+    current.observedAt,
+    60,
+  );
+
+  assert.equal(shouldEvaluateAlert(summary), false);
 });
 
 test("warns when the pool has only one token with reserve", () => {

--- a/src/token-observability.ts
+++ b/src/token-observability.ts
@@ -4,6 +4,9 @@ const MIN_TOKEN_REMAINING = 1_000;
 const HISTORY_HOURS = 24;
 const ALERT_REPEAT_HOURS = 12;
 const MIN_RATE_INTERVAL_HOURS = 10 / 60;
+const MAX_TOKEN_CHECKS_PER_RUN = 45;
+const OBSERVATION_INTERVAL_MS = 15 * 60_000;
+const TOKEN_CHECK_CONCURRENCY = 5;
 
 type PoolToken = {
   id: number;
@@ -34,6 +37,8 @@ export type TokenPoolSummary = {
   reasons: string[];
   observedAt: string | null;
   tokenCount: number;
+  checkedTokens: number;
+  complete: boolean;
   availableTokens: number;
   rateLimitedTokens: number;
   belowReserveTokens: number;
@@ -149,7 +154,7 @@ async function loadPoolTokens(
       `SELECT id, user_id, user_name, token, usage_count, rate_limited_at
        FROM tokens
        WHERE is_active = 1
-         AND user_id != 'jdx'
+         AND (user_id IS NULL OR user_id != 'jdx')
          AND (expires_at IS NULL OR expires_at > ?)
        ORDER BY id`,
     )
@@ -161,6 +166,7 @@ async function loadPoolTokens(
 async function storeObservations(
   db: D1Database,
   observedAt: string,
+  tokenCount: number,
   observations: TokenObservation[],
 ): Promise<void> {
   await db.batch([
@@ -169,7 +175,7 @@ async function storeObservations(
         `INSERT INTO token_observation_runs (observed_at, token_count)
            VALUES (?, ?)`,
       )
-      .bind(observedAt, observations.length),
+      .bind(observedAt, tokenCount),
     ...observations.map((observation) =>
       db
         .prepare(
@@ -192,6 +198,36 @@ async function storeObservations(
         ),
     ),
   ]);
+}
+
+export function selectTokenBatch<T>(
+  tokens: T[],
+  now: Date,
+  maximum = MAX_TOKEN_CHECKS_PER_RUN,
+): T[] {
+  if (tokens.length <= maximum) return tokens;
+
+  const batchCount = Math.ceil(tokens.length / maximum);
+  const interval = Math.floor(now.getTime() / OBSERVATION_INTERVAL_MS);
+  const batchIndex = interval % batchCount;
+  return tokens.slice(batchIndex * maximum, (batchIndex + 1) * maximum);
+}
+
+async function inspectTokens(
+  tokens: PoolToken[],
+  observedAt: string,
+): Promise<TokenObservation[]> {
+  const observations: TokenObservation[] = [];
+  for (let index = 0; index < tokens.length; index += TOKEN_CHECK_CONCURRENCY) {
+    observations.push(
+      ...(await Promise.all(
+        tokens
+          .slice(index, index + TOKEN_CHECK_CONCURRENCY)
+          .map((token) => inspectToken(token, observedAt)),
+      )),
+    );
+  }
+  return observations;
 }
 
 function mapObservation(row: ObservationRow): TokenObservation {
@@ -283,7 +319,10 @@ export function summarizeTokenPool(
   latest: TokenObservation[],
   recent: TokenObservation[],
   observedAt: string | null = latest[0]?.observedAt ?? null,
+  tokenCount = latest.length,
 ): TokenPoolSummary {
+  const checkedTokens = latest.length;
+  const complete = checkedTokens === tokenCount;
   const usable = latest.filter(
     (token) => token.remaining !== null && !token.error,
   );
@@ -309,9 +348,11 @@ export function summarizeTokenPool(
       token.remaining >= MIN_TOKEN_REMAINING,
   ).length;
   const currentTokenIds = new Set(latest.map((token) => token.tokenId));
-  const rates = calculateRates(
-    recent.filter((token) => currentTokenIds.has(token.tokenId)),
-  );
+  const rates = complete
+    ? calculateRates(
+        recent.filter((token) => currentTokenIds.has(token.tokenId)),
+      )
+    : { quotaBurnPerHour: null, checkoutRatePerHour: null };
   const usableRemaining = usable.reduce(
     (sum, token) =>
       sum + Math.max(0, (token.remaining ?? 0) - MIN_TOKEN_REMAINING),
@@ -329,10 +370,16 @@ export function summarizeTokenPool(
 
   const reasons: string[] = [];
   let level: TokenRiskLevel = "healthy";
-  if (latest.length === 0) reasons.push("No pool tokens are configured");
-  if (availableTokens === 0) {
+  if (tokenCount === 0) reasons.push("No pool tokens are configured");
+  if (!complete) {
+    const deferredTokens = tokenCount - checkedTokens;
+    reasons.push(
+      `${deferredTokens} token${deferredTokens === 1 ? " was" : "s were"} deferred to another check`,
+    );
+  }
+  if (complete && availableTokens === 0) {
     reasons.push("No token has at least 1,000 requests left");
-  } else if (availableTokens === 1) {
+  } else if (complete && availableTokens === 1) {
     reasons.push("Only one token has at least 1,000 requests left");
   }
   if (invalidTokens > 0)
@@ -347,7 +394,7 @@ export function summarizeTokenPool(
     reasons.push(
       `${belowReserveTokens} token${belowReserveTokens === 1 ? " is" : "s are"} below reserve`,
     );
-  if (remainingPercent !== null && remainingPercent <= 35)
+  if (complete && remainingPercent !== null && remainingPercent <= 35)
     reasons.push(`Only ${remainingPercent}% of quota remains`);
   if (hoursToReserve !== null && hoursToReserve <= 6)
     reasons.push(
@@ -355,14 +402,15 @@ export function summarizeTokenPool(
     );
 
   if (
-    latest.length === 0 ||
-    availableTokens === 0 ||
-    (remainingPercent !== null && remainingPercent <= 15) ||
+    tokenCount === 0 ||
+    (complete && availableTokens === 0) ||
+    (complete && remainingPercent !== null && remainingPercent <= 15) ||
     (hoursToReserve !== null && hoursToReserve <= 2)
   ) {
     level = "critical";
   } else if (
-    availableTokens <= 1 ||
+    !complete ||
+    (complete && availableTokens <= 1) ||
     invalidTokens > 0 ||
     rateLimitedTokens > 0 ||
     belowReserveTokens > 0 ||
@@ -376,7 +424,9 @@ export function summarizeTokenPool(
     level,
     reasons,
     observedAt,
-    tokenCount: latest.length,
+    tokenCount,
+    checkedTokens,
+    complete,
     availableTokens,
     rateLimitedTokens,
     belowReserveTokens,
@@ -437,26 +487,32 @@ function historyPoints(
   runs: ObservationRunRow[],
   observations: TokenObservation[],
 ): TokenHistoryPoint[] {
+  const observationCounts = new Map<string, number>();
+  for (const observation of observations) {
+    observationCounts.set(
+      observation.observedAt,
+      (observationCounts.get(observation.observedAt) ?? 0) + 1,
+    );
+  }
   const points = new Map<string, TokenHistoryPoint>(
-    runs.map((run) => [
-      run.observed_at,
-      {
-        observedAt: run.observed_at,
-        remaining: 0,
-        limit: 0,
-        availableTokens: 0,
-        usageCount: 0,
-      },
-    ]),
+    runs
+      .filter(
+        (run) => observationCounts.get(run.observed_at) === run.token_count,
+      )
+      .map((run) => [
+        run.observed_at,
+        {
+          observedAt: run.observed_at,
+          remaining: 0,
+          limit: 0,
+          availableTokens: 0,
+          usageCount: 0,
+        },
+      ]),
   );
   for (const observation of observations) {
-    const point = points.get(observation.observedAt) ?? {
-      observedAt: observation.observedAt,
-      remaining: 0,
-      limit: 0,
-      availableTokens: 0,
-      usageCount: 0,
-    };
+    const point = points.get(observation.observedAt);
+    if (!point) continue;
     point.remaining += observation.remaining ?? 0;
     point.limit += observation.limit ?? 0;
     point.availableTokens += observation.available ? 1 : 0;
@@ -479,9 +535,15 @@ export async function getTokenObservability(
   const runs = await loadObservationRuns(env.DB, since);
   const latestAt = runs.at(-1)?.observed_at;
   const latest = latestRun(observations, latestAt);
+  const latestTokenCount = runs.at(-1)?.token_count ?? latest.length;
 
   return {
-    summary: summarizeTokenPool(latest, observations, latestAt ?? null),
+    summary: summarizeTokenPool(
+      latest,
+      observations,
+      latestAt ?? null,
+      latestTokenCount,
+    ),
     tokens: latest,
     history: historyPoints(runs, observations),
     alerting: {
@@ -496,6 +558,7 @@ export async function getTokenObservability(
 function alertFingerprint(summary: TokenPoolSummary): string {
   return [
     summary.level,
+    summary.complete,
     summary.availableTokens,
     summary.rateLimitedTokens,
     summary.belowReserveTokens,
@@ -585,6 +648,12 @@ async function maybeAlert(
   summary: TokenPoolSummary,
   now: Date,
 ): Promise<void> {
+  const concretePartialFailure =
+    summary.invalidTokens > 0 ||
+    summary.rateLimitedTokens > 0 ||
+    summary.belowReserveTokens > 0;
+  if (!summary.complete && !concretePartialFailure) return;
+
   const state = await getAlertState(env.DB);
   const fingerprint = alertFingerprint(summary);
   const { recovery, shouldSend } = getAlertDecision(
@@ -639,10 +708,9 @@ export async function observeTokenPool(
 ): Promise<TokenObservabilityData> {
   const observedAt = now.toISOString();
   const tokens = await loadPoolTokens(env.DB, observedAt);
-  const observations = await Promise.all(
-    tokens.map((token) => inspectToken(token, observedAt)),
-  );
-  await storeObservations(env.DB, observedAt, observations);
+  const tokensToCheck = selectTokenBatch(tokens, now);
+  const observations = await inspectTokens(tokensToCheck, observedAt);
+  await storeObservations(env.DB, observedAt, tokens.length, observations);
   const retentionCutoff = new Date(
     now.getTime() - 30 * 86_400_000,
   ).toISOString();

--- a/src/token-observability.ts
+++ b/src/token-observability.ts
@@ -476,6 +476,27 @@ async function loadObservationRows(
   return result.results;
 }
 
+async function loadLatestObservationRows(
+  db: D1Database,
+): Promise<ObservationRow[]> {
+  const result = await db
+    .prepare(
+      `SELECT o.token_id, o.user_id, o.user_name, o.observed_at, o.remaining,
+              o.limit_count, o.reset_at, o.usage_count, o.is_available, o.error
+       FROM token_observations o
+       INNER JOIN (
+         SELECT token_id, MAX(observed_at) AS observed_at
+         FROM token_observations
+         GROUP BY token_id
+       ) latest
+         ON latest.token_id = o.token_id
+        AND latest.observed_at = o.observed_at
+       ORDER BY o.token_id`,
+    )
+    .all<ObservationRow>();
+  return result.results;
+}
+
 async function loadObservationRuns(
   db: D1Database,
   since: string,
@@ -495,20 +516,13 @@ async function loadObservationRuns(
 export function selectCurrentObservations(
   observations: TokenObservation[],
   tokenIds: number[],
-  now: Date,
-  maximum = MAX_TOKEN_CHECKS_PER_RUN,
 ): TokenObservation[] {
   if (tokenIds.length === 0) return [];
 
-  const batchCount = Math.ceil(tokenIds.length / maximum);
-  const cutoff = now.getTime() - (batchCount + 1) * OBSERVATION_INTERVAL_MS;
   const currentTokenIds = new Set(tokenIds);
   const latest = new Map<number, TokenObservation>();
   for (const observation of observations) {
-    if (
-      currentTokenIds.has(observation.tokenId) &&
-      Date.parse(observation.observedAt) >= cutoff
-    ) {
+    if (currentTokenIds.has(observation.tokenId)) {
       const current = latest.get(observation.tokenId);
       if (!current || observation.observedAt > current.observedAt) {
         latest.set(observation.tokenId, observation);
@@ -519,6 +533,22 @@ export function selectCurrentObservations(
     const observation = latest.get(tokenId);
     return observation ? [observation] : [];
   });
+}
+
+function selectAlertObservations(
+  observations: TokenObservation[],
+  tokenIds: number[],
+  now: Date,
+  maximum = MAX_TOKEN_CHECKS_PER_RUN,
+): TokenObservation[] {
+  const batchCount = Math.ceil(tokenIds.length / maximum);
+  const cutoff = now.getTime() - (batchCount + 1) * OBSERVATION_INTERVAL_MS;
+  return selectCurrentObservations(
+    observations.filter(
+      (observation) => Date.parse(observation.observedAt) >= cutoff,
+    ),
+    tokenIds,
+  );
 }
 
 function historyPoints(
@@ -565,16 +595,50 @@ export async function getTokenObservability(
   env: Env,
   now = new Date(),
 ): Promise<TokenObservabilityData> {
+  const state = await loadTokenObservabilityState(env, now);
+  return tokenObservabilityData(env, state);
+}
+
+type TokenObservabilityState = {
+  observations: TokenObservation[];
+  latestObservations: TokenObservation[];
+  runs: ObservationRunRow[];
+  latestAt: string | undefined;
+  currentTokenIds: number[];
+};
+
+async function loadTokenObservabilityState(
+  env: Env,
+  now: Date,
+): Promise<TokenObservabilityState> {
   const since = new Date(
     now.getTime() - HISTORY_HOURS * 3_600_000,
   ).toISOString();
   const observations = (await loadObservationRows(env.DB, since)).map(
     mapObservation,
   );
+  const latestObservations = (await loadLatestObservationRows(env.DB)).map(
+    mapObservation,
+  );
   const runs = await loadObservationRuns(env.DB, since);
   const latestAt = runs.at(-1)?.observed_at;
   const currentTokenIds = await loadPoolTokenIds(env.DB, now.toISOString());
-  const latest = selectCurrentObservations(observations, currentTokenIds, now);
+  return {
+    observations,
+    latestObservations,
+    runs,
+    latestAt,
+    currentTokenIds,
+  };
+}
+
+function tokenObservabilityData(
+  env: Env,
+  state: TokenObservabilityState,
+): TokenObservabilityData {
+  const { observations, latestObservations, runs, latestAt, currentTokenIds } =
+    state;
+  const latest = selectCurrentObservations(latestObservations, currentTokenIds);
 
   return {
     summary: summarizeTokenPool(
@@ -595,9 +659,16 @@ export async function getTokenObservability(
 }
 
 function alertFingerprint(summary: TokenPoolSummary): string {
+  if (!summary.complete) {
+    return [
+      "partial",
+      summary.invalidTokens > 0,
+      summary.rateLimitedTokens > 0,
+      summary.belowReserveTokens > 0,
+    ].join("|");
+  }
   return [
     summary.level,
-    summary.complete,
     summary.availableTokens,
     summary.rateLimitedTokens,
     summary.belowReserveTokens,
@@ -693,7 +764,7 @@ async function maybeAlert(
   summary: TokenPoolSummary,
   now: Date,
 ): Promise<void> {
-  if (!summary.complete) return;
+  if (!shouldEvaluateAlert(summary)) return;
 
   const state = await getAlertState(env.DB);
   const fingerprint = alertFingerprint(summary);
@@ -715,6 +786,15 @@ async function maybeAlert(
     sentAt = now.toISOString();
   }
   await saveAlertState(env.DB, summary, fingerprint, sentAt);
+}
+
+export function shouldEvaluateAlert(summary: TokenPoolSummary): boolean {
+  return (
+    summary.complete ||
+    summary.invalidTokens > 0 ||
+    summary.rateLimitedTokens > 0 ||
+    summary.belowReserveTokens > 0
+  );
 }
 
 export function getAlertDecision(
@@ -764,7 +844,19 @@ export async function observeTokenPool(
     ).bind(retentionCutoff),
   ]);
 
-  const data = await getTokenObservability(env, now);
-  await maybeAlert(env, data.summary, now);
+  const state = await loadTokenObservabilityState(env, now);
+  const data = tokenObservabilityData(env, state);
+  const alertObservations = selectAlertObservations(
+    state.latestObservations,
+    state.currentTokenIds,
+    now,
+  );
+  const alertSummary = summarizeTokenPool(
+    alertObservations,
+    state.observations,
+    state.latestAt ?? null,
+    state.currentTokenIds.length,
+  );
+  await maybeAlert(env, alertSummary, now);
   return data;
 }

--- a/src/token-observability.ts
+++ b/src/token-observability.ts
@@ -163,6 +163,24 @@ async function loadPoolTokens(
   return result.results;
 }
 
+async function loadPoolTokenIds(
+  db: D1Database,
+  now: string,
+): Promise<number[]> {
+  const result = await db
+    .prepare(
+      `SELECT id
+       FROM tokens
+       WHERE is_active = 1
+         AND (user_id IS NULL OR user_id != 'jdx')
+         AND (expires_at IS NULL OR expires_at > ?)
+       ORDER BY id`,
+    )
+    .bind(now)
+    .all<{ id: number }>();
+  return result.results.map(({ id }) => id);
+}
+
 async function storeObservations(
   db: D1Database,
   observedAt: string,
@@ -474,13 +492,33 @@ async function loadObservationRuns(
   return result.results;
 }
 
-function latestRun(
+export function selectCurrentObservations(
   observations: TokenObservation[],
-  latestAt: string | undefined,
+  tokenIds: number[],
+  now: Date,
+  maximum = MAX_TOKEN_CHECKS_PER_RUN,
 ): TokenObservation[] {
-  return latestAt
-    ? observations.filter((observation) => observation.observedAt === latestAt)
-    : [];
+  if (tokenIds.length === 0) return [];
+
+  const batchCount = Math.ceil(tokenIds.length / maximum);
+  const cutoff = now.getTime() - (batchCount + 1) * OBSERVATION_INTERVAL_MS;
+  const currentTokenIds = new Set(tokenIds);
+  const latest = new Map<number, TokenObservation>();
+  for (const observation of observations) {
+    if (
+      currentTokenIds.has(observation.tokenId) &&
+      Date.parse(observation.observedAt) >= cutoff
+    ) {
+      const current = latest.get(observation.tokenId);
+      if (!current || observation.observedAt > current.observedAt) {
+        latest.set(observation.tokenId, observation);
+      }
+    }
+  }
+  return tokenIds.flatMap((tokenId) => {
+    const observation = latest.get(tokenId);
+    return observation ? [observation] : [];
+  });
 }
 
 function historyPoints(
@@ -497,7 +535,8 @@ function historyPoints(
   const points = new Map<string, TokenHistoryPoint>(
     runs
       .filter(
-        (run) => observationCounts.get(run.observed_at) === run.token_count,
+        (run) =>
+          (observationCounts.get(run.observed_at) ?? 0) === run.token_count,
       )
       .map((run) => [
         run.observed_at,
@@ -534,15 +573,15 @@ export async function getTokenObservability(
   );
   const runs = await loadObservationRuns(env.DB, since);
   const latestAt = runs.at(-1)?.observed_at;
-  const latest = latestRun(observations, latestAt);
-  const latestTokenCount = runs.at(-1)?.token_count ?? latest.length;
+  const currentTokenIds = await loadPoolTokenIds(env.DB, now.toISOString());
+  const latest = selectCurrentObservations(observations, currentTokenIds, now);
 
   return {
     summary: summarizeTokenPool(
       latest,
       observations,
       latestAt ?? null,
-      latestTokenCount,
+      currentTokenIds.length,
     ),
     tokens: latest,
     history: historyPoints(runs, observations),
@@ -619,6 +658,12 @@ async function sendAlert(
   const reasons = summary.reasons.length
     ? `<ul>${summary.reasons.map((reason) => `<li>${escapeHtml(reason)}</li>`).join("")}</ul>`
     : "<p>The token pool is back within its healthy thresholds.</p>";
+  const availability = summary.complete
+    ? `${summary.availableTokens}/${summary.tokenCount}`
+    : `${summary.availableTokens}/${summary.checkedTokens} checked (${summary.tokenCount} total)`;
+  const quotaLabel = summary.complete
+    ? "Quota remaining"
+    : "Checked-token quota";
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
     headers: {
@@ -630,8 +675,8 @@ async function sendAlert(
       to: env.TOKEN_ALERT_TO,
       subject,
       html: `<h2>GitHub token pool ${escapeHtml(label)}</h2>${reasons}
-        <p><strong>Available tokens:</strong> ${summary.availableTokens}/${summary.tokenCount}<br>
-        <strong>Quota remaining:</strong> ${summary.remaining.toLocaleString()} / ${summary.limit.toLocaleString()} (${summary.remainingPercent ?? "unknown"}%)<br>
+        <p><strong>Available tokens:</strong> ${availability}<br>
+        <strong>${quotaLabel}:</strong> ${summary.remaining.toLocaleString()} / ${summary.limit.toLocaleString()} (${summary.remainingPercent ?? "unknown"}%)<br>
         <strong>Quota burn:</strong> ${summary.quotaBurnPerHour?.toLocaleString() ?? "collecting data"}/hour</p>
         <p><a href="https://mise-versions.jdx.dev/admin">Open token observability</a></p>`,
     }),
@@ -648,11 +693,7 @@ async function maybeAlert(
   summary: TokenPoolSummary,
   now: Date,
 ): Promise<void> {
-  const concretePartialFailure =
-    summary.invalidTokens > 0 ||
-    summary.rateLimitedTokens > 0 ||
-    summary.belowReserveTokens > 0;
-  if (!summary.complete && !concretePartialFailure) return;
+  if (!summary.complete) return;
 
   const state = await getAlertState(env.DB);
   const fingerprint = alertFingerprint(summary);

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -320,6 +320,8 @@ if (!auth || !isAdmin(auth.username)) {
 </Layout>
 
 <script>
+  import type { TokenObservabilityData } from '../../../src/token-observability';
+
   // localStorage helpers for panel state persistence
   const PANEL_STATE_KEY = 'admin-panel-state';
 
@@ -342,45 +344,8 @@ if (!auth || !isAdmin(auth.username)) {
     }
   }
 
-  interface CapacitySummary {
-    level: 'healthy' | 'warning' | 'critical';
-    reasons: string[];
-    observedAt: string | null;
-    tokenCount: number;
-    availableTokens: number;
-    remaining: number;
-    limit: number;
-    remainingPercent: number | null;
-    quotaBurnPerHour: number | null;
-    checkoutRatePerHour: number | null;
-    hoursToReserve: number | null;
-    nextResetAt: string | null;
-  }
-
-  interface CapacityToken {
-    tokenId: number;
-    userId: string | null;
-    userName: string | null;
-    remaining: number | null;
-    limit: number | null;
-    available: boolean;
-    error: string | null;
-  }
-
-  interface CapacityHistoryPoint {
-    observedAt: string;
-    remaining: number;
-    limit: number;
-    availableTokens: number;
-    usageCount: number;
-  }
-
-  interface CapacityData {
-    summary: CapacitySummary;
-    tokens: CapacityToken[];
-    history: CapacityHistoryPoint[];
-    alerting: { configured: boolean; recipient: string | null };
-  }
+  type CapacityHistoryPoint = TokenObservabilityData['history'][number];
+  type CapacityData = TokenObservabilityData;
 
   function escapeHtml(value: string): string {
     const span = document.createElement('span');
@@ -463,10 +428,19 @@ if (!auth || !isAdmin(auth.username)) {
     }
 
     const metricTone = summary.level === 'critical' ? 'text-red-300' : summary.level === 'warning' ? 'text-orange-300' : 'text-green-300';
-    setMetric('metric-available', `${summary.availableTokens}/${summary.tokenCount}`, metricTone);
+    setMetric(
+      'metric-available',
+      summary.complete
+        ? `${summary.availableTokens}/${summary.tokenCount}`
+        : `${summary.availableTokens}/${summary.checkedTokens} checked`,
+      metricTone,
+    );
     setMetric('metric-remaining', summary.remainingPercent === null ? '—' : `${summary.remainingPercent}%`, metricTone);
     const remainingDetail = document.getElementById('metric-remaining-detail');
-    if (remainingDetail) remainingDetail.textContent = `${summary.remaining.toLocaleString()} of ${summary.limit.toLocaleString()} requests`;
+    if (remainingDetail) {
+      const coverage = summary.complete ? 'across the pool' : `across ${summary.checkedTokens} of ${summary.tokenCount} tokens`;
+      remainingDetail.textContent = `${summary.remaining.toLocaleString()} of ${summary.limit.toLocaleString()} requests · ${coverage}`;
+    }
     setMetric('metric-burn', summary.quotaBurnPerHour === null ? 'Learning' : `${formatCompact(summary.quotaBurnPerHour)}/h`);
     const checkouts = document.getElementById('metric-checkouts');
     if (checkouts) checkouts.textContent = summary.checkoutRatePerHour === null ? 'needs two snapshots' : `${formatCompact(summary.checkoutRatePerHour)} token checkouts/hour`;

--- a/web/src/pages/api/admin/token-observability.ts
+++ b/web/src/pages/api/admin/token-observability.ts
@@ -1,5 +1,7 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
+import { drizzle } from "drizzle-orm/d1";
+import { ensureTokenObservabilitySchema } from "../../../../../src/migrations";
 import {
   getTokenObservability,
   observeTokenPool,
@@ -16,6 +18,7 @@ export const GET: APIRoute = async ({ request }) => {
   const authError = await authorize(request);
   if (authError) return authError;
 
+  await ensureTokenObservabilitySchema(drizzle(env.DB));
   return jsonResponse(await getTokenObservability(env), 200, {
     "Cache-Control": "private, no-store",
   });
@@ -25,6 +28,7 @@ export const POST: APIRoute = async ({ request }) => {
   const authError = await authorize(request);
   if (authError) return authError;
 
+  await ensureTokenObservabilitySchema(drizzle(env.DB));
   return jsonResponse(await observeTokenPool(env), 200, {
     "Cache-Control": "private, no-store",
   });


### PR DESCRIPTION
## Summary
- make retained-snapshot repair atomic and add migration 7 recovery for partial prior attempts
- guard admin observability routes during deployment, preserve existing Resend secrets when the Actions secret is absent, and include tokens with null user IDs
- rotate through at most 45 token checks per run with five concurrent requests, explicitly mark partial runs, and exclude them from aggregate burn/history calculations
- share the Worker response type with the dashboard and clarify the scheduled collection flow

This follows up on review comments that arrived as #290 was merged. The collection bound follows Cloudflare’s documented 50 external-subrequest Free-plan limit while leaving room for Resend and redirects.

## Validation
- `npm run test:js` (112 tests)
- `npm run test:shell` (31 tests)
- `tsc --noEmit`
- `npm --workspace web run build`
- `wrangler deploy --dry-run`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect production alerting, D1 migrations, and how pool health is classified; mistakes could suppress alerts or mis-report capacity, though behavior is covered by expanded tests.
> 
> **Overview**
> **Token pool observability** now caps each scheduled run at **45 GitHub checks** (five concurrent), rotating batches every 15 minutes so large pools stay within Workers Free-plan subrequest limits. Summaries expose **`complete` / `checkedTokens`**, treat deferred tokens as **warning** instead of false **critical**, skip aggregate burn/history for partial runs, and only fire alerts when checks are complete or a checked token shows a real problem.
> 
> **Dashboard and alerts** reuse the Worker `TokenObservabilityData` type, show partial coverage in metrics, and label email stats for incomplete runs. Pool queries now include tokens with **null `user_id`**.
> 
> **Deploy and schema**: CI **skips overwriting `RESEND_API_KEY`** when the Actions secret is unset; admin observability routes call **`ensureTokenObservabilitySchema`** so reads work mid-deploy. Migration **7** and a reworked **`preserveTokenObservationSnapshots`** make snapshot table repair **atomic** and recover from interrupted migration 6 attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd988318bf2b2f650925582bfeeebb4929c3f417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->