### PR TITLE
fix(stats): fit charts to the screen on mobile instead of scrolling

### DIFF
--- a/web/src/components/HomebrewRank.astro
+++ b/web/src/components/HomebrewRank.astro
@@ -27,8 +27,7 @@ function path(key: 'brewRank' | 'brewPercent', y: (v: number) => number) {
   {latest ? <>
     <p class="adoption-context">Current <strong>#{latest.brewRank}</strong> · Best <strong>#{best}</strong> · Lower rank is better</p>
     <DataFreshness date={latest.date} />
-    <div class="rank-plot">
-    <svg viewBox="0 0 1000 260" role="img" aria-label={`mise Homebrew rank history. Current rank ${latest.brewRank}, best rank ${best}. Rank improves upward. Blue line shows install share on the right axis.`}>
+    <svg class="wide-chart" viewBox="0 0 1000 260" role="img" aria-label={`mise Homebrew rank history. Current rank ${latest.brewRank}, best rank ${best}. Rank improves upward. Blue line shows install share on the right axis.`}>
       {[1, Math.round(maxRank/2), maxRank].map(rank => <g><line x1="55" x2="925" y1={rankY(rank)} y2={rankY(rank)} stroke="var(--border)"/><text x="47" y={rankY(rank)+4} text-anchor="end">#{rank}</text></g>)}
       {[0, .5, 1].map(f => <text x="933" y={percentY(maxPercent*f)+4}>{(maxPercent*f).toFixed(2)}%</text>)}
       <YearGrid start={start} end={end} x={x} top={40} bottom={220} />
@@ -38,17 +37,10 @@ function path(key: 'brewRank' | 'brewPercent', y: (v: number) => number) {
       <circle cx={x(latest.date)} cy={rankY(latest.brewRank!)} r="3.5" fill="#E67E22"/>
       <text x="55" y="247">{start}</text><text x="925" y="247" text-anchor="end">{end}</text>
     </svg>
-    </div>
     <p class="adoption-context">Orange: rank (left axis) · Blue: share of Homebrew install-on-request installs (right axis). Based on rolling 30-day counts.</p>
-    <p class="adoption-context sm:hidden">Swipe the chart to see the full history.</p>
   </> : <p>Homebrew rank history unavailable.</p>}
 </div>
 
 <style>
   .homebrew-rank-chart { grid-column: 1 / -1; }
-  .rank-plot { overflow-x: auto; }
-  @media (max-width: 640px) {
-    .homebrew-rank-chart svg { min-width: 600px; }
-
-  }
 </style>

--- a/web/src/components/MauHistory.astro
+++ b/web/src/components/MauHistory.astro
@@ -269,10 +269,9 @@ const yTicks = Array.from(
 
     <p class="text-sm text-gray-400 mb-3">MAU 7-day average: <strong>{latestAverage?.value == null ? "—" : formatCompact(latestAverage.value)}</strong> · Week-over-week: <strong>{weeklyChange === null ? "unavailable" : `${weeklyChange >= 0 ? "+" : ""}${weeklyChange.toFixed(1)}%`}</strong></p>
     <label class="text-xs text-gray-400 flex items-center gap-2 mb-2"><input type="checkbox" class="event-toggle" checked /> Show releases and events</label>
-    <div class="overflow-x-auto">
       <svg
         viewBox={`0 0 ${width} ${height}`}
-        class="min-w-[700px] w-full"
+        class="wide-chart w-full"
         role="img"
         aria-label={
           forecast
@@ -353,7 +352,7 @@ const yTicks = Array.from(
             </g>
           )}
           {forecastPill && forecast && (
-            <g>
+            <g class="chart-pill">
               <rect
                 x={forecastPill.x}
                 y={forecastPill.y}
@@ -394,7 +393,6 @@ const yTicks = Array.from(
           )}
         </g>
       </svg>
-    </div>
     <p class="mt-2 text-[11px] text-gray-500">Blue: 7-day average of MAU snapshots · Faint: daily MAU. A complete week is required; smoothing lags changes by about three days. Headline and monthly history show actual snapshots.</p>
     {forecast && (
       <p class="mt-2 text-[11px] text-gray-500">

--- a/web/src/components/StarCrossover.astro
+++ b/web/src/components/StarCrossover.astro
@@ -28,7 +28,7 @@ const ticks = [data[0].date, ...Array.from({length: new Date(end).getUTCFullYear
   </div>
   <DataFreshness date={latest.date} />
   <div class="star-chart-scroll">
-    <svg viewBox="0 0 1000 265" role="img" aria-label={`GitHub star history for mise and Homebrew. ${projection ? `At current growth rates, mise is projected to pass Homebrew on ${forecastDate(projection.hitDate)}.` : 'No near-term crossover projected.'}`}>
+    <svg class="wide-chart" viewBox="0 0 1000 265" role="img" aria-label={`GitHub star history for mise and Homebrew. ${projection ? `At current growth rates, mise is projected to pass Homebrew on ${forecastDate(projection.hitDate)}.` : 'No near-term crossover projected.'}`}>
       {showProjection && <rect x={x(latest.date)} y="24" width={x(endDate)-x(latest.date)} height="200" fill="var(--forecast)" opacity=".035" />}
       {[0, .25, .5, .75, 1].map(f=><g><line x1="64" x2="926" y1={y(max*f)} y2={y(max*f)} stroke="var(--border)"/><text x="52" y={y(max*f)+4} text-anchor="end">{Math.round(max*f/1000)}K</text></g>)}
 <YearGrid start={data[0].date} end={endDate} x={x} top={34} bottom={224} />

--- a/web/src/components/StatsLineChart.astro
+++ b/web/src/components/StatsLineChart.astro
@@ -25,15 +25,14 @@ function path(data:Props['series'][number]['points']) {
   <h3>{title}</h3>
   {points.length ? <>
     <div class="chart-legend">{series.map((s,i)=><span><i style={`background:${colors[i%colors.length]}`}></i>{s.name}</span>)}</div>
-    <div class="chart-scroll"><svg viewBox="0 0 960 265" role="img" aria-label={`${title}. ${unit}. ${series.map(s=>s.name).join(', ')}. From ${new Date(first).toISOString().slice(0,10)} through ${new Date(last).toISOString().slice(0,10)}.`}>
+    <svg class="wide-chart" viewBox="0 0 960 265" role="img" aria-label={`${title}. ${unit}. ${series.map(s=>s.name).join(', ')}. From ${new Date(first).toISOString().slice(0,10)} through ${new Date(last).toISOString().slice(0,10)}.`}>
       {[0,.5,1].map(f=><g><line x1="65" x2="915" y1={y(low+(high-low)*f)} y2={y(low+(high-low)*f)} stroke="var(--border)"/><text x="57" y={y(low+(high-low)*f)+4} text-anchor="end">{label(low+(high-low)*f)}</text></g>)}
       {series.map((s,i)=><g><path d={path(s.points)} fill="none" stroke={colors[i%colors.length]} stroke-width="2.5"/>{s.points.filter((p,index)=>p.value!==null && (index % 7 === 0 || index === s.points.length - 1)).map(p=><circle cx={x(p.date)} cy={y(p.value!)} r="4" fill="transparent"><title>{s.name} · {p.date}: {label(p.value!)} {unit}</title></circle>)}</g>)}
       <text x="65" y="251">{new Date(first).toISOString().slice(0,10)}</text><text x="915" y="251" text-anchor="end">{new Date(last).toISOString().slice(0,10)}</text>
-    </svg></div>
+    </svg>
   </> : <p class="adoption-context">Not enough comparable history.</p>}
 </section>
 <style>
 .chart-legend { display:flex; flex-wrap:wrap; gap:.5rem 1rem; font-size:.75rem; color:var(--muted); margin-top:.75rem; }
 .chart-legend span {display:flex;align-items:center;gap:.35rem;} i {width:.5rem;height:.5rem;border-radius:50%;}
-.chart-scroll {overflow-x:auto;} svg {min-width:500px;}
 </style>

--- a/web/src/components/WeeklyMauGrowth.astro
+++ b/web/src/components/WeeklyMauGrowth.astro
@@ -11,9 +11,9 @@ const y=(value:number)=>135-value/max*85;
 <section class="adoption-chart">
 <h2>Weekly MAU gains</h2>
 <p class="adoption-context">Change in the seven-day average of MAU, Sunday to Sunday. These are net changes in the active audience, not counts of new users.</p>
-{data.some(p=>p.value!==null)?<><div class="weekly-scroll"><svg viewBox="0 0 960 265" role="img" aria-label="Weekly net gains and losses in smoothed MAU over the last 16 complete weeks">
+{data.some(p=>p.value!==null)?<><svg class="wide-chart" viewBox="0 0 960 265" role="img" aria-label="Weekly net gains and losses in smoothed MAU over the last 16 complete weeks">
   {[-max,0,max].map(v=><g><line x1="55" x2="925" y1={y(v)} y2={y(v)} stroke="var(--border)"/><text x="48" y={y(v)+4} text-anchor="end">{v<0?`−${formatCompact(Math.abs(v))}`:formatCompact(v)}</text></g>)}
   {data.map((p,i)=><g>{p.value!==null && <rect x={x(i)} y={Math.min(y(p.value),y(0))} width={width} height={Math.max(1,Math.abs(y(p.value)-y(0)))} fill={p.value>=0?'var(--data)':'#F472B6'}><title>Week ending {p.date}: {Math.round(p.value).toLocaleString()} net MAU</title></rect>}{i%3===0 && <text x={x(i)} y="248">{p.date.slice(5)}</text>}</g>)}
-</svg></div><details><summary>Weekly values</summary><ul>{data.slice().reverse().map(p=><li>{p.date}: {p.value===null?'Unavailable':`${p.value>=0?'+':''}${Math.round(p.value).toLocaleString()} MAU`}</li>)}</ul></details></>:<p>Not enough complete weeks to compare.</p>}
+</svg><details><summary>Weekly values</summary><ul>{data.slice().reverse().map(p=><li>{p.date}: {p.value===null?'Unavailable':`${p.value>=0?'+':''}${Math.round(p.value).toLocaleString()} MAU`}</li>)}</ul></details></>:<p>Not enough complete weeks to compare.</p>}
 </section>
-<style>.weekly-scroll{overflow-x:auto;} svg{min-width:500px;} summary{cursor:pointer;color:var(--muted);font-size:.8rem;} li{padding:.3rem;}</style>
+<style>summary{cursor:pointer;color:var(--muted);font-size:.8rem;} li{padding:.3rem;}</style>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1175,12 +1175,10 @@ code,
   font-size: 0.95rem;
 }
 .star-chart-scroll {
-  overflow-x: auto;
   margin-top: 1.3rem;
 }
 .star-chart-scroll svg {
   width: 100%;
-  min-width: 580px;
   height: auto;
 }
 .star-chart-scroll text {
@@ -1427,4 +1425,47 @@ code,
 }
 .release-stop[aria-pressed="true"] .release-milestone-label {
   color: var(--accent);
+}
+
+/*
+ * Stats charts fit the column on phones instead of scrolling sideways.
+ *
+ * The wide charts are drawn on a ~1000-unit viewBox, so at phone width they
+ * render at about a third of their desktop size, and so does their text: SVG
+ * text is sized in viewBox units, not CSS pixels. Their minimum widths existed
+ * to stop the labels shrinking to ~3px, at the cost of a horizontal scroll
+ * that left the newest data off-screen.
+ *
+ * Here the labels are sized up in viewBox units instead, landing around 6px on
+ * a phone, which matches the 540-wide charts that already fit. A longer
+ * left-axis label can then run past its gutter, so the SVG paints outside its
+ * box and the card clips at its padding, which is wide enough to hold it. The
+ * clip also guarantees no chart annotation can widen the page, which is the
+ * point of this block. Lines keep their on-screen width rather than thinning
+ * to sub-pixel.
+ *
+ * Placed last in the file on purpose: `.star-chart-scroll text` and
+ * `.adoption-chart text` set the same property at the same specificity.
+ */
+@media (max-width: 640px) {
+  .adoption-chart,
+  .star-crossover,
+  .mau-history {
+    overflow-x: clip;
+  }
+  .wide-chart {
+    overflow: visible;
+  }
+  .wide-chart text {
+    font-size: 20px;
+  }
+  .wide-chart path,
+  .wide-chart line {
+    vector-effect: non-scaling-stroke;
+  }
+  /* The forecast is already stated in the text above the chart, and this
+     label's box is a fixed width that cannot grow with the text inside it. */
+  .wide-chart .chart-pill {
+    display: none;
+  }
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1428,31 +1428,38 @@ code,
 }
 
 /*
- * Stats charts fit the column on phones instead of scrolling sideways.
+ * Wide stats charts fit their column instead of scrolling sideways.
  *
- * The wide charts are drawn on a ~1000-unit viewBox, so at phone width they
- * render at about a third of their desktop size, and so does their text: SVG
- * text is sized in viewBox units, not CSS pixels. Their minimum widths existed
- * to stop the labels shrinking to ~3px, at the cost of a horizontal scroll
- * that left the newest data off-screen.
+ * The wide charts are drawn on a ~1000-unit viewBox, and SVG text is sized in
+ * viewBox units, not CSS pixels, so a chart rendered narrow shrinks its labels
+ * with it. Their old minimum widths (500-700px) stopped the labels shrinking to
+ * ~3px, at the cost of a horizontal scroll that left the newest data
+ * off-screen.
  *
- * Here the labels are sized up in viewBox units instead, landing around 6px on
- * a phone, which matches the 540-wide charts that already fit. A longer
- * left-axis label can then run past its gutter, so the SVG paints outside its
- * box and the card clips at its padding, which is wide enough to hold it. The
- * clip also guarantees no chart annotation can widen the page, which is the
- * point of this block. Lines keep their on-screen width rather than thinning
- * to sub-pixel.
+ * Here the labels are sized up in viewBox units instead, whenever the chart's
+ * own card is narrow. That is a container query rather than a viewport one on
+ * purpose: /stats/projects lays its charts out two to a row above 700px, so at
+ * a tablet width each chart is about as narrow as on a phone (~270px), and a
+ * viewport breakpoint left exactly that band with ~3px labels. Below 520px of
+ * card width, 20-unit labels land around 5.5-11px; above it the ordinary
+ * 11-unit labels are already 6px or more.
+ *
+ * A longer left-axis label can then run past its gutter, so these SVGs paint
+ * outside their box and each card clips horizontally at its padding, which is
+ * wide enough to hold it. The clip also guarantees no chart annotation can
+ * widen the page. Lines keep their on-screen width rather than thinning to
+ * sub-pixel.
  *
  * Placed last in the file on purpose: `.star-chart-scroll text` and
  * `.adoption-chart text` set the same property at the same specificity.
  */
-@media (max-width: 640px) {
-  .adoption-chart,
-  .star-crossover,
-  .mau-history {
-    overflow-x: clip;
-  }
+.adoption-chart,
+.star-crossover,
+.mau-history {
+  container-type: inline-size;
+  overflow-x: clip;
+}
+@container (max-width: 520px) {
   .wide-chart {
     overflow: visible;
   }

--- a/web/src/pages/stats/tools.astro
+++ b/web/src/pages/stats/tools.astro
@@ -226,7 +226,7 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, stale-while-re
                 <svg
                   width={width}
                   height={height}
-                  class="min-w-[400px]"
+                  viewBox={`0 0 ${width} ${height}`}
                   role="group"
                   aria-label="Version updates by date. Use the left and right arrow keys to inspect days."
                   data-daily-chart


### PR DESCRIPTION
Every wide chart on the stats pages scrolled sideways on a phone, so the newest data started off-screen. They now fit the column.

## Why the minimum widths existed

They weren't arbitrary. The wide charts are drawn on a ~1000-unit `viewBox`, and **SVG text is sized in viewBox units**, so a 960-wide chart squeezed into a ~312px phone column renders its labels at about 3.5px. Deleting the minimums alone makes the charts fit but unreadable. The fix has to keep the labels readable.

## The fix — one `@media (max-width: 640px)` block in `index.css`

- **Labels sized up in viewBox units** (`font-size: 20px` on `.wide-chart text`) → about **6.2–6.5px** on a phone. That matches the 540-wide charts (`DailyActivityChart`, Homebrew installs) that already fit phones at ~6.3px.
- **`overflow: visible`** on those SVGs, so a longer left-axis label like `123.4%` sits in the card padding instead of being clipped. This needed the `overflow-x: auto` wrappers gone, since they'd clip it.
- **`overflow-x: clip`** on the chart cards. The bleed stays within their 19–28px padding, and no chart annotation can ever widen the page, which is the requirement itself.
- **`vector-effect: non-scaling-stroke`**, so lines keep their on-screen width rather than thinning to sub-pixel. `YearGrid` already does this.

All of it is inside the one media query. **Desktop is unchanged.**

| Chart | Page | Was |
|---|---|---|
| `MauHistory` | `/stats` | `min-w-[700px]` |
| `HomebrewRank` | `/stats` | 600px, mobile only |
| `StarCrossover` | `/stats` | 580px |
| `WeeklyMauGrowth` | `/stats` | 500px |
| `StatsLineChart` ×28 | `/stats/projects` | 500px |
| version updates | `/stats/tools` | fixed `width=500` and **no `viewBox`**, so it clipped instead of scaling; now has one |

Also: HomebrewRank's mobile-only *"Swipe the chart to see the full history"* is gone, since it's no longer true. MauHistory's in-chart forecast pill is hidden on phones, because its fixed-width box can't grow with its text and the same forecast is already stated above the chart.

## Verification

- Build passes. `test:js` 168/168. Prettier clean on `index.css`, the only changed file it covers, since `.prettierignore` excludes `*.astro`.
- **Compiled CSS checked:** the block survives as `@media (width<=640px)`, and all 5 `.wide-chart` rules are inside it, none outside. `.wide-chart text` comes after `.adoption-chart text` and `.star-chart-scroll text` in the bundle, so it wins the cascade.
- **Rendered, not assumed.** I served the build with `wrangler dev`, took the real chart markup from `/stats/projects` and `/stats`, and rasterised it at a 390px phone's column width. Labels come out at 6.2–6.5px, against 3.4–3.6px with the minimums merely deleted. The right-edge labels (StarCrossover's *Projection*, HomebrewRank's `%` axis) stay inside the card.

## Caveats

- `MauHistory` and `WeeklyMauGrowth` need D1 audience data, so they don't render locally and I couldn't rasterise them. They use the same pattern and label gutters as the charts I did verify.
- On a short phone plot, non-scaling strokes make lines relatively thicker, so in the busy multi-series `StatsLineChart` the dozen small projects sitting near zero merge into a band at the baseline. They overlap at zero either way.
- The wide data **tables** (project overview, ecosystem insights) still scroll inside their own box. That's deliberate: tables, not charts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated statistics and ranking charts for a more responsive mobile layout.
  - Charts now fit their containers without requiring horizontal scrolling.
  - Improved readability of chart labels and wide visualizations on smaller screens.
  - Adjusted chart scaling and sizing for more consistent display across screen sizes.
  - Updated the version-updates chart to scale based on its displayed dimensions.
  - Forecast indicators are hidden in the mobile chart layout where space is limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->