### PR TITLE
fix(update): disable release age filtering during collection

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,9 +29,6 @@ env:
   # entry (e.g. a version added without metadata after a GitHub rate limit)
   # gets re-ingested on the next run instead of being corrected from upstream.
   MISE_USE_VERSIONS_HOST: "false"
-  # Collect release metadata immediately. Clients apply their own
-  # minimum_release_age when selecting which version to install.
-  MISE_MINIMUM_RELEASE_AGE: "0s"
   # Include pre-release versions globally so the JSON output of
   # `mise ls-remote --json` carries `prerelease = true` for tags upstream
   # has flagged as pre-releases. Without this, mise filters them out before

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -444,7 +444,7 @@ generate_toml_file() {
 	error_output=$(mktemp)
 
 	# Try to get JSON with timestamps/release URLs/prerelease flags from
-	# mise ls-remote --prerelease --json. The TOML path can carry prerelease
+	# mise ls-remote --minimum-release-age 0s --prerelease --json. The TOML path can carry prerelease
 	# metadata, so collect the superset and let clients filter by that flag.
 	# Pass the rotated per-tool token via GITHUB_API_TOKEN so this call
 	# isn't rate-limited by the workflow's single shared MISE_GITHUB_TOKEN.
@@ -457,7 +457,7 @@ generate_toml_file() {
 	local json_output
 	local json_metadata_fallback=0
 	local fallback_new_versions=""
-	if json_output=$(GITHUB_API_TOKEN="$token" mise ls-remote --prerelease --json "$tool" 2>/dev/null) && [ -n "$json_output" ]; then
+	if json_output=$(GITHUB_API_TOKEN="$token" mise ls-remote --minimum-release-age 0s --prerelease --json "$tool" 2>/dev/null) && [ -n "$json_output" ]; then
 		local json_type json_count
 		read -r json_type json_count < <(printf '%s' "$json_output" | jq -r '[type, (if type == "array" then length else 0 end)] | @tsv' 2>/dev/null || echo "invalid 0")
 		if [ "$json_type" = "array" ] && [ "${json_count:-0}" -gt 0 ]; then
@@ -582,12 +582,13 @@ fetch() {
 
 	# Create a temporary file to capture stderr and check for rate limiting.
 	# Docker container is used for isolation: `mise ls-remote` may execute
-	# untrusted plugin code (asdf/vfox), and the sandbox contains it.
+	# untrusted plugin code (asdf/vfox), and the sandbox contains it. Disable
+	# minimum_release_age explicitly so this fallback catalog is complete.
 	local stderr_file
 	stderr_file=$(mktemp)
 
 	if ! docker run --rm -e GITHUB_TOKEN="$token" -e MISE_USE_VERSIONS_HOST -e MISE_LIST_ALL_VERSIONS -e MISE_LOG_HTTP -e MISE_EXPERIMENTAL -e MISE_PRERELEASES -e MISE_TRUSTED_CONFIG_PATHS=/ \
-		jdxcode/mise -y ls-remote "$tool" >"docs/$tool" 2>"$stderr_file"; then
+		jdxcode/mise -y ls-remote --minimum-release-age 0s "$tool" >"docs/$tool" 2>"$stderr_file"; then
 		log_error "Failed to fetch versions" "tool=$tool"
 		cat "$stderr_file" >&2
 

--- a/scripts/update.test.sh
+++ b/scripts/update.test.sh
@@ -195,6 +195,34 @@ test_skip_list_parser_ignores_other_case_blocks
 echo ""
 
 # ============================================
+# Test: version collection disables release age filtering
+# ============================================
+echo "--- Version Collection Release Age Tests ---"
+
+test_json_collection_disables_release_age_filtering() {
+	local command
+	command=$(grep -F 'json_output=$(GITHUB_API_TOKEN="$token" mise ls-remote' scripts/update.sh)
+
+	assert_contains "$command" 'mise ls-remote --minimum-release-age 0s' \
+		"JSON metadata collection disables minimum_release_age"
+}
+test_json_collection_disables_release_age_filtering
+
+test_docker_collection_disables_release_age_filtering() {
+	local command
+	command=$(awk '
+		/docker run --rm/ { docker_run = $0; next }
+		docker_run && /jdxcode\/mise -y ls-remote/ { print docker_run " " $0; exit }
+	' scripts/update.sh)
+
+	assert_contains "$command" 'ls-remote --minimum-release-age 0s "$tool"' \
+		"Docker catalog collection disables minimum_release_age"
+}
+test_docker_collection_disables_release_age_filtering
+
+echo ""
+
+# ============================================
 # Test: Statistics helpers (isolated)
 # ============================================
 echo "--- Statistics Helper Tests ---"


### PR DESCRIPTION
## Summary
- pass `--minimum-release-age 0s` directly to both catalog-producing `mise ls-remote` calls
- remove the redundant workflow-level environment setting
- add regression coverage for the JSON metadata and Docker fallback paths

The workflow intended to collect complete catalogs by setting `MISE_MINIMUM_RELEASE_AGE=0s`, but the isolated Docker invocation did not forward that variable. When JSON metadata collection fell back to the Docker-produced list, releases inside mise’s default cutoff could be omitted. Making the override explicit at both call sites keeps policy on the client side and avoids adding direct GitHub fallback requests to mise.

Related: https://github.com/jdx/mise/discussions/12543

## Testing
- `aube run test:shell` (33 passed)
- `aube ci`
- full JS/TypeScript/shell suites after web build (99 JS, 16 TypeScript, 33 shell passed)

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect how version catalogs are collected in the update workflow and fallback paths, with no auth or data-model changes beyond fuller version lists.
> 
> **Overview**
> **Catalog collection now disables mise’s minimum release age at both `ls-remote` call sites**, instead of relying on a workflow env var that the Docker sandbox never received.
> 
> The update workflow drops **`MISE_MINIMUM_RELEASE_AGE: "0s"`** from global `env`. **`scripts/update.sh`** passes **`--minimum-release-age 0s`** on the JSON metadata path (`mise ls-remote --prerelease --json`) and on the isolated Docker **`ls-remote`** fallback so newly published versions inside mise’s default cutoff are not omitted when JSON collection falls back to the plain-text catalog.
> 
> **Regression tests** in **`scripts/update.test.sh`** assert both command strings still include the flag, so release-age policy stays on clients while the published version lists remain complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b0c02ca3fe6a0facd0a95845cabbade5ea89323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version catalogs now collect all available releases without unintended age-based filtering.
  * Default release-age behavior remains enabled elsewhere.

* **Tests**
  * Added coverage to verify release-age filtering is disabled during catalog generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->