### PR TITLE
fix(ci): checkout current main for queued updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -40,6 +40,9 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Queued workflow_dispatch runs otherwise retain their stale event SHA.
+          ref: main
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
       - run: curl https://mise.run | MISE_INSTALL_PATH="$HOME/.local/share/mise/bin/mise" sh && mise --version
       - run: aube ci


### PR DESCRIPTION
## Summary
- resolve `main` when an update job starts instead of checking out the SHA captured when it was dispatched
- prevent serialized updater runs from regenerating version files on a stale base and conflicting during the final rebase

This addresses the failure in [run 33511494515](https://github.com/jdx/mise-versions/actions/runs/33511494515/job/99869014351), where the queued run retained `2812966` after the preceding run pushed `c880e78`.

## Validation
- `actionlint .github/workflows/update.yml`
- `prettier --check .github/workflows/update.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI checkout configuration change with no application or data-path impact; it reduces merge/rebase failures during serialized update runs.
> 
> **Overview**
> Fixes the **update** workflow so each job checks out **`main` at run start** instead of the `workflow_dispatch` event SHA, which stays frozen when runs queue behind the shared `update` concurrency group.
> 
> That avoids back-to-back updater jobs regenerating version data from an outdated base and then failing when they rebase and push against commits another run already landed on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b06f7a7deb81cea329fda07b7e301d97607a618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update workflow runs now use the latest version of the main branch, ensuring manually triggered updates process current changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->