### PR TITLE
chore(ci): stagger update schedule

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,7 +8,8 @@ on:
         default: "false"
         type: boolean
   schedule:
-    - cron: "*/30 * * * *"
+    # Avoid the :00 high-load window and stagger half-hour runs away from common boundaries.
+    - cron: "7,37 * * * *"
 
 concurrency:
   group: update


### PR DESCRIPTION
## Summary
- retain the existing twice-hourly update cadence
- move scheduled runs from `:00`/`:30` to `:07`/`:37`
- avoid GitHub Actions’ documented top-of-hour high-load window without increasing API usage or overlapping the typical 11–16 minute runtime

Recent scheduled runs have arrived roughly every 2.5–4 hours despite the `*/30` configuration. GitHub documents that scheduled events may be delayed or dropped under load, particularly at the start of each hour, and recommends scheduling at a different time within the hour.

GitHub guidance: https://docs.github.com/en/actions/how-tos/troubleshoot-workflows#scheduled-workflows-running-at-unexpected-times

## Testing
- `git diff --check`
- `prettier --check .github/workflows/update.yml`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes when the scheduled job fires; no application, auth, or data-path changes.
> 
> **Overview**
> Keeps the **update** workflow on a twice-hourly schedule but shifts scheduled runs from **:00** and **:30** to **:07** and **:37** via `cron: "7,37 * * * *"`.
> 
> Adds a short comment that this avoids GitHub Actions’ top-of-hour load window while staying off common half-hour boundaries. **Manual `workflow_dispatch` and the rest of the job steps are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad15fc54b5fec546518c7f2b0820d1577fadf14d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->