### PR TITLE
fix(cache): version latest release cache on catalog sync

### DIFF
--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -100,8 +100,8 @@ test("catalog generations isolate mutable latest caches", () => {
 
     const release = await getCachedGitHubRelease(
       env,
-      "owner",
-      "repo",
+      "Owner",
+      "Repo",
       "latest",
       generation,
     );

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -116,7 +116,14 @@ test("catalog generations isolate mutable latest caches", () => {
     assert.deepEqual(writes[0].options, { expirationTtl: 2592000 });
     assert.equal(
       releaseCacheHeaders("latest", release)["Cache-Control"],
-      "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+      "public, max-age=0, s-maxage=3600",
+    );
+    assert.equal(
+      __testing.edgeCacheResponse(new Response("latest"), {
+        browserMaxAge: 0,
+        staleWhileRevalidate: 0,
+      }).headers.get("Cache-Control"),
+      "public, max-age=0, s-maxage=3600",
     );
     assert.equal(
       new URL(
@@ -166,6 +173,50 @@ test("catalog generations preserve stale latest fallback", () => {
         "repo",
         "latest",
         generation,
+      ),
+      staleRelease,
+    );
+  `);
+});
+
+test("catalog rotations fall back to the previous latest generation", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import { getCachedGitHubRelease } from "./web/src/lib/github/mirror.ts";
+
+    const current = "123e4567-e89b-42d3-a456-426614174000";
+    const previous = "123e4567-e89b-42d3-a456-426614174001";
+    const previousCacheKey = "github:release:owner/repo:latest:" + previous;
+    const staleRelease = {
+      tag_name: "v1.0.0",
+      draft: false,
+      prerelease: false,
+      created_at: "2026-01-01T00:00:00Z",
+      assets: [{ name: "tool.tar.gz" }],
+    };
+    globalThis.fetch = async () => {
+      throw new Error("GitHub unavailable after catalog rotation");
+    };
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async (key) => key === previousCacheKey
+          ? { cached_at: Date.now() - 7 * 60 * 60 * 1000, data: staleRelease }
+          : null,
+        put: async () => {
+          throw new Error("previous-generation fallback should not write");
+        },
+      },
+    };
+
+    assert.deepEqual(
+      await getCachedGitHubRelease(
+        env,
+        "owner",
+        "repo",
+        "latest",
+        current,
+        previous,
       ),
       staleRelease,
     );

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -182,7 +182,7 @@ test("catalog generations preserve stale latest fallback", () => {
 test("catalog rotations fall back to the previous latest generation", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";
-    import { getCachedGitHubRelease } from "./web/src/lib/github/mirror.ts";
+    import { getCachedGitHubReleaseResult } from "./web/src/lib/github/mirror.ts";
 
     const current = "123e4567-e89b-42d3-a456-426614174000";
     const previous = "123e4567-e89b-42d3-a456-426614174001";
@@ -210,7 +210,7 @@ test("catalog rotations fall back to the previous latest generation", () => {
     };
 
     assert.deepEqual(
-      await getCachedGitHubRelease(
+      await getCachedGitHubReleaseResult(
         env,
         "owner",
         "repo",
@@ -218,7 +218,7 @@ test("catalog rotations fall back to the previous latest generation", () => {
         current,
         previous,
       ),
-      staleRelease,
+      { release: staleRelease, staleFallback: true },
     );
   `);
 });

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -113,7 +113,7 @@ test("catalog generations isolate mutable latest caches", () => {
       writes[0].key,
       "github:release:owner/repo:latest:" + generation,
     );
-    assert.deepEqual(writes[0].options, { expirationTtl: 21600 });
+    assert.deepEqual(writes[0].options, { expirationTtl: 2592000 });
     assert.equal(
       releaseCacheHeaders("latest", release)["Cache-Control"],
       "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
@@ -126,6 +126,48 @@ test("catalog generations isolate mutable latest caches", () => {
         ).url,
       ).searchParams.get("__mise_cache_generation"),
       generation,
+    );
+  `);
+});
+
+test("catalog generations preserve stale latest fallback", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import { getCachedGitHubRelease } from "./web/src/lib/github/mirror.ts";
+
+    const generation = "123e4567-e89b-42d3-a456-426614174000";
+    const cacheKey = "github:release:owner/repo:latest:" + generation;
+    const staleRelease = {
+      tag_name: "v1.0.0",
+      draft: false,
+      prerelease: false,
+      created_at: "2026-01-01T00:00:00Z",
+      assets: [{ name: "tool.tar.gz" }],
+    };
+    globalThis.fetch = async () => {
+      throw new Error("GitHub unavailable");
+    };
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async (key) => key === cacheKey
+          ? { cached_at: Date.now() - 7 * 60 * 60 * 1000, data: staleRelease }
+          : null,
+        put: async () => {
+          throw new Error("stale fallback should not write");
+        },
+      },
+    };
+
+    assert.deepEqual(
+      await getCachedGitHubRelease(
+        env,
+        "owner",
+        "repo",
+        "latest",
+        generation,
+      ),
+      staleRelease,
     );
   `);
 });

--- a/scripts/github-mirror.test.js
+++ b/scripts/github-mirror.test.js
@@ -53,6 +53,83 @@ test("GitHub release mirror caches empty assets as a short cache miss", () => {
   `);
 });
 
+test("catalog generations isolate mutable latest caches", () => {
+  runMirrorTest(`
+    import assert from "node:assert/strict";
+    import {
+      __testing,
+      getCachedGitHubRelease,
+      releaseCacheHeaders,
+    } from "./web/src/lib/github/mirror.ts";
+
+    const generation = "123e4567-e89b-42d3-a456-426614174000";
+    const reads = [];
+    const writes = [];
+    let fetches = 0;
+    globalThis.fetch = async () => {
+      fetches++;
+      return new Response(JSON.stringify({
+        tag_name: "v2.0.0",
+        draft: false,
+        prerelease: false,
+        created_at: "2026-09-01T00:00:00Z",
+        published_at: "2026-09-01T00:00:00Z",
+        assets: [{
+          name: "tool.tar.gz",
+          browser_download_url: "https://github.com/owner/repo/releases/download/v2.0.0/tool.tar.gz",
+          url: "https://api.github.com/repos/owner/repo/releases/assets/2",
+        }],
+      }), { status: 200 });
+    };
+    const env = {
+      DB: {},
+      GITHUB_CACHE: {
+        get: async (key) => {
+          reads.push(key);
+          if (key === "github:release:owner/repo:latest") {
+            return {
+              cached_at: Date.now(),
+              data: { tag_name: "v1.0.0", assets: [{}] },
+            };
+          }
+          return null;
+        },
+        put: async (key, value, options) => writes.push({ key, value, options }),
+      },
+    };
+
+    const release = await getCachedGitHubRelease(
+      env,
+      "owner",
+      "repo",
+      "latest",
+      generation,
+    );
+
+    assert.equal(fetches, 1);
+    assert.equal(release.tag_name, "v2.0.0");
+    assert.equal(reads.includes("github:release:owner/repo:latest"), false);
+    assert.equal(
+      writes[0].key,
+      "github:release:owner/repo:latest:" + generation,
+    );
+    assert.deepEqual(writes[0].options, { expirationTtl: 21600 });
+    assert.equal(
+      releaseCacheHeaders("latest", release)["Cache-Control"],
+      "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+    );
+    assert.equal(
+      new URL(
+        __testing.edgeCacheRequest(
+          new Request("https://example.com/releases/latest?ignored=1"),
+          generation,
+        ).url,
+      ).searchParams.get("__mise_cache_generation"),
+      generation,
+    );
+  `);
+});
+
 test("GitHub release mirror follows API redirects", () => {
   runMirrorTest(`
     import assert from "node:assert/strict";

--- a/scripts/github-release-generation.test.js
+++ b/scripts/github-release-generation.test.js
@@ -60,6 +60,10 @@ test("catalog sync rotates one latest generation per GitHub repository", () => {
       "REPO",
     );
     assert.match(generation.current, /^[0-9a-f]{64}$/);
+    values.set(
+      "github:release:owner/repo:latest:" + generation.current,
+      JSON.stringify({ data: { assets: [{ name: "tool.tar.gz" }] } }),
+    );
 
     await rotateGitHubLatestReleaseGenerations(cache, [{
       versions: [
@@ -88,6 +92,22 @@ test("catalog sync rotates one latest generation per GitHub repository", () => {
       rotated,
     );
     assert.equal(writes.length, 3);
+
+    await rotateGitHubLatestReleaseGenerations(cache, [{
+      versions: [
+        { release_url: "https://github.com/Owner/Repo/releases/tag/v1.0.0" },
+        { release_url: "https://github.com/owner/repo/releases/tag/v1.1.0" },
+        { release_url: "https://github.com/owner/repo/releases/tag/v1.2.0" },
+        { release_url: "https://github.com/owner/repo/releases/tag/v1.3.0" },
+      ],
+    }]);
+    const rotatedWhileCold = await getGitHubLatestReleaseGenerations(
+      cache,
+      "owner",
+      "repo",
+    );
+    assert.notEqual(rotatedWhileCold.current, rotated.current);
+    assert.equal(rotatedWhileCold.previous, generation.current);
   `);
 });
 

--- a/scripts/github-release-generation.test.js
+++ b/scripts/github-release-generation.test.js
@@ -75,3 +75,19 @@ test("invalid latest generations are ignored", () => {
     );
   `);
 });
+
+test("generation lookup failures fall back to legacy cache keys", () => {
+  runGenerationTest(`
+    import assert from "node:assert/strict";
+    import { getGitHubLatestReleaseGeneration } from "./web/src/lib/github/release-generation.ts";
+
+    const warnings = [];
+    console.warn = (...args) => warnings.push(args);
+    const cache = { get: async () => { throw new Error("KV unavailable"); } };
+    assert.equal(
+      await getGitHubLatestReleaseGeneration(cache, "owner", "repo"),
+      undefined,
+    );
+    assert.equal(warnings.length, 1);
+  `);
+});

--- a/scripts/github-release-generation.test.js
+++ b/scripts/github-release-generation.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+function runGenerationTest(source) {
+  const result = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "-"],
+    {
+      cwd: new URL("..", import.meta.url),
+      input: source,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`.trim());
+}
+
+test("catalog sync rotates one latest generation per GitHub repository", () => {
+  runGenerationTest(`
+    import assert from "node:assert/strict";
+    import {
+      getGitHubLatestReleaseGeneration,
+      rotateGitHubLatestReleaseGenerations,
+    } from "./web/src/lib/github/release-generation.ts";
+
+    const values = new Map();
+    const writes = [];
+    const cache = {
+      get: async (key) => values.get(key) ?? null,
+      put: async (key, value) => {
+        writes.push({ key, value });
+        values.set(key, value);
+      },
+    };
+    const count = await rotateGitHubLatestReleaseGenerations(cache, [
+      {
+        versions: [
+          { release_url: "https://github.com/Owner/Repo/releases/tag/v1.0.0" },
+          { release_url: "https://github.com/owner/repo/releases/tag/v1.1.0" },
+          { release_url: "https://example.com/owner/repo/releases/tag/v2" },
+        ],
+      },
+      {
+        versions: [
+          { release_url: "https://github.com/other/tool/releases/tag/release/2026" },
+        ],
+      },
+      { versions: null },
+      {},
+    ]);
+
+    assert.equal(count, 2);
+    assert.deepEqual(writes.map(({ key }) => key).sort(), [
+      "github:release-generation:other/tool",
+      "github:release-generation:owner/repo",
+    ]);
+    const generation = await getGitHubLatestReleaseGeneration(
+      cache,
+      "OWNER",
+      "REPO",
+    );
+    assert.match(generation, /^[0-9a-f-]{36}$/);
+  `);
+});
+
+test("invalid latest generations are ignored", () => {
+  runGenerationTest(`
+    import assert from "node:assert/strict";
+    import { getGitHubLatestReleaseGeneration } from "./web/src/lib/github/release-generation.ts";
+
+    const cache = { get: async () => "../../untrusted" };
+    assert.equal(
+      await getGitHubLatestReleaseGeneration(cache, "owner", "repo"),
+      undefined,
+    );
+  `);
+});

--- a/scripts/github-release-generation.test.js
+++ b/scripts/github-release-generation.test.js
@@ -19,7 +19,7 @@ test("catalog sync rotates one latest generation per GitHub repository", () => {
   runGenerationTest(`
     import assert from "node:assert/strict";
     import {
-      getGitHubLatestReleaseGeneration,
+      getGitHubLatestReleaseGenerations,
       rotateGitHubLatestReleaseGenerations,
     } from "./web/src/lib/github/release-generation.ts";
 
@@ -54,23 +54,36 @@ test("catalog sync rotates one latest generation per GitHub repository", () => {
       "github:release-generation:other/tool",
       "github:release-generation:owner/repo",
     ]);
-    const generation = await getGitHubLatestReleaseGeneration(
+    const generation = await getGitHubLatestReleaseGenerations(
       cache,
       "OWNER",
       "REPO",
     );
-    assert.match(generation, /^[0-9a-f-]{36}$/);
+    assert.match(generation.current, /^[0-9a-f-]{36}$/);
+
+    await rotateGitHubLatestReleaseGenerations(cache, [{
+      versions: [
+        { release_url: "https://github.com/owner/repo/releases/tag/v1.2.0" },
+      ],
+    }]);
+    const rotated = await getGitHubLatestReleaseGenerations(
+      cache,
+      "owner",
+      "repo",
+    );
+    assert.notEqual(rotated.current, generation.current);
+    assert.equal(rotated.previous, generation.current);
   `);
 });
 
 test("invalid latest generations are ignored", () => {
   runGenerationTest(`
     import assert from "node:assert/strict";
-    import { getGitHubLatestReleaseGeneration } from "./web/src/lib/github/release-generation.ts";
+    import { getGitHubLatestReleaseGenerations } from "./web/src/lib/github/release-generation.ts";
 
     const cache = { get: async () => "../../untrusted" };
     assert.equal(
-      await getGitHubLatestReleaseGeneration(cache, "owner", "repo"),
+      await getGitHubLatestReleaseGenerations(cache, "owner", "repo"),
       undefined,
     );
   `);
@@ -79,13 +92,13 @@ test("invalid latest generations are ignored", () => {
 test("generation lookup failures fall back to legacy cache keys", () => {
   runGenerationTest(`
     import assert from "node:assert/strict";
-    import { getGitHubLatestReleaseGeneration } from "./web/src/lib/github/release-generation.ts";
+    import { getGitHubLatestReleaseGenerations } from "./web/src/lib/github/release-generation.ts";
 
     const warnings = [];
     console.warn = (...args) => warnings.push(args);
     const cache = { get: async () => { throw new Error("KV unavailable"); } };
     assert.equal(
-      await getGitHubLatestReleaseGeneration(cache, "owner", "repo"),
+      await getGitHubLatestReleaseGenerations(cache, "owner", "repo"),
       undefined,
     );
     assert.equal(warnings.length, 1);

--- a/scripts/github-release-generation.test.js
+++ b/scripts/github-release-generation.test.js
@@ -59,10 +59,12 @@ test("catalog sync rotates one latest generation per GitHub repository", () => {
       "OWNER",
       "REPO",
     );
-    assert.match(generation.current, /^[0-9a-f-]{36}$/);
+    assert.match(generation.current, /^[0-9a-f]{64}$/);
 
     await rotateGitHubLatestReleaseGenerations(cache, [{
       versions: [
+        { release_url: "https://github.com/Owner/Repo/releases/tag/v1.0.0" },
+        { release_url: "https://github.com/owner/repo/releases/tag/v1.1.0" },
         { release_url: "https://github.com/owner/repo/releases/tag/v1.2.0" },
       ],
     }]);
@@ -73,6 +75,19 @@ test("catalog sync rotates one latest generation per GitHub repository", () => {
     );
     assert.notEqual(rotated.current, generation.current);
     assert.equal(rotated.previous, generation.current);
+
+    await rotateGitHubLatestReleaseGenerations(cache, [{
+      versions: [
+        { release_url: "https://github.com/Owner/Repo/releases/tag/v1.0.0" },
+        { release_url: "https://github.com/owner/repo/releases/tag/v1.1.0" },
+        { release_url: "https://github.com/owner/repo/releases/tag/v1.2.0" },
+      ],
+    }]);
+    assert.deepEqual(
+      await getGitHubLatestReleaseGenerations(cache, "owner", "repo"),
+      rotated,
+    );
+    assert.equal(writes.length, 3);
   `);
 });
 

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -217,6 +217,26 @@ export async function getCachedGitHubRelease(
   cacheGeneration?: string,
   previousCacheGeneration?: string,
 ): Promise<GitHubRelease> {
+  return (
+    await getCachedGitHubReleaseResult(
+      env,
+      owner,
+      repo,
+      tag,
+      cacheGeneration,
+      previousCacheGeneration,
+    )
+  ).release;
+}
+
+export async function getCachedGitHubReleaseResult(
+  env: Env,
+  owner: string,
+  repo: string,
+  tag: string,
+  cacheGeneration?: string,
+  previousCacheGeneration?: string,
+): Promise<{ release: GitHubRelease; staleFallback: boolean }> {
   const generationSuffix = cacheGeneration ? `:${cacheGeneration}` : "";
   const cacheKey = `github:release:${owner}/${repo}:${tag}${generationSuffix}`;
   const negativeCacheKey = `github:release-error:${owner}/${repo}:${tag}${generationSuffix}`;
@@ -226,6 +246,7 @@ export async function getCachedGitHubRelease(
   }
 
   let release: GitHubRelease;
+  let staleFallback = false;
   try {
     release = await getOrRefresh({
       env,
@@ -244,6 +265,9 @@ export async function getCachedGitHubRelease(
             ? undefined
             : CACHE_TTL_SECONDS,
       useStaleOnError: releaseStaleFallbackAllowed,
+      onStaleFallback: () => {
+        staleFallback = true;
+      },
       staleCacheKey:
         tag === "latest" && cacheGeneration
           ? `github:release:${owner}/${repo}:${tag}${previousCacheGeneration ? `:${previousCacheGeneration}` : ""}`
@@ -272,7 +296,7 @@ export async function getCachedGitHubRelease(
       new Headers(),
     );
   }
-  return release;
+  return { release, staleFallback };
 }
 
 async function cachedReleaseError(
@@ -374,6 +398,7 @@ async function getOrRefresh<T>({
   expirationTtl,
   useStaleOnError = () => true,
   staleCacheKey,
+  onStaleFallback,
   onFetchError,
 }: {
   env: Env;
@@ -383,6 +408,7 @@ async function getOrRefresh<T>({
   expirationTtl?: (data: T) => number | undefined;
   useStaleOnError?: (error: unknown) => boolean;
   staleCacheKey?: string;
+  onStaleFallback?: () => void;
   onFetchError?: (
     error: unknown,
     cached: CacheEntry<T> | null,
@@ -410,6 +436,7 @@ async function getOrRefresh<T>({
     }
     await onFetchError?.(error, cached);
     if (cached && useStaleOnError(error)) {
+      onStaleFallback?.();
       return cached.data;
     }
     if (staleCacheKey && useStaleOnError(error)) {
@@ -418,7 +445,10 @@ async function getOrRefresh<T>({
           staleCacheKey,
           "json",
         );
-        if (stale) return stale.data;
+        if (stale) {
+          onStaleFallback?.();
+          return stale.data;
+        }
       } catch (cacheError) {
         console.warn("failed to read fallback GitHub cache entry:", cacheError);
       }

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -237,9 +237,10 @@ export async function getCachedGitHubReleaseResult(
   cacheGeneration?: string,
   previousCacheGeneration?: string,
 ): Promise<{ release: GitHubRelease; staleFallback: boolean }> {
+  const cacheRepository = `${owner.toLowerCase()}/${repo.toLowerCase()}`;
   const generationSuffix = cacheGeneration ? `:${cacheGeneration}` : "";
-  const cacheKey = `github:release:${owner}/${repo}:${tag}${generationSuffix}`;
-  const negativeCacheKey = `github:release-error:${owner}/${repo}:${tag}${generationSuffix}`;
+  const cacheKey = `github:release:${cacheRepository}:${tag}${generationSuffix}`;
+  const negativeCacheKey = `github:release-error:${cacheRepository}:${tag}${generationSuffix}`;
   const cachedError = await cachedReleaseError(env, negativeCacheKey);
   if (cachedError) {
     throw cachedError;
@@ -270,7 +271,7 @@ export async function getCachedGitHubReleaseResult(
       },
       staleCacheKey:
         tag === "latest" && cacheGeneration
-          ? `github:release:${owner}/${repo}:${tag}${previousCacheGeneration ? `:${previousCacheGeneration}` : ""}`
+          ? `github:release:${cacheRepository}:${tag}${previousCacheGeneration ? `:${previousCacheGeneration}` : ""}`
           : undefined,
       onFetchError: async (error, cached) => {
         if (cached && githubStatus(error) === 404) {

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -93,6 +93,7 @@ export function releaseCacheHeaders(tag: string, release: GitHubRelease) {
     browserMaxAge:
       tag === "latest" ? 0 : immutable ? 600 : EDGE_SHORT_TTL_SECONDS,
     edgeMaxAge: immutable ? EDGE_IMMUTABLE_TTL_SECONDS : EDGE_SHORT_TTL_SECONDS,
+    staleWhileRevalidate: tag === "latest" ? 0 : undefined,
     immutable,
   });
 }
@@ -214,6 +215,7 @@ export async function getCachedGitHubRelease(
   repo: string,
   tag: string,
   cacheGeneration?: string,
+  previousCacheGeneration?: string,
 ): Promise<GitHubRelease> {
   const generationSuffix = cacheGeneration ? `:${cacheGeneration}` : "";
   const cacheKey = `github:release:${owner}/${repo}:${tag}${generationSuffix}`;
@@ -242,6 +244,10 @@ export async function getCachedGitHubRelease(
             ? undefined
             : CACHE_TTL_SECONDS,
       useStaleOnError: releaseStaleFallbackAllowed,
+      staleCacheKey:
+        tag === "latest" && cacheGeneration
+          ? `github:release:${owner}/${repo}:${tag}${previousCacheGeneration ? `:${previousCacheGeneration}` : ""}`
+          : undefined,
       onFetchError: async (error, cached) => {
         if (cached && githubStatus(error) === 404) {
           await deleteCachedRelease(env, cacheKey);
@@ -367,6 +373,7 @@ async function getOrRefresh<T>({
   fetcher,
   expirationTtl,
   useStaleOnError = () => true,
+  staleCacheKey,
   onFetchError,
 }: {
   env: Env;
@@ -375,6 +382,7 @@ async function getOrRefresh<T>({
   fetcher: (token: TokenRecord | null) => Promise<T>;
   expirationTtl?: (data: T) => number | undefined;
   useStaleOnError?: (error: unknown) => boolean;
+  staleCacheKey?: string;
   onFetchError?: (
     error: unknown,
     cached: CacheEntry<T> | null,
@@ -403,6 +411,17 @@ async function getOrRefresh<T>({
     await onFetchError?.(error, cached);
     if (cached && useStaleOnError(error)) {
       return cached.data;
+    }
+    if (staleCacheKey && useStaleOnError(error)) {
+      try {
+        const stale = await env.GITHUB_CACHE.get<CacheEntry<T>>(
+          staleCacheKey,
+          "json",
+        );
+        if (stale) return stale.data;
+      } catch (cacheError) {
+        console.warn("failed to read fallback GitHub cache entry:", cacheError);
+      }
     }
     throw error;
   }

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -4,7 +4,6 @@ import { setupDatabase } from "../../../../src/database";
 
 const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
 const RELEASE_FRESH_MS = 6 * 60 * 60 * 1000;
-const RELEASE_FRESH_SECONDS = RELEASE_FRESH_MS / 1000;
 const EMPTY_RELEASE_FRESH_MS = 30 * 60 * 1000;
 const EMPTY_RELEASE_CACHE_TTL_SECONDS = 30 * 60;
 const RELEASE_IMMUTABLE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
@@ -239,11 +238,9 @@ export async function getCachedGitHubRelease(
       expirationTtl: (data) =>
         data.assets.length === 0
           ? EMPTY_RELEASE_CACHE_TTL_SECONDS
-          : cacheGeneration
-            ? RELEASE_FRESH_SECONDS
-            : tag !== "latest" && data.immutable === true
-              ? undefined
-              : CACHE_TTL_SECONDS,
+          : tag !== "latest" && data.immutable === true
+            ? undefined
+            : CACHE_TTL_SECONDS,
       useStaleOnError: releaseStaleFallbackAllowed,
       onFetchError: async (error, cached) => {
         if (cached && githubStatus(error) === 404) {

--- a/web/src/lib/github/mirror.ts
+++ b/web/src/lib/github/mirror.ts
@@ -4,6 +4,7 @@ import { setupDatabase } from "../../../../src/database";
 
 const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
 const RELEASE_FRESH_MS = 6 * 60 * 60 * 1000;
+const RELEASE_FRESH_SECONDS = RELEASE_FRESH_MS / 1000;
 const EMPTY_RELEASE_FRESH_MS = 30 * 60 * 1000;
 const EMPTY_RELEASE_CACHE_TTL_SECONDS = 30 * 60;
 const RELEASE_IMMUTABLE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
@@ -90,7 +91,8 @@ export function cacheHeaders({
 export function releaseCacheHeaders(tag: string, release: GitHubRelease) {
   const immutable = tag !== "latest" && release.immutable === true;
   return cacheHeaders({
-    browserMaxAge: immutable ? 600 : EDGE_SHORT_TTL_SECONDS,
+    browserMaxAge:
+      tag === "latest" ? 0 : immutable ? 600 : EDGE_SHORT_TTL_SECONDS,
     edgeMaxAge: immutable ? EDGE_IMMUTABLE_TTL_SECONDS : EDGE_SHORT_TTL_SECONDS,
     immutable,
   });
@@ -106,9 +108,14 @@ export function attestationsCacheHeaders() {
 
 export async function matchGitHubMirrorEdgeCache(
   request: Request,
+  cacheGeneration?: string,
 ): Promise<Response | null> {
   try {
-    return (await defaultEdgeCache().match(edgeCacheRequest(request))) ?? null;
+    return (
+      (await defaultEdgeCache().match(
+        edgeCacheRequest(request, cacheGeneration),
+      )) ?? null
+    );
   } catch (error) {
     console.warn("failed to read GitHub mirror edge cache:", error);
     return null;
@@ -124,7 +131,7 @@ export async function putGitHubMirrorEdgeCache(
 
   try {
     await defaultEdgeCache().put(
-      edgeCacheRequest(request),
+      edgeCacheRequest(request, options?.cacheGeneration),
       edgeCacheResponse(response, options),
     );
   } catch (error) {
@@ -136,6 +143,7 @@ interface EdgeCacheOptions {
   browserMaxAge?: number;
   edgeMaxAge?: number;
   staleWhileRevalidate?: number;
+  cacheGeneration?: string;
 }
 
 function edgeCacheResponse(
@@ -167,13 +175,16 @@ function defaultEdgeCache(): Cache {
   return (caches as unknown as { default: Cache }).default;
 }
 
-function edgeCacheRequest(request: Request): Request {
+function edgeCacheRequest(request: Request, cacheGeneration?: string): Request {
   // Query params are ignored by these mirror handlers, so strip them to avoid
   // unbounded cache-key variants. Cache API cold misses are not coalesced, and
   // cached allowlisted responses can outlive registry removals until this
   // capped edge TTL expires.
   const url = new URL(request.url);
   url.search = "";
+  if (cacheGeneration) {
+    url.searchParams.set("__mise_cache_generation", cacheGeneration);
+  }
   return new Request(url.toString(), { method: "GET" });
 }
 
@@ -203,9 +214,11 @@ export async function getCachedGitHubRelease(
   owner: string,
   repo: string,
   tag: string,
+  cacheGeneration?: string,
 ): Promise<GitHubRelease> {
-  const cacheKey = `github:release:${owner}/${repo}:${tag}`;
-  const negativeCacheKey = `github:release-error:${owner}/${repo}:${tag}`;
+  const generationSuffix = cacheGeneration ? `:${cacheGeneration}` : "";
+  const cacheKey = `github:release:${owner}/${repo}:${tag}${generationSuffix}`;
+  const negativeCacheKey = `github:release-error:${owner}/${repo}:${tag}${generationSuffix}`;
   const cachedError = await cachedReleaseError(env, negativeCacheKey);
   if (cachedError) {
     throw cachedError;
@@ -226,9 +239,11 @@ export async function getCachedGitHubRelease(
       expirationTtl: (data) =>
         data.assets.length === 0
           ? EMPTY_RELEASE_CACHE_TTL_SECONDS
-          : tag !== "latest" && data.immutable === true
-            ? undefined
-            : CACHE_TTL_SECONDS,
+          : cacheGeneration
+            ? RELEASE_FRESH_SECONDS
+            : tag !== "latest" && data.immutable === true
+              ? undefined
+              : CACHE_TTL_SECONDS,
       useStaleOnError: releaseStaleFallbackAllowed,
       onFetchError: async (error, cached) => {
         if (cached && githubStatus(error) === 404) {
@@ -724,6 +739,7 @@ class GitHubError extends Error {
 
 export const __testing = {
   GitHubError,
+  edgeCacheRequest,
   edgeCacheResponse,
   githubJsonHeaders,
   isGitHubApiUrl,

--- a/web/src/lib/github/release-generation.ts
+++ b/web/src/lib/github/release-generation.ts
@@ -8,6 +8,11 @@ interface ToolReleaseData {
   versions?: VersionReleaseData[];
 }
 
+export interface GitHubLatestReleaseGenerations {
+  current: string;
+  previous?: string;
+}
+
 function repositoryFromReleaseUrl(
   releaseUrl: string | null | undefined,
 ): string | null {
@@ -43,14 +48,43 @@ function validGeneration(value: string | null): value is string {
   );
 }
 
-export async function getGitHubLatestReleaseGeneration(
+function parseGenerations(
+  value: string | null,
+): GitHubLatestReleaseGenerations | undefined {
+  if (validGeneration(value)) return { current: value };
+  if (!value) return undefined;
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const record = parsed as Record<string, unknown>;
+    if (!validGenerationValue(record.current)) return undefined;
+    return {
+      current: record.current,
+      previous: validGenerationValue(record.previous)
+        ? record.previous
+        : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function validGenerationValue(value: unknown): value is string {
+  return typeof value === "string" && validGeneration(value);
+}
+
+export async function getGitHubLatestReleaseGenerations(
   cache: KVNamespace,
   owner: string,
   repo: string,
-): Promise<string | undefined> {
+): Promise<GitHubLatestReleaseGenerations | undefined> {
   try {
-    const generation = await cache.get(latestReleaseGenerationKey(owner, repo));
-    return validGeneration(generation) ? generation : undefined;
+    return parseGenerations(
+      await cache.get(latestReleaseGenerationKey(owner, repo)),
+    );
   } catch (error) {
     console.warn(
       `failed to read GitHub latest release generation for ${owner}/${repo}:`,
@@ -74,19 +108,21 @@ export async function rotateGitHubLatestReleaseGenerations(
     }
   }
 
-  await Promise.all(
-    [...repositories].map((repository) =>
-      cache.put(
-        `${LATEST_RELEASE_GENERATION_PREFIX}${repository}`,
-        crypto.randomUUID(),
-      ),
-    ),
-  );
+  for (const repository of repositories) {
+    const key = `${LATEST_RELEASE_GENERATION_PREFIX}${repository}`;
+    const existing = parseGenerations(await cache.get(key));
+    const generations: GitHubLatestReleaseGenerations = {
+      current: crypto.randomUUID(),
+      previous: existing?.current,
+    };
+    await cache.put(key, JSON.stringify(generations));
+  }
   return repositories.size;
 }
 
 export const __testing = {
   latestReleaseGenerationKey,
+  parseGenerations,
   repositoryFromReleaseUrl,
   validGeneration,
 };

--- a/web/src/lib/github/release-generation.ts
+++ b/web/src/lib/github/release-generation.ts
@@ -42,9 +42,10 @@ function latestReleaseGenerationKey(owner: string, repo: string): string {
 function validGeneration(value: string | null): value is string {
   return (
     value !== null &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    (/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
       value,
-    )
+    ) ||
+      /^[0-9a-f]{64}$/i.test(value))
   );
 }
 
@@ -76,6 +77,18 @@ function validGenerationValue(value: unknown): value is string {
   return typeof value === "string" && validGeneration(value);
 }
 
+async function generationForReleaseUrls(
+  releaseUrls: Set<string>,
+): Promise<string> {
+  const input = new TextEncoder().encode(
+    JSON.stringify([...releaseUrls].sort()),
+  );
+  const digest = await crypto.subtle.digest("SHA-256", input);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 export async function getGitHubLatestReleaseGenerations(
   cache: KVNamespace,
   owner: string,
@@ -98,21 +111,26 @@ export async function rotateGitHubLatestReleaseGenerations(
   cache: KVNamespace,
   tools: ToolReleaseData[],
 ): Promise<number> {
-  const repositories = new Set<string>();
+  const repositories = new Map<string, Set<string>>();
   for (const tool of tools) {
     if (!Array.isArray(tool.versions)) continue;
     for (const version of tool.versions) {
       if (!version || typeof version !== "object") continue;
       const repository = repositoryFromReleaseUrl(version.release_url);
-      if (repository) repositories.add(repository);
+      if (!repository || typeof version.release_url !== "string") continue;
+      const releaseUrls = repositories.get(repository) ?? new Set<string>();
+      releaseUrls.add(version.release_url);
+      repositories.set(repository, releaseUrls);
     }
   }
 
-  for (const repository of repositories) {
+  for (const [repository, releaseUrls] of repositories) {
     const key = `${LATEST_RELEASE_GENERATION_PREFIX}${repository}`;
     const existing = parseGenerations(await cache.get(key));
+    const current = await generationForReleaseUrls(releaseUrls);
+    if (existing?.current === current) continue;
     const generations: GitHubLatestReleaseGenerations = {
-      current: crypto.randomUUID(),
+      current,
       previous: existing?.current,
     };
     await cache.put(key, JSON.stringify(generations));
@@ -121,6 +139,7 @@ export async function rotateGitHubLatestReleaseGenerations(
 }
 
 export const __testing = {
+  generationForReleaseUrls,
   latestReleaseGenerationKey,
   parseGenerations,
   repositoryFromReleaseUrl,

--- a/web/src/lib/github/release-generation.ts
+++ b/web/src/lib/github/release-generation.ts
@@ -77,6 +77,18 @@ function validGenerationValue(value: unknown): value is string {
   return typeof value === "string" && validGeneration(value);
 }
 
+function hasUsableRelease(value: string | null): boolean {
+  if (!value) return false;
+  try {
+    const parsed = JSON.parse(value) as {
+      data?: { assets?: unknown[] };
+    };
+    return Array.isArray(parsed.data?.assets) && parsed.data.assets.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 async function generationForReleaseUrls(
   releaseUrls: Set<string>,
 ): Promise<string> {
@@ -129,9 +141,16 @@ export async function rotateGitHubLatestReleaseGenerations(
     const existing = parseGenerations(await cache.get(key));
     const current = await generationForReleaseUrls(releaseUrls);
     if (existing?.current === current) continue;
+    let previous = existing?.previous;
+    if (existing) {
+      const outgoingRelease = await cache.get(
+        `github:release:${repository}:latest:${existing.current}`,
+      );
+      if (hasUsableRelease(outgoingRelease)) previous = existing.current;
+    }
     const generations: GitHubLatestReleaseGenerations = {
       current,
-      previous: existing?.current,
+      previous,
     };
     await cache.put(key, JSON.stringify(generations));
   }
@@ -140,6 +159,7 @@ export async function rotateGitHubLatestReleaseGenerations(
 
 export const __testing = {
   generationForReleaseUrls,
+  hasUsableRelease,
   latestReleaseGenerationKey,
   parseGenerations,
   repositoryFromReleaseUrl,

--- a/web/src/lib/github/release-generation.ts
+++ b/web/src/lib/github/release-generation.ts
@@ -48,8 +48,16 @@ export async function getGitHubLatestReleaseGeneration(
   owner: string,
   repo: string,
 ): Promise<string | undefined> {
-  const generation = await cache.get(latestReleaseGenerationKey(owner, repo));
-  return validGeneration(generation) ? generation : undefined;
+  try {
+    const generation = await cache.get(latestReleaseGenerationKey(owner, repo));
+    return validGeneration(generation) ? generation : undefined;
+  } catch (error) {
+    console.warn(
+      `failed to read GitHub latest release generation for ${owner}/${repo}:`,
+      error,
+    );
+    return undefined;
+  }
 }
 
 export async function rotateGitHubLatestReleaseGenerations(

--- a/web/src/lib/github/release-generation.ts
+++ b/web/src/lib/github/release-generation.ts
@@ -1,0 +1,84 @@
+const LATEST_RELEASE_GENERATION_PREFIX = "github:release-generation:";
+
+interface VersionReleaseData {
+  release_url?: string | null;
+}
+
+interface ToolReleaseData {
+  versions?: VersionReleaseData[];
+}
+
+function repositoryFromReleaseUrl(
+  releaseUrl: string | null | undefined,
+): string | null {
+  if (typeof releaseUrl !== "string" || !releaseUrl) return null;
+
+  try {
+    const url = new URL(releaseUrl);
+    if (
+      url.protocol !== "https:" ||
+      (url.hostname !== "github.com" && url.hostname !== "www.github.com")
+    ) {
+      return null;
+    }
+    const match = url.pathname.match(
+      /^\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/releases\/tag\//,
+    );
+    return match ? `${match[1].toLowerCase()}/${match[2].toLowerCase()}` : null;
+  } catch {
+    return null;
+  }
+}
+
+function latestReleaseGenerationKey(owner: string, repo: string): string {
+  return `${LATEST_RELEASE_GENERATION_PREFIX}${owner.toLowerCase()}/${repo.toLowerCase()}`;
+}
+
+function validGeneration(value: string | null): value is string {
+  return (
+    value !== null &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  );
+}
+
+export async function getGitHubLatestReleaseGeneration(
+  cache: KVNamespace,
+  owner: string,
+  repo: string,
+): Promise<string | undefined> {
+  const generation = await cache.get(latestReleaseGenerationKey(owner, repo));
+  return validGeneration(generation) ? generation : undefined;
+}
+
+export async function rotateGitHubLatestReleaseGenerations(
+  cache: KVNamespace,
+  tools: ToolReleaseData[],
+): Promise<number> {
+  const repositories = new Set<string>();
+  for (const tool of tools) {
+    if (!Array.isArray(tool.versions)) continue;
+    for (const version of tool.versions) {
+      if (!version || typeof version !== "object") continue;
+      const repository = repositoryFromReleaseUrl(version.release_url);
+      if (repository) repositories.add(repository);
+    }
+  }
+
+  await Promise.all(
+    [...repositories].map((repository) =>
+      cache.put(
+        `${LATEST_RELEASE_GENERATION_PREFIX}${repository}`,
+        crypto.randomUUID(),
+      ),
+    ),
+  );
+  return repositories.size;
+}
+
+export const __testing = {
+  latestReleaseGenerationKey,
+  repositoryFromReleaseUrl,
+  validGeneration,
+};

--- a/web/src/pages/api/admin/versions/sync.ts
+++ b/web/src/pages/api/admin/versions/sync.ts
@@ -11,6 +11,7 @@ import {
   runAnalyticsMigrations,
   setupAnalytics,
 } from "../../../../../../src/analytics";
+import { rotateGitHubLatestReleaseGenerations } from "../../../../lib/github/release-generation";
 
 interface VersionData {
   version: string;
@@ -262,12 +263,21 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
   }
 
+  // Rotate mutable `releases/latest` cache keys after the catalog is synced.
+  // Exact-tag release caches remain reusable, while the next latest lookup is
+  // guaranteed not to reuse metadata from an earlier catalog generation.
+  const latestCacheGenerations = await rotateGitHubLatestReleaseGenerations(
+    env.GITHUB_CACHE,
+    body.tools,
+  );
+
   return jsonResponse({
     success: true,
     tools_processed: toolsProcessed,
     versions_upserted: versionsUpserted,
     versions_deleted: versionsDeleted,
     new_versions: newVersionsTotal,
+    latest_cache_generations: latestCacheGenerations,
     errors,
   });
 };

--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -2,7 +2,8 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { errorResponse, jsonResponse } from "../../../../../../../lib/api";
 import {
-  getCachedGitHubRelease,
+  cacheHeaders,
+  getCachedGitHubReleaseResult,
   githubStatus,
   matchGitHubMirrorEdgeCache,
   putGitHubMirrorEdgeCache,
@@ -52,7 +53,7 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
   }
 
   try {
-    const release = await getCachedGitHubRelease(
+    const { release, staleFallback } = await getCachedGitHubReleaseResult(
       env,
       owner,
       repo,
@@ -63,15 +64,23 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
     const response = jsonResponse(
       release,
       200,
-      releaseCacheHeaders(tag, release),
+      staleFallback
+        ? cacheHeaders({
+            browserMaxAge: 0,
+            edgeMaxAge: 0,
+            staleWhileRevalidate: 0,
+          })
+        : releaseCacheHeaders(tag, release),
     );
-    locals.cfContext.waitUntil(
-      putGitHubMirrorEdgeCache(request, response, {
-        browserMaxAge: tag === "latest" ? 0 : undefined,
-        staleWhileRevalidate: tag === "latest" ? 0 : undefined,
-        cacheGeneration,
-      }),
-    );
+    if (!staleFallback) {
+      locals.cfContext.waitUntil(
+        putGitHubMirrorEdgeCache(request, response, {
+          browserMaxAge: tag === "latest" ? 0 : undefined,
+          staleWhileRevalidate: tag === "latest" ? 0 : undefined,
+          cacheGeneration,
+        }),
+      );
+    }
     return response;
   } catch (error) {
     console.error(

--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -11,7 +11,7 @@ import {
   validRepoPart,
 } from "../../../../../../../lib/github/mirror";
 import { isRegisteredGitHubRepo } from "../../../../../../../lib/github/registry";
-import { getGitHubLatestReleaseGeneration } from "../../../../../../../lib/github/release-generation";
+import { getGitHubLatestReleaseGenerations } from "../../../../../../../lib/github/release-generation";
 
 export const GET: APIRoute = async ({ params, request, locals }) => {
   const { owner, repo } = params;
@@ -32,10 +32,11 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
     return errorResponse("Invalid GitHub release path", 400);
   }
 
-  const cacheGeneration =
+  const cacheGenerations =
     tag === "latest"
-      ? await getGitHubLatestReleaseGeneration(env.GITHUB_CACHE, owner, repo)
+      ? await getGitHubLatestReleaseGenerations(env.GITHUB_CACHE, owner, repo)
       : undefined;
+  const cacheGeneration = cacheGenerations?.current;
   const cached = await matchGitHubMirrorEdgeCache(request, cacheGeneration);
   if (cached) return cached;
 
@@ -57,6 +58,7 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
       repo,
       tag,
       cacheGeneration,
+      cacheGenerations?.previous,
     );
     const response = jsonResponse(
       release,
@@ -66,6 +68,7 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
     locals.cfContext.waitUntil(
       putGitHubMirrorEdgeCache(request, response, {
         browserMaxAge: tag === "latest" ? 0 : undefined,
+        staleWhileRevalidate: tag === "latest" ? 0 : undefined,
         cacheGeneration,
       }),
     );

--- a/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
+++ b/web/src/pages/api/github/repos/[owner]/[repo]/releases/[...tag].ts
@@ -11,6 +11,7 @@ import {
   validRepoPart,
 } from "../../../../../../../lib/github/mirror";
 import { isRegisteredGitHubRepo } from "../../../../../../../lib/github/registry";
+import { getGitHubLatestReleaseGeneration } from "../../../../../../../lib/github/release-generation";
 
 export const GET: APIRoute = async ({ params, request, locals }) => {
   const { owner, repo } = params;
@@ -31,7 +32,11 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
     return errorResponse("Invalid GitHub release path", 400);
   }
 
-  const cached = await matchGitHubMirrorEdgeCache(request);
+  const cacheGeneration =
+    tag === "latest"
+      ? await getGitHubLatestReleaseGeneration(env.GITHUB_CACHE, owner, repo)
+      : undefined;
+  const cached = await matchGitHubMirrorEdgeCache(request, cacheGeneration);
   if (cached) return cached;
 
   let registered: boolean;
@@ -46,13 +51,24 @@ export const GET: APIRoute = async ({ params, request, locals }) => {
   }
 
   try {
-    const release = await getCachedGitHubRelease(env, owner, repo, tag);
+    const release = await getCachedGitHubRelease(
+      env,
+      owner,
+      repo,
+      tag,
+      cacheGeneration,
+    );
     const response = jsonResponse(
       release,
       200,
       releaseCacheHeaders(tag, release),
     );
-    locals.cfContext.waitUntil(putGitHubMirrorEdgeCache(request, response));
+    locals.cfContext.waitUntil(
+      putGitHubMirrorEdgeCache(request, response, {
+        browserMaxAge: tag === "latest" ? 0 : undefined,
+        cacheGeneration,
+      }),
+    );
     return response;
   } catch (error) {
     console.error(


### PR DESCRIPTION
## Summary

- derive retry-safe per-repository cache generations from catalog release URLs
- include each generation in hosted `releases/latest` KV and edge cache keys
- retain the last populated generation for stale fallback during transient upstream failures
- return stale fallbacks without storing them in the current edge generation
- disable browser stale reuse for mutable latest responses
- leave exact-tag caches unchanged and preserve the existing 30-day stale-on-error window
- fall back to legacy cache keys when the generation lookup is unavailable

This prevents canonical-latest metadata from trailing a catalog that already contains a newer release. It does not add client-side upstream requests, depend on a particular release cadence, or assume version ordering.

Related: https://github.com/jdx/mise/discussions/12543#discussioncomment-18238790

## Testing

- `aube --dir web run build`
- `aube run test:js` — 102 passed
- `aube run test:shell` — 42 passed
- focused GitHub mirror and generation tests — 27 passed
- Prettier on all changed files

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes caching semantics for a high-traffic GitHub mirror path and couples correctness to catalog sync rotation; mitigations include legacy key fallback and previous-generation stale reads only on errors.
> 
> **Overview**
> **Fixes stale `releases/latest` mirror data** after the mise catalog advances but KV/edge still serve an older GitHub “latest” snapshot.
> 
> Catalog sync now **rotates a per-repo cache generation** (SHA-256 of sorted GitHub release URLs in the synced tools). That generation is stored in KV and appended to **`latest` KV keys** and **edge cache keys** (`__mise_cache_generation`), so a new catalog generation cannot reuse prior `latest` metadata. Exact-tag release caching is unchanged; if generation lookup fails, behavior falls back to legacy keys.
> 
> On upstream errors, **`latest` can still serve stale data** from the current generation entry or, after rotation, from the **previous generation** when the new slot is cold. Those stale responses get **no edge write** and **zero `Cache-Control` TTL**; normal `latest` responses use **browser `max-age=0`** and **no `stale-while-revalidate`**. Admin version sync returns **`latest_cache_generations`** for how many repos were rotated.
> 
> New **`release-generation.ts`** and expanded mirror/sync/API tests cover isolation, stale fallback, rotation, and invalid generation handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02afd855a122f46fb4d4985ff5936c1c89e805ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->