### PR TITLE
fix(update): reject new versions without metadata

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -344,14 +344,14 @@ generate_summary() {
 | Metric | Value |
 |--------|-------|
 | JSON Metadata Fallbacks | $(get_stat "total_json_metadata_fallbacks") |
-| New Versions Added Via Fallback | ${fallback_new_versions_count} |
+| New Versions Rejected Without Metadata | ${fallback_new_versions_count} |
 SUMMARY_EOF
 
 	append_summary_list_section "📦 Updated Tools" "updated_tools_list" "No tools were updated in this run." "docs_link" "$commit_hash"
 	append_summary_list_section "❌ Failed Tools" "failed_tools_list" "No tools failed in this run." "code" "$commit_hash"
 	append_summary_list_section "📭 No Versions" "no_versions_tools_list" "No tools returned an empty version list." "code" "$commit_hash"
-	append_summary_list_section "🔁 JSON Metadata Fallbacks" "json_metadata_fallback_tools_list" "No tools needed plain-text fallback after an empty JSON metadata response." "docs_link" "$commit_hash"
-	append_summary_list_section "🆕 New Versions Added Via Fallback" "fallback_new_versions_list" "No new versions were added through the plain-text fallback path." "fallback_version" "$commit_hash"
+	append_summary_list_section "🔁 JSON Metadata Fallbacks" "json_metadata_fallback_tools_list" "No tools needed a plain-text fallback after a JSON metadata failure." "docs_link" "$commit_hash"
+	append_summary_list_section "🚫 New Versions Rejected Without Metadata" "fallback_new_versions_list" "No new versions were rejected because of missing metadata." "fallback_version" "$commit_hash"
 
 	# Output to GitHub Actions summary
 	if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
@@ -440,8 +440,9 @@ generate_toml_file() {
 		return
 	fi
 
-	local error_output
+	local error_output metadata_error_output
 	error_output=$(mktemp)
+	metadata_error_output=$(mktemp)
 
 	# Try to get JSON with timestamps/release URLs/prerelease flags from
 	# mise ls-remote --minimum-release-age 0s --prerelease --json. The TOML path can carry prerelease
@@ -455,50 +456,68 @@ generate_toml_file() {
 	# plain-text path — losing `release_url` and `created_at` for any new
 	# version that wasn't already in the existing TOML.
 	local json_output
-	local json_metadata_fallback=0
+	local json_metadata_fallback_reason=""
 	local fallback_new_versions=""
-	if json_output=$(GITHUB_API_TOKEN="$token" mise ls-remote --minimum-release-age 0s --prerelease --json "$tool" 2>/dev/null) && [ -n "$json_output" ]; then
-		local json_type json_count
-		read -r json_type json_count < <(printf '%s' "$json_output" | jq -r '[type, (if type == "array" then length else 0 end)] | @tsv' 2>/dev/null || echo "invalid 0")
-		if [ "$json_type" = "array" ] && [ "${json_count:-0}" -gt 0 ]; then
-			# Convert JSON array to NDJSON and pipe to generate-toml.js
-			if printf '%s' "$json_output" | jq -c '.[]' 2>/dev/null | node scripts/generate-toml.js "$tool" "$toml_file" >"$toml_file.tmp" 2>"$error_output"; then
-				if toml_has_versions "$toml_file.tmp"; then
-					mv "$toml_file.tmp" "$toml_file"
-					rm -f "$error_output"
-					return
+	if json_output=$(GITHUB_API_TOKEN="$token" mise ls-remote --minimum-release-age 0s --prerelease --json --no-versions-host --strict-metadata "$tool" 2>"$metadata_error_output"); then
+		if [ -z "$json_output" ]; then
+			json_metadata_fallback_reason="empty JSON metadata response"
+		else
+			local json_type json_count
+			read -r json_type json_count < <(printf '%s' "$json_output" | jq -r '[type, (if type == "array" then length else 0 end)] | @tsv' 2>/dev/null || echo "invalid 0")
+			if [ "$json_type" = "array" ] && [ "${json_count:-0}" -gt 0 ]; then
+				# Convert JSON array to NDJSON and pipe to generate-toml.js
+				if printf '%s' "$json_output" | jq -c '.[]' 2>/dev/null | node scripts/generate-toml.js "$tool" "$toml_file" >"$toml_file.tmp" 2>"$error_output"; then
+					if toml_has_versions "$toml_file.tmp"; then
+						mv "$toml_file.tmp" "$toml_file"
+						rm -f "$error_output" "$metadata_error_output"
+						return
+					fi
+					rm -f "$toml_file.tmp"
 				fi
-				rm -f "$toml_file.tmp"
+				json_metadata_fallback_reason="failed to generate TOML from JSON metadata"
+			elif [ "$json_type" = "array" ] && [ "${json_count:-0}" -eq 0 ]; then
+				json_metadata_fallback_reason="empty JSON metadata array"
+			else
+				json_metadata_fallback_reason="invalid JSON metadata response"
 			fi
-		elif [ "$json_type" = "array" ] && [ "${json_count:-0}" -eq 0 ]; then
-			json_metadata_fallback=1
-			increment_stat "total_json_metadata_fallbacks"
-			add_to_list "json_metadata_fallback_tools_list" "$tool"
-			log_info "mise ls-remote --json returned empty, using plain-text fallback" "tool=$tool"
 		fi
+	else
+		json_metadata_fallback_reason="mise ls-remote --json failed"
 	fi
 
-	# Fall back to plain text conversion (preserves existing timestamps).
-	# `fetch()` already guaranteed versions_file is non-empty, so this path
-	# should always produce a populated TOML.
-	if [ "$json_metadata_fallback" -eq 1 ]; then
-		fallback_new_versions=$(collect_fallback_new_versions "$tool" || true)
+	# Fall back to plain text only when it cannot introduce incomplete metadata.
+	# Existing versions retain their stored metadata, but a newly discovered
+	# version would otherwise receive the current time and lose fields such as
+	# release_url and prerelease. Skip the tool and retry it on the next run.
+	increment_stat "total_json_metadata_fallbacks"
+	add_to_list "json_metadata_fallback_tools_list" "$tool"
+	log_warn "Using plain-text fallback after metadata failure" "tool=$tool" "reason=$json_metadata_fallback_reason"
+	if [ -s "$metadata_error_output" ]; then
+		cat "$metadata_error_output" >&2
+	fi
+	fallback_new_versions=$(collect_fallback_new_versions "$tool" || true)
+	if [ -n "$fallback_new_versions" ]; then
+		record_fallback_new_versions "$tool" "$fallback_new_versions"
+		log_error "Refusing to add new versions without metadata" "tool=$tool"
+		rm -f "$toml_file.tmp" "$error_output" "$metadata_error_output"
+		return 1
 	fi
 	if jq -R -c 'select(length > 0) | {version: .}' "$versions_file" | node scripts/generate-toml.js "$tool" "$toml_file" >"$toml_file.tmp" 2>"$error_output"; then
 		if toml_has_versions "$toml_file.tmp"; then
 			mv "$toml_file.tmp" "$toml_file"
-			record_fallback_new_versions "$tool" "$fallback_new_versions"
-			rm -f "$error_output"
+			rm -f "$error_output" "$metadata_error_output"
 		else
 			log_warn "Generated TOML had no versions, refusing to overwrite" "tool=$tool"
-			rm -f "$toml_file.tmp" "$error_output"
+			rm -f "$toml_file.tmp" "$error_output" "$metadata_error_output"
+			return 1
 		fi
 	else
 		echo "Warning: Failed to generate TOML for $tool" >&2
 		if [ -s "$error_output" ]; then
 			cat "$error_output" >&2
 		fi
-		rm -f "$toml_file.tmp" "$error_output"
+		rm -f "$toml_file.tmp" "$error_output" "$metadata_error_output"
+		return 1
 	fi
 }
 
@@ -647,7 +666,11 @@ fetch() {
 		;;
 	esac
 
-	generate_toml_file "$tool" "$token"
+	if ! generate_toml_file "$tool" "$token"; then
+		rm -f "docs/$tool"
+		echo "failed" >"$status_file"
+		return 1
+	fi
 	rm -f "docs/$tool"
 	echo "fetched" >"$status_file"
 }

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -389,10 +389,22 @@ collect_fallback_new_versions() {
 
 	local fetched_versions
 	local existing_versions
+	local filtered_toml
 	fetched_versions=$(mktemp)
 	existing_versions=$(mktemp)
+	filtered_toml=$(mktemp)
 
-	awk 'NF && !seen[$0]++ { print }' "$versions_file" >"$fetched_versions"
+	# Use the canonical generator to apply ignored-versions.toml before
+	# deciding whether the plain-text fallback contains a new version.
+	if ! jq -R -c 'select(length > 0) | {version: .}' "$versions_file" |
+		node scripts/generate-toml.js "$tool" >"$filtered_toml"; then
+		rm -f "$fetched_versions" "$existing_versions" "$filtered_toml"
+		return 1
+	fi
+	if ! yq -p=toml -o=json '.versions // {}' "$filtered_toml" 2>/dev/null | jq -r 'keys[]' >"$fetched_versions"; then
+		rm -f "$fetched_versions" "$existing_versions" "$filtered_toml"
+		return 1
+	fi
 
 	if [ -s "$toml_file" ] && yq -p=toml -o=json '.versions // {}' "$toml_file" 2>/dev/null | jq -r 'keys[]' >"$existing_versions"; then
 		awk 'NR == FNR { existing[$0] = 1; next } !($0 in existing)' "$existing_versions" "$fetched_versions"
@@ -400,7 +412,7 @@ collect_fallback_new_versions() {
 		cat "$fetched_versions"
 	fi
 
-	rm -f "$fetched_versions" "$existing_versions"
+	rm -f "$fetched_versions" "$existing_versions" "$filtered_toml"
 }
 
 record_fallback_new_versions() {
@@ -437,7 +449,8 @@ generate_toml_file() {
 
 	# Check if versions file exists
 	if [ ! -f "$versions_file" ]; then
-		return
+		log_error "Versions file disappeared before TOML generation" "tool=$tool"
+		return 1
 	fi
 
 	local error_output metadata_error_output
@@ -495,7 +508,14 @@ generate_toml_file() {
 	if [ -s "$metadata_error_output" ]; then
 		cat "$metadata_error_output" >&2
 	fi
-	fallback_new_versions=$(collect_fallback_new_versions "$tool" || true)
+	if [ -s "$error_output" ]; then
+		cat "$error_output" >&2
+	fi
+	if ! fallback_new_versions=$(collect_fallback_new_versions "$tool"); then
+		log_error "Failed to compare fallback versions" "tool=$tool"
+		rm -f "$toml_file.tmp" "$error_output" "$metadata_error_output"
+		return 1
+	fi
 	if [ -n "$fallback_new_versions" ]; then
 		record_fallback_new_versions "$tool" "$fallback_new_versions"
 		log_error "Refusing to add new versions without metadata" "tool=$tool"

--- a/scripts/update.test.sh
+++ b/scripts/update.test.sh
@@ -208,6 +208,30 @@ test_json_collection_disables_release_age_filtering() {
 }
 test_json_collection_disables_release_age_filtering
 
+test_json_collection_requires_upstream_metadata() {
+	local command
+	command=$(grep -F 'json_output=$(GITHUB_API_TOKEN="$token" mise ls-remote' scripts/update.sh)
+
+	assert_contains "$command" '--no-versions-host' \
+		"JSON metadata collection explicitly bypasses the versions host"
+	assert_contains "$command" '--strict-metadata' \
+		"JSON metadata collection fails when upstream metadata fails"
+}
+test_json_collection_requires_upstream_metadata
+
+test_new_versions_are_rejected_during_metadata_fallback() {
+	local fallback_block
+	fallback_block=$(sed -n '/fallback_new_versions=$(collect_fallback_new_versions/,/if jq -R -c/p' scripts/update.sh)
+
+	assert_contains "$fallback_block" 'if [ -n "$fallback_new_versions" ]; then' \
+		"Metadata fallback detects newly discovered versions"
+	assert_contains "$fallback_block" 'Refusing to add new versions without metadata' \
+		"Metadata fallback rejects incomplete new versions"
+	assert_contains "$fallback_block" 'return 1' \
+		"Metadata fallback fails the tool update"
+}
+test_new_versions_are_rejected_during_metadata_fallback
+
 test_docker_collection_disables_release_age_filtering() {
 	local command
 	command=$(awk '

--- a/scripts/update.test.sh
+++ b/scripts/update.test.sh
@@ -232,6 +232,55 @@ test_new_versions_are_rejected_during_metadata_fallback() {
 }
 test_new_versions_are_rejected_during_metadata_fallback
 
+test_fallback_new_versions_ignore_denied_tags() {
+	local test_root="$TEMP_DIR/fallback_versions"
+	local collect_function
+	local yq_bin
+	collect_function=$(sed -n '/^collect_fallback_new_versions() {/,/^}/p' scripts/update.sh)
+	yq_bin=$(mise which yq 2>/dev/null || command -v yq)
+	mkdir -p "$test_root/docs"
+	ln -s "$PWD/scripts" "$test_root/scripts"
+	printf '1.0.0\nnightly\n' >"$test_root/docs/crush"
+	printf '[versions]\n"1.0.0" = { created_at = 2026-01-01T00:00:00.000Z }\n' >"$test_root/docs/crush.toml"
+
+	local result
+	result=$(
+		cd "$test_root"
+		PATH="$(dirname "$yq_bin"):$PATH"
+		eval "$collect_function"
+		collect_fallback_new_versions crush
+	)
+	assert_equals "" "$result" "Ignored tags do not block metadata fallback"
+
+	printf '1.0.0\n2.0.0\nnightly\n' >"$test_root/docs/crush"
+	result=$(
+		cd "$test_root"
+		PATH="$(dirname "$yq_bin"):$PATH"
+		eval "$collect_function"
+		collect_fallback_new_versions crush
+	)
+	assert_equals "2.0.0" "$result" "Fallback comparison still reports real new versions"
+}
+test_fallback_new_versions_ignore_denied_tags
+
+test_generate_toml_missing_versions_file_fails() {
+	local missing_file_block
+	missing_file_block=$(sed -n '/# Check if versions file exists/,/local error_output/p' scripts/update.sh)
+
+	assert_contains "$missing_file_block" 'return 1' \
+		"Missing versions files fail TOML generation"
+}
+test_generate_toml_missing_versions_file_fails
+
+test_json_generation_errors_are_reported() {
+	local fallback_block
+	fallback_block=$(sed -n '/Using plain-text fallback after metadata failure/,/fallback_new_versions=/p' scripts/update.sh)
+
+	assert_contains "$fallback_block" 'cat "$error_output" >&2' \
+		"JSON-to-TOML generation errors are printed before fallback"
+}
+test_json_generation_errors_are_reported
+
 test_docker_collection_disables_release_age_filtering() {
 	local command
 	command=$(awk '


### PR DESCRIPTION
## Summary
- require direct, strict metadata for the JSON version pass
- record command failures, empty output, invalid JSON, and generation failures as metadata fallbacks
- reject newly discovered versions when only plain-text data is available, while preserving harmless fallback behavior for existing versions
- report rejected versions accurately in the workflow summary

This prevents entries such as `hunk@0.21.0-beta.1` from being committed with a generated timestamp and without `release_url` or `prerelease` metadata when the JSON metadata command fails.

## Tests
- `bash scripts/update.test.sh`
- `aube run test:js` after `aube --dir web run build` (99 tests passed)
- `shfmt -d scripts/update.sh scripts/update.test.sh`
- `git diff --check`
- live strict metadata query for `hunk@0.21.0-beta.1`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core version-ingestion behavior for all tools: metadata outages can fail updates that previously committed synthetic timestamps, which is intentional but affects CI reliability and catalog freshness.
> 
> **Overview**
> The update workflow now treats **JSON metadata as mandatory** for any **new** version: `mise ls-remote --json` runs with `--no-versions-host` and `--strict-metadata`, and failures (command error, empty/invalid JSON, or TOML generation from JSON) all go through a **logged plain-text fallback** only when it cannot add incomplete rows.
> 
> When fallback would introduce versions that are not already in the TOML, the run **records them in the summary as rejected**, logs **“Refusing to add new versions without metadata”**, and **fails that tool** (including removing the transient versions file). Plain-text TOML generation still runs when fallback only refreshes **existing** versions. **`collect_fallback_new_versions`** now pipes through **`generate-toml.js`** so **ignored tags** (e.g. `nightly`) do not count as “new.”
> 
> Workflow summary copy and sections were renamed to **“New Versions Rejected Without Metadata”** and broadened **JSON metadata fallback** tracking. **`fetch`** propagates **`generate_toml_file`** failures as tool failures. Tests in **`update.test.sh`** lock in the new flags, rejection path, ignored-tag filtering, missing versions file handling, and error reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76cdde3d5202648255c302e32976596a9ac46f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->