### PR TITLE
feat: project the next million MAU on stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "test": "aube run test:js && aube run test:shell",
-    "test:js": "node --test scripts/*.test.js && tsx --test src/*.test.ts",
+    "test:js": "node --test scripts/*.test.js && tsx --test src/*.test.ts web/src/lib/*.test.ts",
     "test:shell": "bash scripts/update.test.sh"
   },
   "devDependencies": {

--- a/web/src/components/MauHistory.astro
+++ b/web/src/components/MauHistory.astro
@@ -1,7 +1,12 @@
 ---
 import { formatCompact } from "../lib/format";
-
-type MauPoint = { date: string; mau: number };
+import {
+  forecastNextMillion,
+  formatForecastRelative,
+  formatUtcDate,
+  parseUtcDate,
+  type MauPoint,
+} from "../lib/mau-forecast";
 
 interface Props {
   daily: MauPoint[];
@@ -85,23 +90,37 @@ const quattroChange =
     ? formatChange(latest.mau, quattroBaseline?.mau)
     : null;
 
+const forecast = forecastNextMillion(data);
+const showForecastOnChart = Boolean(forecast?.showOnChart);
 const width = 1000;
 const height = 280;
-const padding = { top: 24, right: 24, bottom: 42, left: 70 };
+const padding = { top: 28, right: showForecastOnChart ? 36 : 24, bottom: 42, left: 70 };
 const chartWidth = width - padding.left - padding.right;
 const chartHeight = height - padding.top - padding.bottom;
-const values = data.map((point) => point.mau);
+const values = [
+  ...data.map((point) => point.mau),
+  ...(showForecastOnChart && forecast ? [forecast.target] : []),
+];
 const rawMin = values.length > 0 ? Math.min(...values) : 0;
 const rawMax = values.length > 0 ? Math.max(...values) : 1;
 const range = Math.max(rawMax - rawMin, rawMax * 0.1, 1);
 const yStep = niceStep(range);
 const yMin = Math.max(0, Math.floor(rawMin / yStep) * yStep);
-const roundedYMax = Math.ceil(rawMax / yStep) * yStep;
-const yMax = roundedYMax > yMin ? roundedYMax : yMin + yStep;
-const timestampForDate = (date: string) =>
-  new Date(`${date}T00:00:00Z`).getTime();
+let yMax = Math.ceil(rawMax / yStep) * yStep;
+if (yMax <= yMin) yMax = yMin + yStep;
+if (showForecastOnChart && forecast && yMax <= forecast.target) {
+  yMax = forecast.target + yStep;
+}
+const timestampForDate = (date: string) => parseUtcDate(date);
 const firstTimestamp = data.length > 0 ? timestampForDate(data[0].date) : 0;
-const lastTimestamp = latest ? timestampForDate(latest.date) : firstTimestamp;
+const chartEndDate = (() => {
+  if (!latest) return "";
+  if (!showForecastOnChart || !forecast) return latest.date;
+  const historyDays = Math.max(daysBetween(data[0].date, latest.date), 1);
+  const padDays = Math.max(4, Math.round(historyDays * 0.05));
+  return formatUtcDate(parseUtcDate(forecast.hitDate) + padDays * 86400_000);
+})();
+const lastTimestamp = chartEndDate ? timestampForDate(chartEndDate) : firstTimestamp;
 const xForDate = (date: string) =>
   firstTimestamp === lastTimestamp
     ? chartWidth / 2
@@ -116,6 +135,39 @@ const mauPath = data
       `${index === 0 ? "M" : "L"} ${xForDate(point.date)} ${yForValue(point.mau)}`,
   )
   .join(" ");
+const mauAreaPath =
+  data.length > 0 && latest
+    ? `${mauPath} L ${xForDate(latest.date)} ${chartHeight} L ${xForDate(data[0].date)} ${chartHeight} Z`
+    : "";
+const forecastPath =
+  showForecastOnChart && forecast && latest
+    ? `M ${xForDate(latest.date)} ${yForValue(latest.mau)} L ${xForDate(forecast.hitDate)} ${yForValue(forecast.target)}`
+    : "";
+const forecastAreaPath =
+  showForecastOnChart && forecast && latest
+    ? `M ${xForDate(latest.date)} ${yForValue(latest.mau)} L ${xForDate(forecast.hitDate)} ${yForValue(forecast.target)} L ${xForDate(forecast.hitDate)} ${chartHeight} L ${xForDate(latest.date)} ${chartHeight} Z`
+    : "";
+const forecastLabel =
+  forecast
+    ? `${forecast.targetLabel} · ${formatDate(forecast.hitDate)}`
+    : "";
+const forecastPillWidth = Math.max(108, forecastLabel.length * 6.7 + 18);
+const forecastPoint = showForecastOnChart && forecast
+  ? {
+      x: xForDate(forecast.hitDate),
+      y: yForValue(forecast.target),
+    }
+  : null;
+const forecastPill =
+  forecastPoint && forecast
+    ? {
+        x: Math.min(
+          Math.max(forecastPoint.x - forecastPillWidth + 8, 4),
+          chartWidth - forecastPillWidth - 4,
+        ),
+        y: forecastPoint.y > 30 ? forecastPoint.y - 28 : forecastPoint.y + 14,
+      }
+    : null;
 const showQuattroLaunch =
   data.length > 0 && quattroLaunch >= data[0].date && quattroLaunch <= latest!.date;
 const monthStarts = [
@@ -128,9 +180,14 @@ const monthStarts = [
     .values(),
 ];
 const tickInterval = Math.max(1, Math.ceil(monthStarts.length / 7));
-const xTicks = monthStarts.filter(
-  (_, index) => index % tickInterval === 0 || index === monthStarts.length - 1,
-);
+const xTicks = monthStarts
+  .filter(
+    (_, index) => index % tickInterval === 0 || index === monthStarts.length - 1,
+  )
+  .filter((point) => {
+    if (!showForecastOnChart || !forecast) return true;
+    return Math.abs(daysBetween(point.date, forecast.hitDate)) > 20;
+  });
 const yTicks = Array.from(
   { length: Math.round((yMax - yMin) / yStep) + 1 },
   (_, index) => yMax - index * yStep,
@@ -147,7 +204,7 @@ const yTicks = Array.from(
       </p>
     </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-5">
+    <div class={`grid grid-cols-1 gap-3 mb-5 ${forecast ? "sm:grid-cols-2 xl:grid-cols-4" : "sm:grid-cols-3"}`}>
       <div class="bg-dark-700 rounded p-3">
         <div class="text-xs text-gray-400">Latest MAU snapshot</div>
         <div class="text-2xl font-semibold text-cyan-400">{formatCompact(latest.mau)}</div>
@@ -176,10 +233,51 @@ const yTicks = Array.from(
         )}
         <div class="text-[11px] text-gray-600 mt-1">Timing comparison, not causal attribution.</div>
       </div>
+      {forecast && (
+        <div class="relative overflow-hidden rounded p-3 bg-dark-700 ring-1 ring-amber-400/35">
+          <div class="pointer-events-none absolute inset-0 bg-gradient-to-br from-amber-400/15 via-transparent to-cyan-400/10"></div>
+          <div class="relative">
+            <div class="text-xs text-amber-300/80">On pace for {forecast.targetLabel}</div>
+            <div class="text-2xl font-semibold text-amber-300">{formatDate(forecast.hitDate)}</div>
+            <div class="text-xs text-gray-400">
+              {formatForecastRelative(forecast.daysAway)}
+            </div>
+            <div class="text-[11px] text-gray-600 mt-1">
+              Linear projection of the last {forecast.windowDays} days.
+            </div>
+          </div>
+        </div>
+      )}
     </div>
 
     <div class="overflow-x-auto">
-      <svg viewBox={`0 0 ${width} ${height}`} class="min-w-[700px] w-full" role="img" aria-label="Daily snapshots of trailing 30-day monthly active users since March 2026">
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        class="min-w-[700px] w-full"
+        role="img"
+        aria-label={
+          forecast
+            ? `Daily snapshots of trailing 30-day monthly active users since March 2026. On pace for ${forecast.targetLabel} around ${formatDate(forecast.hitDate)}.`
+            : "Daily snapshots of trailing 30-day monthly active users since March 2026"
+        }
+      >
+        <defs>
+          <linearGradient id="mau-history-fill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#00D4FF" stop-opacity="0.22" />
+            <stop offset="100%" stop-color="#00D4FF" stop-opacity="0" />
+          </linearGradient>
+          <linearGradient id="mau-forecast-fill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#FBBF24" stop-opacity="0.16" />
+            <stop offset="100%" stop-color="#FBBF24" stop-opacity="0" />
+          </linearGradient>
+          <filter id="mau-forecast-glow" x="-80%" y="-80%" width="260%" height="260%">
+            <feGaussianBlur stdDeviation="2.4" result="blur" />
+            <feMerge>
+              <feMergeNode in="blur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
         <g transform={`translate(${padding.left}, ${padding.top})`}>
           {yTicks.map((tick) => (
             <g>
@@ -189,6 +287,18 @@ const yTicks = Array.from(
               </text>
             </g>
           ))}
+          {showForecastOnChart && forecast && (
+            <line
+              x1="0"
+              x2={xForDate(forecast.hitDate)}
+              y1={yForValue(forecast.target)}
+              y2={yForValue(forecast.target)}
+              stroke="#FBBF24"
+              stroke-width="1"
+              stroke-dasharray="3 5"
+              opacity="0.55"
+            />
+          )}
           {showQuattroLaunch && (
             <g>
               <line
@@ -203,13 +313,70 @@ const yTicks = Array.from(
               <text x={xForDate(quattroLaunch) - 6} y="12" text-anchor="end" class="fill-pink-400 text-xs">Quattro · Aug 14</text>
             </g>
           )}
+          {mauAreaPath && <path d={mauAreaPath} fill="url(#mau-history-fill)" />}
+          {forecastAreaPath && <path d={forecastAreaPath} fill="url(#mau-forecast-fill)" />}
           <path d={mauPath} fill="none" stroke="#00D4FF" stroke-width="3" stroke-linejoin="round" />
+          {showForecastOnChart && forecast && forecastPath && (
+            <g>
+              <line
+                x1={xForDate(forecast.hitDate)}
+                x2={xForDate(forecast.hitDate)}
+                y1={yForValue(forecast.target)}
+                y2={chartHeight}
+                stroke="#FBBF24"
+                stroke-width="1"
+                stroke-dasharray="3 5"
+                opacity="0.45"
+              />
+              <path
+                d={forecastPath}
+                class="mau-forecast-dash"
+                fill="none"
+                stroke="#FBBF24"
+                stroke-width="2.5"
+                stroke-linecap="round"
+              />
+            </g>
+          )}
           {data.map((point) => (
             <circle cx={xForDate(point.date)} cy={yForValue(point.mau)} r="6" fill="transparent">
               <title>{point.date}: {point.mau.toLocaleString()} MAU</title>
             </circle>
           ))}
           <circle cx={xForDate(latest.date)} cy={yForValue(latest.mau)} r="4" fill="#00D4FF" />
+          {forecastPoint && forecast && (
+            <g filter="url(#mau-forecast-glow)">
+              <circle cx={forecastPoint.x} cy={forecastPoint.y} r="8" fill="#FBBF24" fill-opacity="0.18" />
+              <circle cx={forecastPoint.x} cy={forecastPoint.y} r="4.5" fill="#FBBF24" />
+              <circle cx={forecastPoint.x} cy={forecastPoint.y} r="2" fill="#0a0a0f" />
+              <title>
+                {forecast.targetLabel} pace: {formatDate(forecast.hitDate)} ({formatForecastRelative(forecast.daysAway)})
+              </title>
+            </g>
+          )}
+          {forecastPill && forecast && (
+            <g>
+              <rect
+                x={forecastPill.x}
+                y={forecastPill.y}
+                width={forecastPillWidth}
+                height="20"
+                rx="10"
+                fill="#12121a"
+                stroke="#FBBF24"
+                stroke-width="1"
+                opacity="0.95"
+              />
+              <text
+                x={forecastPill.x + forecastPillWidth / 2}
+                y={forecastPill.y + 14}
+                text-anchor="middle"
+                class="fill-amber-200 text-[11px]"
+              >
+                {forecastLabel}
+              </text>
+            </g>
+          )}
           {xTicks.map((point) => {
             return (
               <text x={xForDate(point.date)} y={chartHeight + 24} text-anchor="middle" class="fill-gray-500 text-xs">
@@ -217,9 +384,26 @@ const yTicks = Array.from(
               </text>
             );
           })}
+          {showForecastOnChart && forecast && (
+            <text
+              x={xForDate(forecast.hitDate)}
+              y={chartHeight + 24}
+              text-anchor="middle"
+              class="fill-amber-300/80 text-[11px]"
+            >
+              {new Date(`${forecast.hitDate}T00:00:00Z`).toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })}
+            </text>
+          )}
         </g>
       </svg>
     </div>
+    {forecast && (
+      <p class="mt-2 text-[11px] text-gray-500">
+        {showForecastOnChart
+          ? `Dashed gold line projects the last ${forecast.windowDays} days linearly.`
+          : `On pace for ${forecast.targetLabel} around ${formatDate(forecast.hitDate)} (${formatForecastRelative(forecast.daysAway)}), from a linear fit of the last ${forecast.windowDays} days. Too far out to plot.`}
+      </p>
+    )}
 
     {recentMonths.length > 0 && (
       <div class="mt-5">
@@ -290,3 +474,22 @@ const yTicks = Array.from(
     )}
   </section>
 )}
+
+<style>
+  .mau-forecast-dash {
+    stroke-dasharray: 7 6;
+    animation: mau-dash 1.3s linear infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mau-forecast-dash {
+      animation: none;
+    }
+  }
+
+  @keyframes mau-dash {
+    to {
+      stroke-dashoffset: -13;
+    }
+  }
+</style>

--- a/web/src/lib/mau-forecast.test.ts
+++ b/web/src/lib/mau-forecast.test.ts
@@ -1,0 +1,146 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  FORECAST_WINDOW_DAYS,
+  forecastNextMillion,
+  formatForecastRelative,
+  formatMillionLabel,
+  nextMillion,
+} from "./mau-forecast";
+
+function series(
+  start: string,
+  values: number[],
+  stepDays = 1,
+): Array<{ date: string; mau: number }> {
+  const origin = Date.parse(`${start}T00:00:00Z`);
+  return values.map((mau, index) => ({
+    date: new Date(origin + index * stepDays * 86_400_000)
+      .toISOString()
+      .slice(0, 10),
+    mau,
+  }));
+}
+
+test("next million is the first million above current MAU", () => {
+  assert.equal(nextMillion(755_509), 1_000_000);
+  assert.equal(nextMillion(999_999), 1_000_000);
+  assert.equal(nextMillion(1_000_000), 2_000_000);
+  assert.equal(nextMillion(1_500_000), 2_000_000);
+  assert.equal(nextMillion(2_000_001), 3_000_000);
+});
+
+test("million labels stay compact", () => {
+  assert.equal(formatMillionLabel(1_000_000), "1M");
+  assert.equal(formatMillionLabel(2_000_000), "2M");
+});
+
+test("relative copy covers days, weeks, months, and years", () => {
+  assert.equal(formatForecastRelative(0), "today");
+  assert.equal(formatForecastRelative(1), "tomorrow");
+  assert.equal(formatForecastRelative(16), "in 16 days");
+  assert.equal(formatForecastRelative(21), "in 3 weeks");
+  assert.equal(formatForecastRelative(90), "in 3 months");
+  assert.equal(formatForecastRelative(800), "in 2.2 years");
+});
+
+test("linear window projects a constant climb to 1M", () => {
+  const points = series(
+    "2026-08-17",
+    Array.from({ length: 21 }, (_, i) => 460_000 + i * 14_000),
+  );
+  const forecast = forecastNextMillion(points);
+  assert.ok(forecast);
+  assert.equal(forecast.target, 1_000_000);
+  assert.equal(forecast.targetLabel, "1M");
+  assert.equal(forecast.hitDate, "2026-09-24");
+  assert.equal(forecast.daysAway, 18);
+  assert.equal(forecast.windowDays, FORECAST_WINDOW_DAYS);
+  assert.equal(forecast.showOnChart, true);
+  assert.equal(forecast.showInText, true);
+  assert.ok(Math.abs(forecast.dailySlope - 14_000) < 1e-6);
+});
+
+test("after 1M the same slope aims at 2M", () => {
+  const points = series(
+    "2026-10-01",
+    Array.from({ length: 21 }, (_, i) => 1_050_000 + i * 10_000),
+  );
+  const forecast = forecastNextMillion(points);
+  assert.ok(forecast);
+  assert.equal(forecast.target, 2_000_000);
+  assert.equal(forecast.targetLabel, "2M");
+  assert.equal(forecast.showOnChart, true);
+});
+
+test("hides the chart line after 16 months but keeps page copy", () => {
+  const points = series(
+    "2026-01-01",
+    Array.from({ length: 21 }, (_, i) => 100_000 + i * 1_000),
+  );
+  const forecast = forecastNextMillion(points);
+  assert.ok(forecast);
+  assert.equal(forecast.showOnChart, false);
+  assert.equal(forecast.showInText, true);
+  assert.ok(forecast.daysAway > 16 * 30);
+});
+
+test("omits forecasts more than 10 years out", () => {
+  const points = series(
+    "2026-01-01",
+    Array.from({ length: 21 }, (_, i) => 100_000 + i * 20),
+  );
+  assert.equal(forecastNextMillion(points), null);
+});
+
+test("omits a forecast when MAU is not increasing", () => {
+  const points = series(
+    "2026-08-01",
+    Array.from({ length: 21 }, (_, i) => 800_000 - i * 1_000),
+  );
+  assert.equal(forecastNextMillion(points), null);
+});
+
+test("projects the post-Quattro climb near the end of September 2026", () => {
+  const points = [
+    ["2026-08-17", 481_024],
+    ["2026-08-18", 497_974],
+    ["2026-08-19", 508_684],
+    ["2026-08-20", 518_085],
+    ["2026-08-21", 528_046],
+    ["2026-08-22", 536_235],
+    ["2026-08-23", 544_070],
+    ["2026-08-24", 568_065],
+    ["2026-08-25", 593_168],
+    ["2026-08-26", 609_492],
+    ["2026-08-27", 626_301],
+    ["2026-08-28", 639_563],
+    ["2026-08-29", 646_457],
+    ["2026-08-30", 652_422],
+    ["2026-08-31", 676_917],
+    ["2026-09-01", 701_828],
+    ["2026-09-02", 720_069],
+    ["2026-09-03", 734_217],
+    ["2026-09-04", 747_358],
+    ["2026-09-05", 752_423],
+    ["2026-09-06", 755_509],
+  ].map(([date, mau]) => ({ date, mau: Number(mau) }));
+  const forecast = forecastNextMillion(points);
+  assert.ok(forecast);
+  assert.equal(forecast.targetLabel, "1M");
+  assert.equal(forecast.showOnChart, true);
+  assert.ok(forecast.hitDate >= "2026-09-20");
+  assert.ok(forecast.hitDate <= "2026-09-24");
+});
+
+test("needs enough recent points to fit", () => {
+  assert.equal(
+    forecastNextMillion([
+      { date: "2026-09-01", mau: 700_000 },
+      { date: "2026-09-02", mau: 720_000 },
+    ]),
+    null,
+  );
+});

--- a/web/src/lib/mau-forecast.ts
+++ b/web/src/lib/mau-forecast.ts
@@ -1,0 +1,124 @@
+export type MauPoint = { date: string; mau: number };
+
+export type MauForecast = {
+  target: number;
+  targetLabel: string;
+  hitDate: string;
+  daysAway: number;
+  dailySlope: number;
+  windowDays: number;
+  showOnChart: boolean;
+  showInText: boolean;
+};
+
+export const FORECAST_WINDOW_DAYS = 21;
+export const CHART_HORIZON_MONTHS = 16;
+export const TEXT_HORIZON_YEARS = 10;
+
+const DAY_MS = 86_400_000;
+const MIN_WINDOW_POINTS = 7;
+
+export function parseUtcDate(date: string): number {
+  return Date.parse(`${date}T00:00:00Z`);
+}
+
+export function formatUtcDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+export function addUtcMonths(date: string, months: number): string {
+  const next = new Date(`${date}T00:00:00Z`);
+  next.setUTCMonth(next.getUTCMonth() + months);
+  return next.toISOString().slice(0, 10);
+}
+
+export function nextMillion(mau: number): number {
+  return (Math.floor(Math.max(mau, 0) / 1_000_000) + 1) * 1_000_000;
+}
+
+export function formatMillionLabel(target: number): string {
+  return `${target / 1_000_000}M`;
+}
+
+export function formatForecastRelative(daysAway: number): string {
+  if (daysAway <= 0) return "today";
+  if (daysAway === 1) return "tomorrow";
+  if (daysAway < 21) return `in ${daysAway} days`;
+  if (daysAway < 60) {
+    const weeks = Math.max(1, Math.round(daysAway / 7));
+    return weeks === 1 ? "in 1 week" : `in ${weeks} weeks`;
+  }
+  if (daysAway < 730) {
+    const months = Math.max(1, Math.round(daysAway / 30.44));
+    return months === 1 ? "in 1 month" : `in ${months} months`;
+  }
+  const years = daysAway / 365.25;
+  const rounded = years >= 10 ? years.toFixed(0) : years.toFixed(1);
+  return `in ${rounded} years`;
+}
+
+function linearSlope(points: MauPoint[]): number | null {
+  const n = points.length;
+  if (n < MIN_WINDOW_POINTS) return null;
+
+  const origin = parseUtcDate(points[0].date);
+  const xs = points.map(
+    (point) => (parseUtcDate(point.date) - origin) / DAY_MS,
+  );
+  const ys = points.map((point) => point.mau);
+  const meanX = xs.reduce((sum, x) => sum + x, 0) / n;
+  const meanY = ys.reduce((sum, y) => sum + y, 0) / n;
+  let sxx = 0;
+  let sxy = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - meanX;
+    sxx += dx * dx;
+    sxy += dx * (ys[i] - meanY);
+  }
+  if (sxx === 0) return null;
+  return sxy / sxx;
+}
+
+export function forecastNextMillion(points: MauPoint[]): MauForecast | null {
+  const series = points.filter((point) => point.mau > 0);
+  const latest = series.at(-1);
+  if (!latest) return null;
+
+  const windowStart = formatUtcDate(
+    parseUtcDate(latest.date) - FORECAST_WINDOW_DAYS * DAY_MS,
+  );
+  const window = series.filter((point) => point.date >= windowStart);
+  const slope = linearSlope(
+    window.length >= MIN_WINDOW_POINTS ? window : series,
+  );
+  if (slope === null || slope <= 0) return null;
+
+  const target = nextMillion(latest.mau);
+  const remaining = target - latest.mau;
+  if (remaining <= 0) return null;
+
+  const rawDays = remaining / slope;
+  if (!Number.isFinite(rawDays) || rawDays <= 0) return null;
+
+  const hitMs = parseUtcDate(latest.date) + rawDays * DAY_MS;
+  const hitDate = formatUtcDate(hitMs);
+  const daysAway = Math.max(
+    0,
+    Math.round((parseUtcDate(hitDate) - parseUtcDate(latest.date)) / DAY_MS),
+  );
+  const chartDeadline = addUtcMonths(latest.date, CHART_HORIZON_MONTHS);
+  const textDeadline = addUtcMonths(latest.date, TEXT_HORIZON_YEARS * 12);
+
+  if (hitDate > textDeadline) return null;
+
+  return {
+    target,
+    targetLabel: formatMillionLabel(target),
+    hitDate,
+    daysAway,
+    dailySlope: slope,
+    windowDays: FORECAST_WINDOW_DAYS,
+    showOnChart: hitDate <= chartDeadline,
+    showInText: true,
+  };
+}


### PR DESCRIPTION
Adds a next-million projection to the stats MAU chart.

The latest snapshot is fit with a 21-day linear regression. The dashed gold line, milestone marker, and axis extension only render when that hit is within 16 months. A KPI card and caption still show the date unless the pace is more than 10 years out, declining, or there is not enough recent data.

After 1M the same view aims at 2M, then 3M, and so on. On the current series this lands around late September 2026 for 1M.

*AI-assisted — Tool: Grok; model: xAI/grok-4.6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only stats UI and client-side projection math; no API, auth, or data pipeline changes.
> 
> **Overview**
> Adds a **next-million MAU projection** to the stats MAU section, driven by a new `mau-forecast` helper that fits a **21-day linear regression** and estimates when MAU would reach the next whole-million milestone (1M, then 2M, etc.).
> 
> **`MauHistory.astro`** consumes that forecast: a fourth KPI card shows the projected date and relative timing when a forecast exists; the SVG chart can extend past the latest snapshot with a dashed gold projection line, target marker, fills, and updated axis/aria copy. Chart overlays are gated when the hit is within **16 months**; text-only messaging remains for farther (but ≤10-year) projections, and forecasts are omitted for flat/declining series or insufficient data.
> 
> Root **`test:js`** now runs **`web/src/lib/*.test.ts`**, with new unit tests covering slope math, horizons, and real post-Quattro sample data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f292b72e56f527f43e987a0252d92336d52730. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MAU forecasting to the history chart, including projected growth toward the next million active users.
  - Forecasts now display projected dates, target labels, markers, summary details, and explanatory captions.
  - Improved chart readability by filtering nearby month labels and extending the timeline when appropriate.
  - Added responsive forecast layouts and accessibility text, with reduced-motion support for animated forecast indicators.

- **Bug Fixes**
  - Improved handling of insufficient, non-increasing, or unsuitable usage data so forecasts are omitted when unreliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->